### PR TITLE
Make calivppctl more user-friendly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ calico-vpp-agent/cmd/calico-vpp-agent
 calico-vpp-agent/cmd/felix-api-proxy
 calico-vpp-agent/dep/gobgp
 vpp-manager/images/*/vpp-manager
+vpp-manager/images/*/vppdev.sh
 vpp-manager/vpp_build/
 *.deb
 vpplink/binapi/bin/

--- a/test/scripts/shared.sh
+++ b/test/scripts/shared.sh
@@ -30,25 +30,10 @@ LAST_TEST_LOGFILE=$LOG_DIR/testrun.log~
 CI_CONFIG_FILE=~/.config/calicovppci.sh
 PCI_BIND_NIC_TO_KERNEL=$SCRIPTDIR/../baremetal/utils/pci-nic-bind-to-kernel
 
-function green ()
-{
-  printf "\e[0;32m$1\e[0m\n"
-}
-
-function red ()
-{
-  printf "\e[0;31m$1\e[0m\n"
-}
-
-function blue ()
-{
-  printf "\e[0;34m$1\e[0m\n"
-}
-
-function grey ()
-{
-  printf "\e[0;37m$1\e[0m\n"
-}
+function green () { printf "\e[0;32m$1\e[0m\n" ; }
+function red   () { printf "\e[0;31m$1\e[0m\n" ; }
+function blue  () { printf "\e[0;34m$1\e[0m\n" ; }
+function grey  () { printf "\e[0;37m$1\e[0m\n" ; }
 
 find_node_pod () # NODE, POD
 {
@@ -59,13 +44,25 @@ find_node_pod () # NODE, POD
 exec_node () # C, POD, NODE
 {
   SVC=${SVC:=kube-system}
-  kubectl exec -it -n $SVC $(find_node_pod) -c $C -- $@
+  local pod_name=$(find_node_pod)
+  if [ x$pod_name == x ]; then
+    >&2 echo "pod '$POD' not found on node '$NODE'"
+  	exit 1
+  else
+	kubectl exec -it -n $SVC $pod_name -c $C -- $@
+  fi
 }
 
 log_node () # C, POD, NODE
 {
   SVC=${SVC:=kube-system}
-  kubectl logs $FOLLOW -n $SVC $(find_node_pod) -c $C
+  local pod_name=$(find_node_pod)
+  if [ x$pod_name == x ]; then
+    >&2 echo "pod '$POD' not found on node '$NODE'"
+  	exit 1
+  else
+	kubectl logs $FOLLOW -n $SVC $pod_name -c $C
+  fi
 }
 
 vppdev_run_vppctl () # nodeID args

--- a/test/scripts/vppdev.sh
+++ b/test/scripts/vppdev.sh
@@ -13,62 +13,121 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-source $SCRIPTDIR/shared.sh
+function green () { printf "\e[0;32m$1\e[0m\n" ; }
+function red   () { printf "\e[0;31m$1\e[0m\n" ; }
+function blue  () { printf "\e[0;34m$1\e[0m\n" ; }
+function grey  () { printf "\e[0;37m$1\e[0m\n" ; }
 
-vppdev_attach_vpp_gdb ()
+find_node_pod () # NODE, POD
 {
-  CONTAINER=$(docker ps | grep vpp_calico-vpp | cut -d ' ' -f 1)
-  PID=$(docker logs $CONTAINER 2>&1 | grep "VPP started. PID: " | \
-	sed -r 's/.*PID: ([0-9]+).*/\1/')
-  docker exec -it $CONTAINER gdb -p $PID -ex continue
+  SVC=${SVC:=kube-system}
+  echo $(kubectl get pods -n $SVC --field-selector="spec.nodeName=$NODE" | grep $POD | cut -d ' ' -f 1)
 }
 
-vppdev_coredns_apiserver_test() {
-	COREDNS_N=$1
-	COREDNS_TOTAL=$(docker ps | grep "coredns -conf" | cut -d ' ' -f 1 | wc -l)
-	echo "Found $COREDNS_TOTAL coredns"
-	if [ x$COREDNS_TOTAL = x0 ]; then
-		exit 0
+exec_node () # C, POD, NODE
+{
+  SVC=${SVC:=kube-system}
+  local pod_name=$(find_node_pod)
+  if [ x$pod_name == x ]; then
+    >&2 red "pod '$POD' not found on node '$NODE'"
+  	exit 1
+  else
+	kubectl exec -it -n $SVC $pod_name -c $C -- $@
+  fi
+}
+
+log_node () # C, POD, NODE
+{
+  SVC=${SVC:=kube-system}
+  local pod_name=$(find_node_pod)
+  if [ x$pod_name == x ]; then
+    >&2 red "pod '$POD' not found on node '$NODE'"
+  	exit 1
+  else
+	kubectl logs $FOLLOW -n $SVC $pod_name -c $C
+  fi
+}
+
+vppctl () # nodeID args
+{
+  NODE=$1 POD=calico-vpp-node C=vpp exec_node \
+	/usr/bin/vppctl -s /var/run/vpp/cli.sock ${@:2}
+}
+
+#
+# CLI functions
+#
+
+vppdev_cli_gdb ()
+{
+  grey "This finds the VPP running in a vpp_calico-vpp docker container"
+  grey "and attaches to it. [Ctrl+C detach q ENTER] to exit"
+  local container=$(docker ps | grep vpp_calico-vpp | awk '{ print $1 }')
+  if [ x$container == x ]; then
+  	red "No vpp container found"
+  	exit 1
+  fi
+  local pid=$(docker exec -it $container cat /var/run/vpp/vpp.pid)
+  docker exec -it $container gdb -p $pid -ex continue
+}
+
+vppdev_cli_export ()
+{
+	kubectl version > /dev/null 2>&1
+	if [ $? != 0 ]; then
+		red "Couldn't connect to kubernetes using kubectl"
+		exit 1
 	fi
-	COREDNS_DOCKERID=$(docker ps | grep "coredns -conf" | cut -d ' ' -f 1 | head -n $COREDNS_N | tail -n 1)
-	COREDNS_PID=$(docker inspect --format '{{ .State.Pid }}' $COREDNS_DOCKERID )
-	sudo nsenter -t $COREDNS_PID -n curl -k 'https://[fd10::1]:443'
-}
-
-vppdev_validate_v46 () {
-	green ".spec.podCIDRs"
-	kubectl get nodes node1 -o go-template --template='{{range .spec.podCIDRs}}{{printf "%s\n" .}}{{end}}'
-	green ".status.addresses"
-	kubectl get nodes node1 -o go-template --template='{{range .status.addresses}}{{printf "%s: %s \n" .type .address}}{{end}}'
-}
-
-vppdev_export ()
-{
 	if [ x$(kubectl -n kube-system get pods | grep calico-vpp | wc -l) = x0 ]; then
-		echo "No calico-vpp pod found"
+		red "No calico-vpp pod found"
 		exit 1
 	fi
 
 	DIR=$1
 	PREFIX=$2
-	DIR=${DIR:=./results}
+	DIR=${DIR:=./export}
 	mkdir -p $DIR
+
+	grey "Logging k8 internals..."
+
+	kubectl version                                              > ${DIR}/${PREFIX}kubectl-version
+	sudo journalctl -u kubelet -r -n200                          > ${DIR}/${PREFIX}kubelet-journal 2>&1
+	kubectl -n kube-system get pods -o wide                      > ${DIR}/${PREFIX}get-pods
+	kubectl -n kube-system get services -o wide                  > ${DIR}/${PREFIX}get-services
+	kubectl -n kube-system get nodes -o wide                     > ${DIR}/${PREFIX}get-nodes
+	kubectl -n kube-system get configmap calico-config -o yaml   > ${DIR}/${PREFIX}calico-config.configmap.yaml
+	kubectl -n kube-system get daemonset calico-vpp-node -o yaml > ${DIR}/${PREFIX}calico-vpp-node.daemonset.yaml
+
 	for node in $(kubectl get nodes -o go-template --template='{{range .items}}{{printf "%s\n" .metadata.name}}{{end}}')
 	do
-		vppdev_run_vppctl $node show hardware-interfaces > ${DIR}/${PREFIX}${node}.hwi
-		vppdev_run_vppctl $node show run                 > ${DIR}/${PREFIX}${node}.run
-		vppdev_run_vppctl $node show err                 > ${DIR}/${PREFIX}${node}.err
-		vppdev_run_vppctl $node show log                 > ${DIR}/${PREFIX}${node}.log
-		vppdev_run_vppctl $node show buffers             > ${DIR}/${PREFIX}${node}.buf
-		vppdev_run_vppctl $node show int                 > ${DIR}/${PREFIX}${node}.int
-		vppdev_run_vppctl $node show int rx              > ${DIR}/${PREFIX}${node}.intrx
-		vppdev_run_vppctl $node show tun                 > ${DIR}/${PREFIX}${node}.tun
+		grey "Logging node $node..."
+		local calicovpp_pod_name=$(POD=calico-vpp-node NODE=$node find_node_pod)
+		vppctl $node show hardware-interfaces                    > ${DIR}/${PREFIX}${node}.hardware-interfaces
+		vppctl $node show run                                    > ${DIR}/${PREFIX}${node}.show-run
+		vppctl $node show err                                    > ${DIR}/${PREFIX}${node}.show-err
+		vppctl $node show log                                    > ${DIR}/${PREFIX}${node}.show-log
+		vppctl $node show buffers                                > ${DIR}/${PREFIX}${node}.show-buffers
+		vppctl $node show int                                    > ${DIR}/${PREFIX}${node}.show-int
+		vppctl $node show int rx                                 > ${DIR}/${PREFIX}${node}.show-int-rx
+		vppctl $node show tun                                    > ${DIR}/${PREFIX}${node}.show-tun
+		kubectl -n kube-system describe pod/$calicovpp_pod_name  > ${DIR}/${PREFIX}${node}.describe-vpp-pod
+		NODE=$node POD=calico-vpp-node C=vpp log_node            > ${DIR}/${PREFIX}${node}.vpp.log
+		NODE=$node POD=calico-vpp-node C=calico-node log_node    > ${DIR}/${PREFIX}${node}.calico.log
+		NODE=$node POD=calico-vpp-node C=calico-node exec_node \
+		  cat /var/log/calico/calico-vpp-agent/current           > ${DIR}/${PREFIX}${node}.agent.log
 	done
-
+	# By default, compress to archive
+	if [ x$DIR = x./export ]; then
+		grey "compressing..."
+		tar -zcvf ./export.tar.gz ./export > /dev/null
+		rm -r ./export
+		green "Done exporting to ./export.tar.gz"
+	else
+		green "Done exporting to $DIR"
+	fi
 }
 
-vppdev_clear ()
+vppdev_cli_clear ()
 {
 	if [ x$(kubectl -n kube-system get pods | grep calico-vpp | wc -l) = x0 ]; then
 		echo "No calico-vpp pod found"
@@ -76,67 +135,99 @@ vppdev_clear ()
 	fi
 	for node in $(kubectl get nodes -o go-template --template='{{range .items}}{{printf "%s\n" .metadata.name}}{{end}}')
 	do
-		vppdev_run_vppctl $node clear run
-		vppdev_run_vppctl $node clear err
+		vppctl $node clear run
+		vppctl $node clear err
 	done
+}
+
+vppdev_cli_vppctl ()
+{
+  vppctl $@
+}
+
+vppdev_cli_log ()
+{
+	local container=""
+	local FOLLOW=""
+	local node_name=""
+	local cattail="cat"
+	while (( $# )); do
+		case "$1" in
+		-vpp)
+			container=vpp
+			shift
+			;;
+		-agent)
+			container=agent
+			shift
+			;;
+		-f)
+			FOLLOW="-f"
+			cattail="tail -f"
+			shift
+			;;
+		*)
+        	node_name=$1
+			shift
+			;;
+		esac
+	done
+
+	if [ x$node_name = x ]; then
+		red "Please specify a node name"
+		exit 1
+	fi
+
+	if [[ "$container" = "vpp" ]]; then
+	  NODE=$node_name POD=calico-vpp-node C=vpp FOLLOW=$FOLLOW log_node
+	elif [[ "$container" = "agent" ]]; then
+	  NODE=$node_name POD=calico-vpp-node C=calico-node exec_node \
+    	$cattail /var/log/calico/calico-vpp-agent/current
+	else
+	  blue "----- VPP Manager      -----"
+	  NODE=$node_name POD=calico-vpp-node C=vpp log_node
+	  blue "----- Calico-VPP agent -----"
+	  NODE=$node_name POD=calico-vpp-node C=calico-node exec_node \
+    	cat /var/log/calico/calico-vpp-agent/current
+	fi
+}
+
+vppdev_cli_sh ()
+{
+  if [[ "$1" = "vpp" ]]; then
+	NODE=$2 POD=calico-vpp-node C=vpp exec_node bash
+  elif [[ "$1" = "agent" ]]; then
+	NODE=$2 POD=calico-vpp-node C=calico-node exec_node bash
+  else
+  	echo "Use $(basename -- $0) sh [vpp|node] [NODENAME]"
+  fi
 }
 
 vppdev_cli ()
 {
-  if [[ "$1" = "up" ]]; then
-	if [ -f $SCRIPTDIR/conf/$2 ]; then
-		echo "Using conf from $SCRIPTDIR/conf/$2"
-		source $SCRIPTDIR/conf/$2
-	fi
-    calico_up_cni
-	elif [[ "$1" = "down" ]]; then
-	if [ -f $SCRIPTDIR/conf/$2 ]; then
-		echo "Using conf from $SCRIPTDIR/conf/$2"
-		source $SCRIPTDIR/conf/$2
-	fi
-    calico_down_cni
-  # ---------------------------------
-  #               SHELLS
-  # ---------------------------------
-  elif [[ "$1" = "export" ]]; then
-    vppdev_export ${@:2}
-  elif [[ "$1" = "clear" ]]; then
-    vppdev_clear ${@:2}
-  elif [[ "$1" = "vppctl" ]]; then
-    vppdev_run_vppctl ${@:2}
-  elif [[ "$1" = "gdb" ]]; then
-    vppdev_attach_vpp_gdb
-  elif [[ "$1" = "validate" ]]; then
-  	vppdev_validate_v46
-  elif [[ "$1" = "coredns" ]]; then
-  	shift
-    vppdev_coredns_apiserver_test $@
-  elif [[ "$1 $2" = "log vpp" ]]; then
-    NODE=$3 POD=calico-vpp-node C=vpp log_node
-  elif [[ "$1 $2" = "tail vpp" ]]; then
-    NODE=$3 POD=calico-vpp-node C=vpp FOLLOW="-f" log_node
-  elif [[ "$1 $2" = "log node" ]]; then
-    NODE=$3 POD=calico-vpp-node C=calico-node exec_node \
-      cat /var/log/calico/calico-vpp-agent/current
-  elif [[ "$1 $2" = "tail node" ]]; then
-    NODE=$3 POD=calico-vpp-node C=calico-node exec_node \
-      tail -f /var/log/calico/calico-vpp-agent/current
-  elif [[ "$1 $2" = "sh vpp" ]]; then
-    NODE=$3 POD=calico-vpp-node C=vpp exec_node bash
-  elif [[ "$1 $2" = "sh node" ]]; then
-    NODE=$3 POD=calico-vpp-node C=calico-node exec_node bash
+  local fn_name=vppdev_cli_$1
+  shift
+  if [[ $(declare -F) =~ (^|[[:space:]])"$fn_name"($|[[:space:]]) ]] ; then
+    $fn_name $@
   else
+	echo '   ______      ___               _    ______  ____ '
+	echo '  / ____/___ _/ (_)________     | |  / / __ \/ __ \'
+	echo ' / /   / __ `/ / / ___/ __ \    | | / / /_/ / /_/ /'
+	echo '/ /___/ /_/ / / / /__/ /_/ /    | |/ / ____/ ____/ '
+	echo '\____/\__,_/_/_/\___/\____/     |___/_/   /_/      '
+	echo '                                                   '
+    echo ""
     echo "Usage:"
+    echo
+    echo "$(basename -- $0) vppctl [NODENAME]                 - Get a vppctl shell on specific node"
+    echo "$(basename -- $0) log [-f] [-vpp|-agent] [NODENAME] - Get the logs of vpp (dataplane) or calico-node (controlplane) container"
+    echo
+    echo "$(basename -- $0) clear                             - Clear vpp internal stats"
+    echo "$(basename -- $0) export                            - Create an archive with vpp & k8 system state for debugging"
+    echo "                                                    it accepts a dir name and a prefix 'export [dir] [prefix]'"
+	echo
     echo "$(basename -- $0) gdb                               - Attach a gdb to the running vpp on the current machine"
-    echo "$(basename -- $0) coredns [N]                       - test Nth coredns connectivity to the apiserver"
-    echo
-    echo "$(basename -- $0) vppctl [NAME]                     - Get a vppctl shell on specific node"
-    echo "$(basename -- $0) sh [vpp|node] [NAME]              - Get a shell in vpp (dataplane) or calico-node (controlplane) container"
-    echo "$(basename -- $0) log [vpp|node] [NAME]             - Get the logs of vpp (dataplane) or calico-node (controlplane) container"
-    echo "$(basename -- $0) tail [vpp|node] [NAME]            - tail -f the logs of vpp (dataplane) or calico-node (controlplane) container"
-    echo
-    echo "$(basename -- $0) clear                             - Clear run"
-    echo "$(basename -- $0) export [DIR] [PREFIX]             - Export vpp logs to DIR"
+    echo "$(basename -- $0) sh [vpp|agent] [NODENAME]         - Get a shell in vpp (dataplane) or calico-node (controlplane) container"
   fi
 }
 

