### PR TITLE
Usability fixes [dpdk, af-packet]

### DIFF
--- a/vpp-manager/utils/utils.go
+++ b/vpp-manager/utils/utils.go
@@ -273,6 +273,20 @@ func BindVFtoDriver(pciId string, driver string) error {
 	return nil
 }
 
+func GetInterfaceNameFromPci(pciId string) (string, error) {
+	// Grab Driver id for the pci device
+	driverLinkPath := fmt.Sprintf("/sys/bus/pci/devices/%s/net", pciId)
+    netDevs, err := ioutil.ReadDir(driverLinkPath)
+    if err != nil {
+		return "", errors.Wrapf(err, "cannot list /net for %s", pciId)
+    }
+    if len(netDevs) != 1 {
+		return "", errors.Wrapf(err, "Found %d devices in /net for %s", len(netDevs), pciId)
+    }
+    return netDevs[0].Name(), nil
+}
+
+
 func GetDriverNameFromPci(pciId string) (string, error) {
 	// Grab Driver id for the pci device
 	driverLinkPath := fmt.Sprintf("/sys/bus/pci/devices/%s/driver", pciId)

--- a/vpplink/binapi/vpp_clone_current.sh
+++ b/vpplink/binapi/vpp_clone_current.sh
@@ -45,3 +45,4 @@ git fetch "https://gerrit.fd.io/r/vpp" refs/changes/13/28513/16 && git cherry-pi
 
 git fetch "https://gerrit.fd.io/r/vpp" refs/changes/95/30695/2 && git cherry-pick FETCH_HEAD # 30695: wireguard: testing alternative timer dispatch | https://gerrit.fd.io/r/c/vpp/+/30695
 git fetch "https://gerrit.fd.io/r/vpp" refs/changes/51/30951/1 && git cherry-pick FETCH_HEAD # 30951: tap: fix the interrupt handling | https://gerrit.fd.io/r/c/vpp/+/30951
+git fetch "https://gerrit.fd.io/r/vpp" refs/changes/17/31017/1 && git cherry-pick FETCH_HEAD # 31017: interface: automask interrupts to polling rxqs | https://gerrit.fd.io/r/c/vpp/+/31017

--- a/vpplink/ipip.go
+++ b/vpplink/ipip.go
@@ -43,7 +43,7 @@ func (v *VppLink) ListIPIPTunnels() ([]*types.IPIPTunnel, error) {
 			break
 		}
 		tunnels = append(tunnels, &types.IPIPTunnel{
-			Src:       types.FromVppAddress(response.Tunnel.Dst),
+			Src:       types.FromVppAddress(response.Tunnel.Src),
 			Dst:       types.FromVppAddress(response.Tunnel.Dst),
 			TableID:   response.Tunnel.TableID,
 			SwIfIndex: uint32(response.Tunnel.SwIfIndex),

--- a/yaml/overlays/dev/kustomize.sh
+++ b/yaml/overlays/dev/kustomize.sh
@@ -244,8 +244,8 @@ calico_create_template ()
   export CALICOVPP_TAP_RING_SIZE=${CALICOVPP_TAP_RING_SIZE}
   export USERHOME=${HOME}
   export FELIX_XDPENABLED=${FELIX_XDPENABLED:=false}
-  export IP_AUTODETECTION_METHOD=${IP_AUTODETECTION_METHOD:=interface=$vpp_dataplane_interface}
-  export IP6_AUTODETECTION_METHOD=${IP6_AUTODETECTION_METHOD:=interface=$vpp_dataplane_interface}
+  export IP_AUTODETECTION_METHOD=${IP_AUTODETECTION_METHOD:=interface=vpptap0}
+  export IP6_AUTODETECTION_METHOD=${IP6_AUTODETECTION_METHOD:=interface=vpptap0}
   cd $SCRIPTDIR
   kubectl kustomize . | envsubst | sudo tee /tmp/calico-vpp.yaml > /dev/null
 }


### PR DESCRIPTION
* in dpdk, check if interface was renamed in the process
* add af-packet interrupt patch
* autodetect = vpptap0 in dev