### PR TITLE
vpp-manager: Fix ip6 flow hash

### DIFF
--- a/vpplink/routes.go
+++ b/vpplink/routes.go
@@ -176,20 +176,20 @@ func (v *VppLink) addDelIPRoute(route *types.Route, isAdd bool) error {
 	return nil
 }
 
-func (v *VppLink) SetIPFlowHash(vrfID uint32, isIPv6 bool, src bool, dst bool, sport bool, dport bool, proto bool, reverse bool, symmetric bool) error {
+func (v *VppLink) SetIPFlowHash(ipFlowHash *types.IPFlowHash, vrfID uint32, isIPv6 bool) error {
 	v.lock.Lock()
 	defer v.lock.Unlock()
 
 	request := &vppip.SetIPFlowHash{
 		VrfID:     vrfID,
 		IsIPv6:    isIPv6,
-		Src:       src,
-		Dst:       dst,
-		Sport:     sport,
-		Dport:     dport,
-		Proto:     proto,
-		Reverse:   reverse,
-		Symmetric: symmetric,
+		Src:       ipFlowHash.Src,
+		Dst:       ipFlowHash.Dst,
+		Sport:     ipFlowHash.SrcPort,
+		Dport:     ipFlowHash.DstPort,
+		Proto:     ipFlowHash.Proto,
+		Reverse:   ipFlowHash.Reverse,
+		Symmetric: ipFlowHash.Symmetric,
 	}
 
 	response := &vppip.SetIPFlowHashReply{}

--- a/vpplink/types/route.go
+++ b/vpplink/types/route.go
@@ -109,3 +109,13 @@ func (r *Route) IsLinkLocal() bool {
 	}
 	return r.Dst.IP.IsLinkLocalUnicast()
 }
+
+type IPFlowHash struct {
+	Src       bool
+	Dst       bool
+	SrcPort   bool
+	DstPort   bool
+	Proto     bool
+	Reverse   bool
+	Symmetric bool
+}


### PR DESCRIPTION
Set ip4 flow hash only if specifying multiple addresses
Don't use ip6 flow hash as it isn't used & breaks in current vpp

Signed-off-by: Nathan Skrzypczak <nathan.skrzypczak@gmail.com>