### PR TITLE
vpp-manager: Fix build & add cnat patch

### DIFF
--- a/vpp-manager/Makefile
+++ b/vpp-manager/Makefile
@@ -30,11 +30,13 @@ imageonly: build
 		-t calicovpp/vpp:$(TAG) $(IMAGE_DIR)
 
 vpp: vpp-build-env
+	rm -f ./vpp_build/build-root/*.deb
+	rm -f ./vpp_build/build-root/*.buildinfo
+	rm -f $(IMAGE_DIR)/*.deb
 	bash $(VPPLINK_DIR)/binapi/vpp_clone_current.sh ./vpp_build
 	docker run --rm \
 		-v $(CURDIR):/root/vpp-manager:delegated \
 		calicovpp/vpp-build:latest
-	rm -f $(IMAGE_DIR)*.deb
 	for pkg in vpp vpp-plugin-core vpp-plugin-dpdk libvppinfra vpp-dbg ; do \
 		cp vpp_build/build-root/$$pkg_*.deb $(IMAGE_DIR) ; \
 	done

--- a/vpp-manager/images/ubuntu-build/build_script.sh
+++ b/vpp-manager/images/ubuntu-build/build_script.sh
@@ -4,7 +4,7 @@ set -o errexit
 
 cd /root/vpp-manager/vpp_build
 
-make build
+make build-release
 rm -f ./build-root/*.deb ./build-root/*.changes ./build-root/*.buildinfo
-make pkg-deb-debug
+make pkg-deb
 

--- a/vpplink/binapi/vpp_clone_current.sh
+++ b/vpplink/binapi/vpp_clone_current.sh
@@ -31,4 +31,4 @@ index 7531dd197..94a2bfb12 100644
 " | git apply -- && git add -A &&  git commit --author "Anonymous <>" -m "Use 10us interrupt sleep"
 
 git fetch "https://gerrit.fd.io/r/vpp" refs/changes/35/29735/2 && git cherry-pick FETCH_HEAD # 29735: cnat: Fix invalid adj_index | https://gerrit.fd.io/r/c/vpp/+/29735
-
+git fetch "https://gerrit.fd.io/r/vpp" refs/changes/55/29955/1 && git cherry-pick FETCH_HEAD # 29955: cnat: Fix throttle hash & cleanup | https://gerrit.fd.io/r/c/vpp/+/29955


### PR DESCRIPTION
- VPP build Image was wrongly debug
- rebuild errored due to debs not being removed during build

Signed-off-by: Nathan Skrzypczak <nathan.skrzypczak@gmail.com>