### PR TITLE
Fix AVF uplink & broken pipe

### DIFF
--- a/vpp-manager/main.go
+++ b/vpp-manager/main.go
@@ -90,7 +90,7 @@ func handleSignals() {
 			} else {
 				log.Infof("ignoring sigchld")
 			}
-		} else {
+		} else if s != syscall.SIGPIPE {
 			/* special case
 			   for SIGTERM, which doesn't kill vpp quick enough */
 			if s == syscall.SIGTERM {

--- a/vpp-manager/pool_sync.go
+++ b/vpp-manager/pool_sync.go
@@ -71,14 +71,14 @@ func poolSyncError(err error) {
 
 func syncPools() {
 	pools := make(map[string]interface{})
-	client, err := calicocli.NewFromEnv()
-	if err != nil {
-		poolSyncError(errors.Wrap(err, "error creating calico client"))
-		return
-	}
-
 	log.Info("Starting pools watcher...")
 	for {
+		/* Need to recreate the client at each loop if pipe breaks */
+		client, err := calicocli.NewFromEnv()
+		if err != nil {
+			poolSyncError(errors.Wrap(err, "error creating calico client"))
+			return
+		}
 		poolsList, err := client.IPPools().List(context.Background(), options.ListOptions{})
 		if err != nil {
 			poolSyncError(errors.Wrap(err, "error listing pools"))


### PR DESCRIPTION
* When using avf uplink, vpp-manager will now :
  * if the interface is a PF without a VF, create a VF + generate a mac for it. Addresses will be taken on the PF in linux
  * if the interface is a PF with an existing VF, it will use the first vf and its mac. ip addresses & routes taken on the linux PF
  * if the interface is a VF, it will use it as is
* This also fixes the broken pipe signal being mishandled & forwarded to VPP