### PR TITLE
Add debug symbols to release container

### DIFF
--- a/vpp-manager/Makefile
+++ b/vpp-manager/Makefile
@@ -38,7 +38,7 @@ vpp: vpp-build-env
 		-v $(CURDIR):/root/vpp-manager:delegated \
 		calicovpp/vpp-build:latest
 	rm -f $(IMAGE_DIR)*.deb
-	for pkg in vpp vpp-plugin-core vpp-plugin-dpdk libvppinfra ; do \
+	for pkg in vpp vpp-plugin-core vpp-plugin-dpdk libvppinfra vpp-dbg ; do \
 		cp vpp_build/build-root/$$pkg_*.deb $(IMAGE_DIR) ; \
 	done
 

--- a/vpp-manager/images/ubuntu/Dockerfile
+++ b/vpp-manager/images/ubuntu/Dockerfile
@@ -20,8 +20,8 @@ RUN dpkg -i /tmp/vpp/libvppinfra_*.deb && \
     rm -f /var/lib/dpkg/info/vpp.postinst && \
     dpkg --configure vpp && \
     dpkg -i /tmp/vpp/vpp-plugin-core_*.deb \
-    /tmp/vpp/vpp-plugin-dpdk_*.deb
-
+    /tmp/vpp/vpp-plugin-dpdk_*.deb \
+    /tmp/vpp/vpp-dbg_*.deb
 
 RUN rm -rf /tmp/vpp
 ADD vpp-manager /usr/bin/


### PR DESCRIPTION
Those are now needed to be able to inspect corefiles generated on VPP crash.
It's debatable whether or not we want to ship them with release images, 
but in an alpha/beta stage, it might be best including them for the sake of 
user-friendlyness when reporting issues.

Signed-off-by: Nathan Skrzypczak <nathan.skrzypczak@gmail.com>