### PR TITLE
Add dualstack support

### DIFF
--- a/test/baremetal/kubeadm/ClusterJoinConfiguration.template.yaml
+++ b/test/baremetal/kubeadm/ClusterJoinConfiguration.template.yaml
@@ -2,7 +2,7 @@ apiVersion: kubeadm.k8s.io/v1beta2
 caCertPath: /etc/kubernetes/pki/ca.crt
 discovery:
   bootstrapToken:
-    apiServerEndpoint: "__6SAFE_MASTER_NODE_IP__:6443"
+    apiServerEndpoint: "${SAFE6_MAIN_NODE_IP}:6443"
     token: "abcdef.0123456789abcdef"
     unsafeSkipCAVerification: true
   timeout: 5m0s
@@ -11,58 +11,60 @@ kind: JoinConfiguration
 nodeRegistration:
   taints: null
   kubeletExtraArgs:
-    node-ip: "__NODE_IP__"
+    node-ip: "${FIRST_NODE_IP}"
   criSocket: /var/run/dockershim.sock
-  name: "__NODE_NAME__"
+  name: "${NODE_NAME}"
   ignorePreflightErrors:
   - SystemVerification
   - FileContent--proc-sys-net-ipv6-conf-default-forwarding
 ---
 # https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/
+apiVersion: kubeadm.k8s.io/v1beta2
+kind: ClusterConfiguration
 apiServer:
   timeoutForControlPlane: 4m0s
   extraArgs:
     authorization-mode: Node,RBAC
-    advertise-address: "__NODE_IP__"
-    bind-address: "__NODE_IP__"
-    service-cluster-ip-range: "__SERVICE_CIDR__"
-apiVersion: kubeadm.k8s.io/v1beta2
+    advertise-address: "${FIRST_NODE_IP}"
+    service-cluster-ip-range: "${SERVICE_CIDR}"
+    feature-gates: "IPv6DualStack=${IS_DUAL}"
 certificatesDir: /etc/kubernetes/pki
 clusterName: kubernetes
 # https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/
 controllerManager:
   extraArgs:
-    # master: "__6SAFE_NODE_IP__"
-    cluster-cidr: "__POD_CIDR__"
-    allocate-node-cidrs: "false"
+    feature-gates: "IPv6DualStack=${IS_DUAL}"
+    allocate-node-cidrs: "true"
+    cluster-cidr: "${POD_CIDR}"
+    service-cluster-ip-range: "${SERVICE_CIDR}"
+    node-cidr-mask-size-ipv4: "${NODE_CIDR_MASK_SIZE4}"
+    node-cidr-mask-size-ipv6: "${NODE_CIDR_MASK_SIZE6}"
+    node-cidr-mask-size-ipv6: "${NODE_CIDR_MASK_SIZE6}"
+    node-cidr-mask-size: "${NODE_CIDR_MASK_SIZE}"
 dns:
-  type: __DNS_TYPE__
+  type: ${DNS_TYPE}
 etcd:
   local:
     dataDir: /var/lib/etcd
 imageRepository: k8s.gcr.io
-kind: ClusterConfiguration
 kubernetesVersion: v1.17.4
 networking:
   dnsDomain: cluster.local
-  podSubnet: "__POD_CIDR__"
-  serviceSubnet: "__SERVICE_CIDR__"
-# https://kubernetes.io/docs/reference/command-line-tools-reference/kube-scheduler/
-scheduler:
-  extraArgs:
-    # master: "__NODE_IP__"
-    bind-address: "__NODE_IP__"
-    # v: "10"
+  podSubnet: "${FIRST_POD_CIDR}"
+  serviceSubnet: "${FIRST_SERVICE_CIDR}"
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
 conntrack:
   maxPerCore: 0
-kind: KubeProxyConfiguration
+featureGates:
+  IPv6DualStack: ${IS_DUAL}
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-address: "__LISTEN_ADDR__"
+# address: "${LISTEN_ADDR}"
 featureGates:
   LocalStorageCapacityIsolation: false
+  IPv6DualStack: ${IS_DUAL}
 
 

--- a/test/baremetal/kubeadm/ClusterNewConfiguration.template.yaml
+++ b/test/baremetal/kubeadm/ClusterNewConfiguration.template.yaml
@@ -9,64 +9,64 @@ bootstrapTokens:
   - authentication
 kind: InitConfiguration
 localAPIEndpoint:
-  advertiseAddress: "__NODE_IP__"
+  advertiseAddress: "${FIRST_NODE_IP}"
   bindPort: 6443
 nodeRegistration:
   taints: null
   kubeletExtraArgs:
-    node-ip: "__NODE_IP__"
+    node-ip: "${FIRST_NODE_IP}"
   criSocket: /var/run/dockershim.sock
-  name: "__NODE_NAME__"
+  name: "${NODE_NAME}"
   ignorePreflightErrors:
   - SystemVerification
   - FileContent--proc-sys-net-ipv6-conf-default-forwarding
   - DirAvailable--var-lib-etcd
 ---
 # https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/
+apiVersion: kubeadm.k8s.io/v1beta2
+kind: ClusterConfiguration
 apiServer:
   timeoutForControlPlane: 4m0s
   extraArgs:
     authorization-mode: Node,RBAC
-    advertise-address: "__NODE_IP__"
-    bind-address: "__NODE_IP__"
-    service-cluster-ip-range: "__SERVICE_CIDR__"
-apiVersion: kubeadm.k8s.io/v1beta2
+    advertise-address: "${FIRST_NODE_IP}"
+    service-cluster-ip-range: "${SERVICE_CIDR}"
+    feature-gates: "IPv6DualStack=${IS_DUAL}"
 certificatesDir: /etc/kubernetes/pki
 clusterName: kubernetes
 # https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/
 controllerManager:
   extraArgs:
