### PR TITLE
Fix graceful restart & add more tests and CI

### DIFF
--- a/calico-vpp-agent/common/common.go
+++ b/calico-vpp-agent/common/common.go
@@ -81,9 +81,9 @@ func HandleVppManagerRestart(log *logrus.Logger, vpp *vpplink.VppLink, servers .
 		WaitForVppManager()
 		log.Infof("SR:Vpp restarted")
 		barrier = true
-		err := vpp.Reconnect()
+		err := vpp.Retry(time.Second, 10, vpp.Reconnect)
 		if err != nil {
-			log.Errorf("Reconnection failed %v", err)
+			log.Errorf("Reconnection failed after 10 tries %v", err)
 		}
 		for i, srv := range servers {
 			srv.OnVppRestart()

--- a/calico-vpp-agent/routing/connectivity/connectivity.go
+++ b/calico-vpp-agent/routing/connectivity/connectivity.go
@@ -36,6 +36,7 @@ func (cn *NodeConnectivity) String() string {
 type ConnectivityProvider interface {
 	AddConnectivity(cn *NodeConnectivity) error
 	DelConnectivity(cn *NodeConnectivity) error
+	OnVppRestart()
 }
 
 type ConnectivityProviderData struct {

--- a/calico-vpp-agent/routing/connectivity/flat.go
+++ b/calico-vpp-agent/routing/connectivity/flat.go
@@ -18,9 +18,9 @@ package connectivity
 import (
 	"net"
 
+	"github.com/pkg/errors"
 	"github.com/projectcalico/vpp-dataplane/vpplink"
 	"github.com/projectcalico/vpp-dataplane/vpplink/types"
-	"github.com/pkg/errors"
 )
 
 type FlatL3Provider struct {
@@ -33,6 +33,10 @@ func getRoutePaths(addr net.IP) []types.RoutePath {
 		SwIfIndex: vpplink.AnyInterface,
 		Table:     0,
 	}}
+}
+
+func (p *FlatL3Provider) OnVppRestart() {
+	/* Nothing to do */
 }
 
 func NewFlatL3Provider(d *ConnectivityProviderData) *FlatL3Provider {

--- a/calico-vpp-agent/routing/connectivity/ipip.go
+++ b/calico-vpp-agent/routing/connectivity/ipip.go
@@ -16,10 +16,10 @@
 package connectivity
 
 import (
+	"github.com/pkg/errors"
 	"github.com/projectcalico/vpp-dataplane/calico-vpp-agent/config"
 	"github.com/projectcalico/vpp-dataplane/vpplink"
 	"github.com/projectcalico/vpp-dataplane/vpplink/types"
-	"github.com/pkg/errors"
 )
 
 type IpipProvider struct {
@@ -29,6 +29,10 @@ type IpipProvider struct {
 
 func NewIPIPProvider(d *ConnectivityProviderData) *IpipProvider {
 	return &IpipProvider{d, make(map[string]uint32)}
+}
+
+func (p *IpipProvider) OnVppRestart() {
+	p.ipipIfs = make(map[string]uint32)
 }
 
 func (p IpipProvider) AddConnectivity(cn *NodeConnectivity) error {

--- a/test/scripts/cases.sh
+++ b/test/scripts/cases.sh
@@ -16,9 +16,28 @@
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source $SCRIPTDIR/cases_util.sh
 
+# This file contains integration test scenarios. They take the form
+# of kubectl commands to be run on a running cluster with CNI and
+# test framework installed
+
+function vpp_restart_v4 ()
+{
+	NS=iperf
+	POD=iperf-client
+	kill_local_vpp
+	test "iperf ServiceName -P4" iperf -c iperf-service                              -t 1 -P4 -i1
+}
+
+function vpp_restart_v6 ()
+{
+	NS=iperf
+	POD=iperf-client
+	kill_local_vpp
+	test "iperf ServiceName -P4" iperf -V -c iperf-service                              -t 1 -P4 -i1
+}
+
 function ipv4 ()
 {
-	start_test
 	NS=iperf
 	POD=iperf-client
 	echo "--Cross node TCP tests--"
@@ -53,7 +72,6 @@ function ipv4 ()
 
 function ipv6 ()
 {
-	start_test
 	NS=iperf
 	POD=iperf-client
 	echo "--Cross node TCP tests--"

--- a/test/scripts/cases.sh
+++ b/test/scripts/cases.sh
@@ -33,7 +33,21 @@ function vpp_restart_v6 ()
 	NS=iperf
 	POD=iperf-client
 	kill_local_vpp
-	test "iperf ServiceName -P4" iperf -V -c iperf-service                              -t 1 -P4 -i1
+	test "iperf ServiceName -P4" iperf -V -c iperf-service                           -t 1 -P4 -i1
+}
+
+function snat_ip4 ()
+{
+	NS=iperf
+	POD=iperf-client-samehost
+	test "iperf 20.0.0.2 -P4" iperf -c 20.0.0.2                                      -t 1 -P1 -i1
+}
+
+function snat_ip6 ()
+{
+	NS=iperf
+	POD=iperf-client-samehost
+	test "iperf fd11::2 -P4" iperf -V -c fd11::2                                     -t 1 -P1 -i1
 }
 
 function ipv4 ()
@@ -43,8 +57,11 @@ function ipv4 ()
 	echo "--Cross node TCP tests--"
 	test "DNS lookup" nslookup kubernetes.default
 	test "iperf PodIP"           iperf -c $(NS=iperf POD=iperf-server onePodIP)      -t 1 -P1 -i1
+	assert_test_output_contains_not "connect failed"
 	test "iperf ServiceIP"       iperf -c $(NS=iperf SVC=iperf-service getClusterIP) -t 1 -P1 -i1
+	assert_test_output_contains_not "connect failed"
 	test "iperf ServiceName -P4" iperf -c iperf-service                              -t 1 -P4 -i1
+	assert_test_output_contains_not "connect failed"
 
 	echo "--Cross node UDP tests--"
 	test "iperf PodIP"           iperf -c $(NS=iperf POD=iperf-server onePodIP)      -t 1 -P1 -i1 -u -l1450 -p5003
@@ -58,8 +75,11 @@ function ipv4 ()
 	echo "--Same host TCP tests--"
 	test "DNS lookup" nslookup kubernetes.default
 	test "iperf PodIP"           iperf -c $(NS=iperf POD=iperf-server onePodIP)      -t 1 -P1 -i1
+	assert_test_output_contains_not "connect failed"
 	test "iperf ServiceIP"       iperf -c $(NS=iperf SVC=iperf-service getClusterIP) -t 1 -P1 -i1
+	assert_test_output_contains_not "connect failed"
 	test "iperf ServiceName -P4" iperf -c iperf-service                              -t 1 -P4 -i1
+	assert_test_output_contains_not "connect failed"
 
 	echo "--Same host UDP tests--"
 	test "iperf PodIP"           iperf -c $(NS=iperf POD=iperf-server onePodIP)      -t 1 -P1 -i1 -u -l1450 -p5003

--- a/test/scripts/ci.sh
+++ b/test/scripts/ci.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+
+# Copyright (c) 2020 Cisco and/or its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source $SCRIPTDIR/ci_util.sh
+
+# This file contains full integration tests. It provisions a cluster,
+# deploys calico-vpp CNI to it, applies the test framework yaml and
+# run the test scenarios contained in cases.sh
+
+function raw_ip4 () {
+	create_cluster
+	start_calico
+	start_test
+
+	echo "============ RAW ipv4 ============"
+	$CASES ipv4
+	echo "============ VPP restart ============"
+	$CASES vpp_restart_v4
+
+	teardown_cluster
+}
+
+function ipip_ip4 () {
+	create_cluster
+	start_calico_ipip
+	start_test
+
+	echo "============ IPIP ipv4 ============"
+	$CASES ipv4
+	echo "============ VPP restart ============"
+	$CASES vpp_restart_v4
+
+	teardown_cluster
+}
+
+function ipsec_ip4 () {
+	create_cluster
+	start_calico_ipsec
+	start_test
+
+	echo "============ IPsec ipv4 ============"
+	$CASES ipv4
+	echo "============ VPP restart ============"
+	$CASES vpp_restart_v4
+
+	teardown_cluster
+}
+
+function raw_ip6 () {
+	V=6 create_cluster
+	start_calico
+	start_test
+
+	echo "============ RAW ipv6 ============"
+	$CASES ipv6
+	echo "============ VPP restart ============"
+	$CASES vpp_restart_v6
+
+	teardown_cluster
+}
+
+function ipip_ip6 () {
+	V=6 create_cluster
+	start_calico_ipip
+	start_test
+
+	echo "============ IPIP ipv6 ============"
+	$CASES ipv6
+	echo "============ VPP restart ============"
+	$CASES vpp_restart_v6
+
+	teardown_cluster
+}
+
+function ipsec_ip6 () {
+	create_cluster
+	start_calico_ipsec
+	start_test
+
+	echo "============ IPsec ipv6 ============"
+	$CASES ipv6
+	echo "============ VPP restart ============"
+	$CASES vpp_restart_v6
+
+	teardown_cluster
+}
+
+if [ $# = 0 ]; then
+	echo "Usage"
+	echo "ci raw_ip4"
+	echo "ci ipip_ip4"
+	echo "ci ipsec_ip4"
+	echo "ci raw_ip6"
+	echo "ci ipip_ip6"
+	echo "ci ipsec_ip6"
+else
+	load_parameters
+	"$1"
+fi

--- a/test/scripts/ci_util.sh
+++ b/test/scripts/ci_util.sh
@@ -1,0 +1,177 @@
+#!/bin/bash
+
+# Copyright (c) 2020 Cisco and/or its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source $SCRIPTDIR/shared.sh
+
+CI_CONFIG_FILE=~/.config/calicovppci.sh
+
+function load_parameters () {
+	if [ -f $CI_CONFIG_FILE ]; then
+		source $CI_CONFIG_FILE
+	else
+		echo "Please create $CI_CONFIG_FILE"
+		echo "with:"
+		echo "IF=eth0"
+		echo "NODESSH=hostname"
+		exit 1
+	fi
+	if [[ $(systemctl is-active --quiet kubelet || echo "dead") != dead ]]; then
+		red "Kubelet seems to be already started"
+		exit 1
+	fi
+}
+
+# ------------ CLUSTER ------------
+
+function cluster_provisionning () {
+  ACTION=$1
+  IF=${IF:=eth0}
+  if [[ $V = 6 ]]; then
+    POD_CIDR=fd20::0/112
+    SERVICE_CIDR=fd10::0/120
+    MAIN=fd11::1/124
+    OTHERS=fd11::2/124@${NODESSH}
+  elif [[ $V = 46 ]]; then
+    POD_CIDR=10.0.0.0/16,fd20::0/112
+    SERVICE_CIDR=10.96.0.0/16,fd10::0/120
+    MAIN=20.0.0.1/24,fd11::1/124
+    OTHERS=20.0.0.2/24,fd11::2/124@${NODESSH}
+  else
+    POD_CIDR=10.0.0.0/16
+    SERVICE_CIDR=10.96.0.0/16
+    MAIN=20.0.0.1/24
+    OTHERS=20.0.0.2/24@${NODESSH}
+  fi
+  if [[ $N = 0 ]]; then
+  	OLD_OTHERS=$OTHERS
+    OTHERS=
+  fi
+
+  $ORCH $ACTION \
+    IF=$IF \
+    POD_CIDR=$POD_CIDR \
+    SERVICE_CIDR=$SERVICE_CIDR \
+    MAIN=$MAIN \
+    OTHERS=$OTHERS > $ORCHUP_LOG 2>&1
+}
+
+function create_cluster () {
+  blue "Starting cluster... at $(date)"
+  mkdir -p $LOG_DIR
+  cluster_provisionning up
+}
+
+function teardown_cluster () {
+  blue "Stopping cluster... at $(date)"
+  cluster_provisionning dn
+}
+
+# ------------ CNI ------------
+
+function wait_for_calico_vpp () {
+	NVPPS=0
+	while [ x$NVPPS != x2 ]; do
+	  NVPPS=$(kubectl -n kube-system get pods | grep calico-vpp | grep '2/2' | wc -l)
+	  grey "calico not yet ready"
+	  sleep 5
+	done
+}
+
+function start_calico () {
+  blue "Starting calico $1... at $(date)"
+  export CALICO_NODE_IMAGE=calicovpp/node:latest
+  export CALICO_VPP_IMAGE=calicovpp/vpp:latest
+  export IMAGE_PULL_POLICY=Never
+  export CALICOVPP_CORE_PATTERN=/home/hostuser/vppcore.%e.%p
+  export CALICOVPP_TAP_GSO_ENABLED=true
+  export CALICOVPP_INTERFACE=$IF
+
+  export CALICOVPP_IPSEC_ENABLED=false
+
+  $KUST up > $CALICOUP_LOG 2>&1
+  wait_for_calico_vpp
+}
+
+function start_calico_ipsec () {
+  export CALICO_IPV4POOL_IPIP=Always
+  export CALICO_IPV6POOL_IPIP=Always
+  export CALICOVPP_IPSEC_ENABLED=true
+  export CALICOVPP_IPSEC_CROSS_TUNNELS=false
+  export CALICOVPP_CONFIGURE_EXTRA_ADDRESSES=0
+  start_calico
+}
+
+function start_calico_ipip () {
+  export CALICO_IPV4POOL_IPIP=Always
+  export CALICO_IPV6POOL_IPIP=Always
+  start_calico
+}
+
+# ------------ Test framework ------------
+
+function wait_for_coredns () {
+	NVPPS=0
+	while [ x$NVPPS != x2 ]; do
+	  NVPPS=$(kubectl -n kube-system get pods | grep coredns | grep '1/1' | wc -l)
+	  echo "coredns not yet ready..."
+	  sleep 5
+	done
+}
+
+function wait_for_calico_test () {
+	NPODS=0
+	sleep 1
+	while [ x$NPODS != x1 ]; do
+	  NPODS=$(kubectl -n $SVC get pods | grep -v Running | wc -l)
+	  echo "test not yet ready..."
+	  sleep 1
+	done
+}
+
+function start_test () {
+	echo "Starting test clients... at $(date)"
+	$SCRIPTDIR/test.sh up iperf > iperfup.log 2>&1
+	wait_for_coredns
+	SVC=iperf wait_for_calico_test
+}
+
+function start_iperf4 () {
+	ssh $NODESSH -t "sudo ip link set $IF up" > /dev/null 2>&1
+	ssh $NODESSH -t "sudo ip addr add 20.0.0.2/24 dev $IF" > /dev/null 2>&1 || true
+	ssh $NODESSH -t "nohup bash -c 'iperf -s -B 20.0.0.2 > /tmp/iperf.log 2>&1 &'" > /dev/null 2>&1
+}
+
+function start_iperf6 () {
+	ssh $NODESSH -t "sudo ip link set $IF up" > /dev/null 2>&1
+	ssh $NODESSH -t "sudo ip addr add fd11::2/120 dev $IF" > /dev/null 2>&1 || true
+	ssh $NODESSH -t "nohup bash -c 'iperf -s -V -B fd11::2 > /tmp/iperf.log 2>&1 &'" > /dev/null 2>&1
+}
+
+function stop_iperf () {
+	ssh $NODESSH -t "sudo pkill iperf ; cat /tmp/iperf.log" > $LAST_TEST_LOGFILE 2> /dev/null
+}
+
+function sshtest () {
+	echo "-----------TESTCASE $1-----------" > $LAST_TEST_LOGFILE
+	ssh $NODESSH -t "timeout -k 1 4 ${@:2}" >> $LAST_TEST_LOGFILE
+	CODE=$?
+	if [ x$CODE = x0 ]; then
+	  green "$1 .... OK"
+	else
+	  red "$1 .... FAILED exit=$CODE"
+	fi
+	cat $LAST_TEST_LOGFILE >> $LOGFILE
+}

--- a/test/scripts/shared.sh
+++ b/test/scripts/shared.sh
@@ -15,6 +15,16 @@
 
 if [[ "$X" != "" ]]; then set -x ; fi
 
+ORCH=$SCRIPTDIR/../baremetal/orch.sh
+CASES=$SCRIPTDIR/../scripts/cases.sh
+KUST=$SCRIPTDIR/../../yaml/overlays/dev/kustomize.sh
+
+LOG_DIR=/tmp/calicovppci
+ORCHUP_LOG=$LOG_DIR/orchup.log
+CALICOUP_LOG=$LOG_DIR/calicoup.log
+LOGFILE=$LOG_DIR/testrun.log
+LAST_TEST_LOGFILE=$LOG_DIR/testrun.log~
+
 function green ()
 {
   printf "\e[0;32m$1\e[0m\n"

--- a/test/scripts/shared.sh
+++ b/test/scripts/shared.sh
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
-
 if [[ "$X" != "" ]]; then set -x ; fi
 
 function green ()
@@ -25,6 +23,16 @@ function green ()
 function red ()
 {
   printf "\e[0;31m$1\e[0m\n"
+}
+
+function blue ()
+{
+  printf "\e[0;34m$1\e[0m\n"
+}
+
+function grey ()
+{
+  printf "\e[0;37m$1\e[0m\n"
 }
 
 find_node_pod () # NODE, POD


### PR DESCRIPTION
* This fixes graceful restart for ipip & ipsec (cache wasn't getting properly cleaned)
* It adds a synchronization mechanism in the case where we need to restart the BGP server
* It adds `ci.sh` and `ci_util.sh` scripts to allow running a ~somewhat rudimentary CI (bash script based...)
* Adds new tests `(flat ip, ipip, ipsec) x (ipv4, ipv6)` and `(nodeports, natOutgoing) x (ipv4, ipv6)`