--- a/vpp-manager/Makefile
+++ b/vpp-manager/Makefile
@@ -4,6 +4,7 @@ VPPLINK_DIR=../vpplink
 INIT_EKS_IMAGE_DIR=images/init-eks/
 DEV_IMAGE_DIR=images/dev/
 IMAGE_DIR=images/ubuntu
+VPPDEV_FILE=../test/scripts/vppdev.sh
 TAG ?= latest
 
 all: image
@@ -17,6 +18,7 @@ eksimage:
 		-t calicovpp/init-eks:$(TAG) $(INIT_EKS_IMAGE_DIR)
 
 image: build vpp
+	cp $(VPPDEV_FILE) $(IMAGE_DIR)
 	docker build --pull \
 		--build-arg http_proxy=${DOCKER_BUILD_PROXY} \
 		-t calicovpp/vpp:$(TAG) $(IMAGE_DIR)
@@ -25,6 +27,7 @@ push: image
 	docker push calicovpp/vpp:$(TAG)
 
 imageonly: build
+	cp $(VPPDEV_FILE) $(IMAGE_DIR)
 	docker build --pull \
 		--build-arg http_proxy=${DOCKER_BUILD_PROXY} \
 		-t calicovpp/vpp:$(TAG) $(IMAGE_DIR)
