### PR TITLE
Feature/calico-VPP version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ test/vagrant/.vagrant
 
 # macOS
 .DS_Store
+
+# build artefacts
+calico-vpp-agent/version
+vpp-manager/images/ubuntu/version

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ release: check-TAG push
 	$(MAKE) -C yaml
 	git checkout -b release/$(TAG)
 	git add yaml
-	git commit -sm "Release $(TAG)"	
+	git commit -sm "Release $(TAG)"
 	# Tag release and push it
 	git tag $(TAG)
 	git push --set-upstream origin release/$(TAG)

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ yaml:
 
 .PHONY: release
 # TAG must be set to something like v0.6.0-calicov3.9.1
-release: check-TAG push
+release: check-TAG
 	@[ -z "$(shell git status --porcelain)" ] || (echo "Repo is not clean! Aborting." && exit 1)
 	# Generate yaml file for this release
 	sed -i.bak "s|:latest|:$(TAG)|g" yaml/base/calico-vpp.yaml

--- a/calico-vpp-agent/Dockerfile
+++ b/calico-vpp-agent/Dockerfile
@@ -7,6 +7,7 @@ ADD cmd/felix-api-proxy /bin/felix-api-proxy
 ADD cmd/calico-vpp-agent /bin/calico-vpp-agent
 ADD cmd/debug /bin/debug
 ADD etc/service/calico-vpp-agent /etc/service/available/calico-vpp-agent
+ADD version /etc/calicovppversion
 
 RUN sed -i.orig \
     -e '/^case "\$CALICO_NETWORKING_BACKEND" in/a \\t"vpp" )\n\

--- a/calico-vpp-agent/Makefile
+++ b/calico-vpp-agent/Makefile
@@ -1,6 +1,7 @@
 .PHONY: all build gobgp image push
 
-TAG ?= latest
+TAG ?= latest # Tag images with :$(TAG)
+ALSO_LATEST ?= n # If 'y' also tag images with :latest
 GENERATE_LOG_FILE=../vpplink/binapi/vppapi/generate.log
 VERSION_FILE=version
 
@@ -22,9 +23,15 @@ image: build gobgp
 	@echo "VPP-dataplane version       : $(shell git log -1 --oneline)" >> $(VERSION_FILE)
 	@cat $(GENERATE_LOG_FILE)                                           >> $(VERSION_FILE)
 	docker build --pull -t calicovpp/node:$(TAG) .
+	@if [ "${ALSO_LATEST}" = "y" ]; then \
+		docker tag calicovpp/node:$(TAG) calicovpp/node:latest; \
+	fi
 
 push: image
 	docker push calicovpp/node:$(TAG)
+	@if [ "${ALSO_LATEST}" = "y" ]; then \
+		docker push calicovpp/node:latest; \
+	fi
 
 dev: build gobgp
 	docker build -t calicovpp/node:$(TAG) .

--- a/calico-vpp-agent/Makefile
+++ b/calico-vpp-agent/Makefile
@@ -1,6 +1,8 @@
 .PHONY: all build gobgp image push
 
 TAG ?= latest
+GENERATE_LOG_FILE=../vpplink/binapi/vppapi/generate.log
+VERSION_FILE=version
 
 all: build gobgp image
 
@@ -16,6 +18,9 @@ gobgp:
 	go build -o ./dep/gobgp $(GOBGP_DIR)/cmd/gobgp/
 
 image: build gobgp
+	@echo "Image tag                   : $(TAG)"                         > $(VERSION_FILE)
+	@echo "VPP-dataplane version       : $(shell git log -1 --oneline)" >> $(VERSION_FILE)
+	@cat $(GENERATE_LOG_FILE)                                           >> $(VERSION_FILE)
 	docker build --pull -t calicovpp/node:$(TAG) .
 
 push: image

--- a/vpp-manager/Makefile
+++ b/vpp-manager/Makefile
@@ -5,6 +5,8 @@ INIT_EKS_IMAGE_DIR=images/init-eks/
 DEV_IMAGE_DIR=images/dev/
 IMAGE_DIR=images/ubuntu
 VPPDEV_FILE=../test/scripts/vppdev.sh
+GENERATE_LOG_FILE=../vpplink/binapi/vppapi/generate.log
+VERSION_FILE=$(IMAGE_DIR)/version
 TAG ?= latest
 
 all: image
@@ -18,7 +20,10 @@ eksimage:
 		-t calicovpp/init-eks:$(TAG) $(INIT_EKS_IMAGE_DIR)
 
 image: build vpp
-	cp $(VPPDEV_FILE) $(IMAGE_DIR)
+	@cp $(VPPDEV_FILE) $(IMAGE_DIR)
+	@echo "Image tag                   : $(TAG)"                         > $(VERSION_FILE)
+	@echo "VPP-dataplane version       : $(shell git log -1 --oneline)" >> $(VERSION_FILE)
+	@cat $(GENERATE_LOG_FILE)                                           >> $(VERSION_FILE)
 	docker build --pull \
 		--build-arg http_proxy=${DOCKER_BUILD_PROXY} \
 		-t calicovpp/vpp:$(TAG) $(IMAGE_DIR)

--- a/vpp-manager/Makefile
+++ b/vpp-manager/Makefile
@@ -7,7 +7,8 @@ IMAGE_DIR=images/ubuntu
 VPPDEV_FILE=../test/scripts/vppdev.sh
 GENERATE_LOG_FILE=../vpplink/binapi/vppapi/generate.log
 VERSION_FILE=$(IMAGE_DIR)/version
-TAG ?= latest
+TAG ?= latest # Tag images with :$(TAG)
+ALSO_LATEST ?= n # If 'y' also tag images with :latest
 
 all: image
 
@@ -27,9 +28,15 @@ image: build vpp
 	docker build --pull \
 		--build-arg http_proxy=${DOCKER_BUILD_PROXY} \
 		-t calicovpp/vpp:$(TAG) $(IMAGE_DIR)
+	@if [ "${ALSO_LATEST}" = "y" ]; then \
+		docker tag calicovpp/vpp:$(TAG) calicovpp/vpp:latest; \
+	fi
 
 push: image
 	docker push calicovpp/vpp:$(TAG)
+	@if [ "${ALSO_LATEST}" = "y" ]; then \
+		docker push calicovpp/vpp:latest; \
+	fi
 
 imageonly: build
 	cp $(VPPDEV_FILE) $(IMAGE_DIR)

--- a/vpp-manager/images/ubuntu/Dockerfile
+++ b/vpp-manager/images/ubuntu/Dockerfile
@@ -26,5 +26,6 @@ RUN dpkg -i /tmp/vpp/libvppinfra_*.deb && \
 RUN rm -rf /tmp/vpp
 ADD vpp-manager /usr/bin/
 ADD vppdev.sh /usr/bin/calivppctl
+ADD version /etc/calicovppversion
 
 ENTRYPOINT ["/usr/bin/vpp-manager"]


### PR DESCRIPTION
* Add a `/etc/calicovppversion` digest in the image for easier debugging
* Add a `IS_LATEST` flag in make that will tag & push the image with `:latest` in addition to `:$(TAG)`
* Don't push the image when running `make release` in case you're building images on a different machine than your working repo  