### PR TITLE
Feature/cnat fix

### DIFF
--- a/vpplink/binapi/vpp_clone_current.sh
+++ b/vpplink/binapi/vpp_clone_current.sh
@@ -43,3 +43,4 @@ index 7531dd197..94a2bfb12 100644
 
 git fetch "https://gerrit.fd.io/r/vpp" refs/changes/46/30146/1 && git cherry-pick FETCH_HEAD # 30146: wireguard: return public key in api | https://gerrit.fd.io/r/c/vpp/+/30146
 git fetch "https://gerrit.fd.io/r/vpp" refs/changes/54/30154/1 && git cherry-pick FETCH_HEAD # 30154: wireguard: run feature after gso | https://gerrit.fd.io/r/c/vpp/+/30154
+git fetch "https://gerrit.fd.io/r/vpp" refs/changes/73/30273/1 && git cherry-pick FETCH_HEAD # 30273: cnat: Fix session with deleted tr | https://gerrit.fd.io/r/c/vpp/+/30273

--- a/vpplink/binapi/vppapi/generate.log
+++ b/vpplink/binapi/vppapi/generate.log
@@ -1,7 +1,10 @@
-VPP Version                 : 21.01-rc0~294-g7c35ebfa1
+VPP Version                 : 21.01-rc0~297-geed62250c
 Binapi-generator version    : govpp v0.4.0-dev
 VPP Base commit             : 5f4f2081c nat: nat44 enable/disable dynamic config
 ------------------ Cherry picked commits --------------------
+eed62250c cnat: Fix session with deleted tr
+f1d1caed5 wireguard: run feature after gso
+af1b8a1f3 wireguard: return public key in api
 7c35ebfa1 Use 10us interrupt sleep
 a41954a5e capo: Calico Policies plugin
 6935e4232 acl: acl-plugin custom policies


### PR DESCRIPTION
Add vpp cnat fix :
    When a translation gets deleted, hiting a
    session pointing to it sefaults. We're better
    off directly storing the next node index.