@@ -45,6 +48,7 @@ vpp-build-env:
 		-t calicovpp/vpp-build:latest images/ubuntu-build
 
 dev: build
+	cp $(VPPDEV_FILE) $(DEV_IMAGE_DIR)
 	docker build --pull \
 	  --build-arg http_proxy=${DOCKER_BUILD_PROXY} \
 	  -t calicovpp/vpp:$(TAG) $(DEV_IMAGE_DIR)

--- a/vpp-manager/images/dev/Dockerfile
+++ b/vpp-manager/images/dev/Dockerfile
@@ -16,5 +16,6 @@ ADD vpp.sh /usr/bin/vpp
 ADD vppctl.sh /usr/bin/vppctl
 
 RUN chmod +x /usr/bin/entrypoint /usr/bin/vppctl /usr/bin/vpp
+ADD vppdev.sh /usr/bin/calivppctl
 
 ENTRYPOINT ["/usr/bin/entrypoint"]

--- a/vpp-manager/images/ubuntu/Dockerfile
+++ b/vpp-manager/images/ubuntu/Dockerfile
@@ -25,5 +25,6 @@ RUN dpkg -i /tmp/vpp/libvppinfra_*.deb && \
 
 RUN rm -rf /tmp/vpp
 ADD vpp-manager /usr/bin/