-    # master: "__6SAFE_NODE_IP__"
-    cluster-cidr: "__POD_CIDR__"
-    allocate-node-cidrs: "false"
+    feature-gates: "IPv6DualStack=${IS_DUAL}"
+    allocate-node-cidrs: "true"
+    cluster-cidr: "${POD_CIDR}"
+    service-cluster-ip-range: "${SERVICE_CIDR}"
+    node-cidr-mask-size-ipv4: "${NODE_CIDR_MASK_SIZE4}"
+    node-cidr-mask-size-ipv6: "${NODE_CIDR_MASK_SIZE6}"
+    node-cidr-mask-size: "${NODE_CIDR_MASK_SIZE}"
 dns:
-  type: __DNS_TYPE__
+  type: ${DNS_TYPE}
 etcd:
   local:
     dataDir: /var/lib/etcd
 imageRepository: k8s.gcr.io
-kind: ClusterConfiguration
 kubernetesVersion: v1.17.4
 networking:
   dnsDomain: cluster.local
-  podSubnet: "__POD_CIDR__"
-  serviceSubnet: "__SERVICE_CIDR__"
-controlPlaneEndpoint: "__6SAFE_NODE_IP__:6443"
-# https://kubernetes.io/docs/reference/command-line-tools-reference/kube-scheduler/
-scheduler:
-  extraArgs:
-      bind-address: "__NODE_IP__"
-      # v: "100"
-      # master: "__6SAFE_NODE_IP__"
+  podSubnet: "${FIRST_POD_CIDR}"
+  serviceSubnet: "${FIRST_SERVICE_CIDR}"
+controlPlaneEndpoint: "${SAFE6_FIRST_NODE_IP}:6443"
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
 conntrack:
   maxPerCore: 0
-kind: KubeProxyConfiguration
+featureGates:
+  IPv6DualStack: ${IS_DUAL}
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-address: "__LISTEN_ADDR__"
 featureGates:
   LocalStorageCapacityIsolation: false
+  IPv6DualStack: ${IS_DUAL}
 

--- a/test/scripts/perftest/iperf/test.yaml
+++ b/test/scripts/perftest/iperf/test.yaml
@@ -57,6 +57,7 @@ metadata:
   namespace: iperf
   name: iperf-service
 spec:
+  ipFamily: IPv4
   selector:
     app: iperf-server
   ports:
@@ -66,6 +67,77 @@ spec:
     - protocol: UDP
       port: 5003
       name: iperf-udp
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: iperf
+  name: iperf-service-v4
+spec:
+  ipFamily: IPv4
+  selector:
+    app: iperf-server
+  ports:
+    - protocol: TCP
+      port: 5001
+      name: iperf-tcp
+    - protocol: UDP
+      port: 5003
+      name: iperf-udp
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: iperf
+  name: iperf-service-v6
+spec:
+  ipFamily: IPv6
+  selector:
+    app: iperf-server
+  ports:
+    - protocol: TCP
+      port: 5001
+      name: iperf-tcp
+    - protocol: UDP
+      port: 5003
+      name: iperf-udp
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: iperf
+  name: iperf-service-nodeport-v6
+spec:
+  ipFamily: IPv6
+  selector:
+    app: iperf-nodeport
+  ports:
+    - protocol: TCP
+      port: 5001
+      name: iperf-tcp
+    - protocol: UDP
+      port: 5003
+      name: iperf-udp
+  type: NodePort
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: iperf
+  name: iperf-service-nodeport-v4
+spec:
+  ipFamily: IPv4
+  selector:
+    app: iperf-nodeport
+  ports:
+    - protocol: TCP
+      port: 5001
+      name: iperf-tcp
+    - protocol: UDP
+      port: 5003
+      name: iperf-udp
+  type: NodePort
 ---
 apiVersion: v1
 kind: Service

--- a/test/scripts/vppdev.sh
+++ b/test/scripts/vppdev.sh
@@ -42,6 +42,13 @@ vppdev_coredns_apiserver_test() {
 	sudo nsenter -t $COREDNS_PID -n curl -k 'https://[fd10::1]:443'
 }
 
+vppdev_validate_v46 () {
+	green ".spec.podCIDRs"
+	kubectl get nodes node1 -o go-template --template='{{range .spec.podCIDRs}}{{printf "%s\n" .}}{{end}}'
+	green ".status.addresses"
+	kubectl get nodes node1 -o go-template --template='{{range .status.addresses}}{{printf "%s: %s \n" .type .address}}{{end}}'
+}
+
 vppdev_cli ()
 {
   if [[ "$1" = "up" ]]; then
@@ -63,6 +70,8 @@ vppdev_cli ()
     vppdev_run_vppctl ${@:2}
   elif [[ "$1" = "gdb" ]]; then
     vppdev_attach_vpp_gdb
+  elif [[ "$1" = "validate" ]]; then
+  	vppdev_validate_v46
   elif [[ "$1" = "coredns" ]]; then
   	shift
     vppdev_coredns_apiserver_test $@

--- a/vpp-manager/README.md
+++ b/vpp-manager/README.md
@@ -7,7 +7,7 @@ It is responsible for:
 - Cleanup: When VPP exits, it properly restores the configuration to what it was before launch, so that Linux gets connectivity back if there is only one interface. This program then exits with VPP's exit code.
 
 
-## Environement varibales
+## Environement variables
 
 - `CALICOVPP_INTERFACE` : name of the vpp interface to get the connectivity configuration from.
 


### PR DESCRIPTION
For now only full dualstack has been tested (services `v4` & `v6` with `v4` & `v6` podIPs and `v4` & `v6` nodeIPs)
Other combinations will need adding support for NAT46 in vpp plugin   