+ADD vppdev.sh /usr/bin/calivppctl
 
 ENTRYPOINT ["/usr/bin/vpp-manager"]

--- a/yaml/base/calico-vpp.yaml
+++ b/yaml/base/calico-vpp.yaml
@@ -62,6 +62,7 @@ data:
       nodaemon
       full-coredump
       cli-listen /var/run/vpp/cli.sock
+      pidfile /run/vpp/vpp.pid
     }
     api-trace { on }
     cpu {

--- a/yaml/overlays/dev/kustomize.sh
+++ b/yaml/overlays/dev/kustomize.sh
@@ -65,6 +65,7 @@ function get_vpp_conf ()
 		full-coredump
 		log /var/run/vpp/vpp.log
 		cli-listen /var/run/vpp/cli.sock
+    	pidfile /run/vpp/vpp.pid
 	  }
 	  cpu { main-core ${MAINCORE} workers ${WRK} }
 	  socksvr {


### PR DESCRIPTION
calivppctl should be shipped in vpp images and installed with :

* With curl 
````bash
curl https://raw.githubusercontent.com/projectcalico/vpp-dataplane/master/test/scripts/vppdev.sh \
  | sudo tee /usr/bin/calivppctl
sudo chmod +x /usr/bin/calivppctl
````
* With docker (and a cluster with calico-vpp runnning)
````bash
sudo docker cp $(docker ps | grep vpp_calico-vpp | awk '{ print $1 }'):/usr/bin/calivppctl /usr/bin/calivppctl
````
* With kubectl (and a cluster with calico-vpp runnning)
````bash
kubectl -n kube-system exec -it \
  $(kubectl -n kube-system get pods -o wide | grep calico-vpp-node- | awk '{ print $1 }' | head -1) \
  -c vpp -- cat /usr/bin/calivppctl | sudo tee /usr/bin/calivppctl > /dev/null
sudo chmod +x /usr/bin/calivppctl
````




Signed-off-by: Nathan Skrzypczak <nathan.skrzypczak@gmail.com>