### PR TITLE
yaml: Fix EKS default yaml

### DIFF
--- a/vpp-manager/config/config.go
+++ b/vpp-manager/config/config.go
@@ -38,6 +38,7 @@ const (
 	HostIfName             = "vpptap0"
 	HostIfTag              = "hosttap"
 	VppSigKillTimeout      = 2
+	DefaultEncapSize       = 60 // Used to lower the MTU of the routes to the cluster
 )
 
 const (
@@ -65,7 +66,7 @@ type VppManagerParams struct {
 	TapTxQueueSize           int
 	RxQueueSize              int
 	TxQueueSize              int
-	TapMtu                   int
+	UserSpecifiedMtu         int
 	NumRxQueues              int
 	NewDriverName            string
 	DefaultGWs               []net.IP
@@ -102,6 +103,18 @@ type KernelVersion struct {
 	Major  int
 	Minor  int
 	Patch  int
+}
+
+func GetUplinkMtu(params *VppManagerParams, conf *InterfaceConfig, includeEncap bool) int {
+	encapSize := 0
+	if includeEncap {
+		encapSize = DefaultEncapSize
+	}
+	// Use the linux interface MTU as default value if nothing is configured from env
+	if params.UserSpecifiedMtu == 0 {
+		return conf.Mtu - encapSize
+	}
+	return params.UserSpecifiedMtu - encapSize
 }
 
 func (ver *KernelVersion) String() string {

--- a/vpp-manager/images/init-eks/init_eks.sh
+++ b/vpp-manager/images/init-eks/init_eks.sh
@@ -82,6 +82,7 @@ EOF
 
 configure_machine ()
 {
+	sudo rm -f /etc/cni/net.d/10-aws.conflist
 	sudo modprobe uio
 	if [ x$(lsmod | awk '{ print $1 }' | grep igb_uio) == x ]; then
 		build_and_install_igb_uio

--- a/vpp-manager/pool_sync.go
+++ b/vpp-manager/pool_sync.go
@@ -27,7 +27,6 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/options"
 	"github.com/projectcalico/libcalico-go/lib/watch"
 	"github.com/projectcalico/vpp-dataplane/vpp-manager/config"
-	"github.com/projectcalico/vpp-dataplane/vpp-manager/startup"
 	log "github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 )
@@ -35,7 +34,8 @@ import (
 type PoolWatcher struct {
 	stop         chan struct{}
 	RouteWatcher *RouteWatcher
-	Params       *config.VppManagerParams
+	params       *config.VppManagerParams
+	conf         *config.InterfaceConfig
 }
 
 func (p *PoolWatcher) Stop() {
@@ -59,7 +59,7 @@ func (p *PoolWatcher) getNetworkRoute(network string) (route *netlink.Route, err
 		Dst:      cidr,
 		Gw:       gw,
 		Protocol: syscall.RTPROT_STATIC,
-		MTU:      p.Params.TapMtu - startup.DefaultEncapSize,
+		MTU:      config.GetUplinkMtu(p.params, p.conf, true /* includeEncap */),
 	}, nil
 }
 

--- a/vpp-manager/uplink/af_xdp.go
+++ b/vpp-manager/uplink/af_xdp.go
@@ -83,10 +83,11 @@ func (d *AFXDPDriver) PreconfigureLinux() error {
 		if err != nil {
 			return errors.Wrapf(err, "Error reducing MTU to %d", maxAfXDPMTU)
 		}
-		if d.params.TapMtu > maxAfXDPMTU {
-			log.Infof("Reducing tap MTU to %d", maxAfXDPMTU)
-			d.params.TapMtu = maxAfXDPMTU
-		}
+		d.conf.Mtu = maxAfXDPMTU
+	}
+	if d.params.UserSpecifiedMtu > maxAfXDPMTU {
+		log.Infof("Reducing user specified MTU to %d", maxAfXDPMTU)
+		d.params.UserSpecifiedMtu = maxAfXDPMTU
 	}
 	return nil
 }

--- a/vpp-manager/vpp_runner.go
+++ b/vpp-manager/vpp_runner.go
@@ -396,13 +396,21 @@ func (v *VppRunner) configureVpp() (err error) {
 		HostMacAddress: v.conf.HardwareAddr,
 		MacAddress:     vppSideMac,
 	})
-
-	// Always set this tap on worker 0
-	err = v.vpp.SetInterfaceRxPlacement(uint32(tapSwIfIndex), uint32(0), uint32(0), false)
-
 	if err != nil {
 		return errors.Wrap(err, "Error creating tap")
 	}
+
+	// Always set this tap on worker 0
+	err = v.vpp.SetInterfaceRxPlacement(uint32(tapSwIfIndex), uint32(0), uint32(0), false)
+	if err != nil {
+		return errors.Wrap(err, "Error setting tap rx placement")
+	}
+
+	err = v.vpp.SetInterfaceMtu(uint32(tapSwIfIndex), uplinkMtu)
+	if err != nil {
+		return errors.Wrapf(err, "Error setting %d MTU on tap interface", uplinkMtu)
+	}
+
 	err = utils.WriteFile(strconv.FormatInt(int64(tapSwIfIndex), 10), config.VppManagerTapIdxFile)
 	if err != nil {
 		return errors.Wrap(err, "Error writing linux mtu")

--- a/yaml/base/calico-patch.yaml
+++ b/yaml/base/calico-patch.yaml
@@ -38,7 +38,7 @@ data:
         }
       ]
     }
-    
+
   # K8s service prefix. We currently cannot retrieve this from the API,
   # so it must be manually configured
   service_prefix: 10.96.0.0/12

--- a/yaml/overlays/eks-dpdk/eks-config.yaml
+++ b/yaml/overlays/eks-dpdk/eks-config.yaml
@@ -52,6 +52,12 @@ spec:
               cpu: 1
             limits:
               hugepages-2Mi: 512Mi
+        - name: calico-node
+          env:
+            - name: CALICO_IPV4POOL_IPIP
+              value: "Always"
+            - name: FELIX_AWSSRCDSTCHECK
+              value: Disable
       volumes:
         - name: hugepage
           emptyDir:

--- a/yaml/overlays/eks-dpdk/eks-config.yaml
+++ b/yaml/overlays/eks-dpdk/eks-config.yaml
@@ -7,7 +7,7 @@ data:  # Configuration template for VPP in EKS
   service_prefix: 10.100.0.0/16
   vpp_dataplane_interface: eth0
   veth_mtu: "1410"
-  default_ipv4_pool_cidr: 192.168.0.0/16
+  default_ipv4_pool_cidr: 10.10.0.0/16
   vpp_uplink_driver: "none"
   vpp_config_template: |-
     unix {

--- a/yaml/overlays/eks-dpdk/eks-init.yaml
+++ b/yaml/overlays/eks-dpdk/eks-init.yaml
@@ -33,3 +33,12 @@ spec:
       - hostPath:
           path: /
         name: host-root
+      tolerations:
+        # Make sure calico-node gets scheduled on all nodes.
+        - effect: NoSchedule
+          operator: Exists
+        # Mark the pod as a critical add-on for rescheduling.
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - effect: NoExecute
+          operator: Exists

--- a/yaml/overlays/eks/eks-config.yaml
+++ b/yaml/overlays/eks/eks-config.yaml
@@ -20,8 +20,6 @@ spec:
       containers:
         - name: calico-node
           env:
-          - name: CALICO_IPV4POOL_IPIP
-            value: "Always"
           - name: FELIX_AWSSRCDSTCHECK
             value: Disable
 

--- a/yaml/overlays/eks/eks-config.yaml
+++ b/yaml/overlays/eks/eks-config.yaml
@@ -7,7 +7,7 @@ data:  # Configuration template for VPP in EKS
   service_prefix: 10.100.0.0/16
   vpp_dataplane_interface: eth0
   veth_mtu: "1410"
-  default_ipv4_pool_cidr: 192.168.0.0/16
+  default_ipv4_pool_cidr: 10.10.0.0/16
   vpp_uplink_driver: af_packet
 ---
 kind: DaemonSet

--- a/yaml/overlays/eks/eks-config.yaml
+++ b/yaml/overlays/eks/eks-config.yaml
@@ -9,4 +9,34 @@ data:  # Configuration template for VPP in EKS
   veth_mtu: "1410"
   default_ipv4_pool_cidr: 192.168.0.0/16
   vpp_uplink_driver: af_packet
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: calico-vpp-node
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      containers:
+        - name: vpp
+          resources:
+            limits:
+              hugepages-2Mi: 0
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: calico-node
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      containers:
+        - name: calico-node
+          env:
+          - name: CALICO_IPV4POOL_IPIP
+            value: "Always"
+          - name: FELIX_AWSSRCDSTCHECK
+            value: Disable
 

--- a/yaml/overlays/eks/eks-config.yaml
+++ b/yaml/overlays/eks/eks-config.yaml
@@ -6,23 +6,8 @@ metadata:
 data:  # Configuration template for VPP in EKS
   service_prefix: 10.100.0.0/16
   vpp_dataplane_interface: eth0
-  veth_mtu: "1410"
   default_ipv4_pool_cidr: 10.10.0.0/16
   vpp_uplink_driver: af_packet
----
-kind: DaemonSet
-apiVersion: apps/v1
-metadata:
-  name: calico-vpp-node
-  namespace: kube-system
-spec:
-  template:
-    spec:
-      containers:
-        - name: vpp
-          resources:
-            limits:
-              hugepages-2Mi: 0
 ---
 kind: DaemonSet
 apiVersion: apps/v1

--- a/yaml/overlays/eks/eks-config.yaml
+++ b/yaml/overlays/eks/eks-config.yaml
@@ -22,4 +22,5 @@ spec:
           env:
           - name: FELIX_AWSSRCDSTCHECK
             value: Disable
-
+          - name: IP_AUTODETECTION_METHOD
+            value: interface=eth0


### PR DESCRIPTION
## Currently tested
### EKS + dpdk
````bash
export CLUSTER_NAME=test-dpdk
eksctl create cluster --name=$CLUSTER_NAME --version=1.17 --without-nodegroup --auto-kubeconfig
kubectl --kubeconfig delete daemonset -n kube-system aws-node
kubectl kustomize ./yaml/overlays/eks-dpdk | kubectl --kubeconfig apply -f -
eksctl create nodegroup --cluster $CLUSTER_NAME --nodes 2 --ssh-access --ssh-public-key=<MYKEY>
````
 ✅ kube-system pods
 ✅ user pods
 ✅ iperf node-node
 ✅ nslookup
 ✅ curl http://
❓ remove / reinstall

### EKS + AF_PACKET
````bash
export CLUSTER_NAME=test-dpdk
eksctl create cluster --name=$CLUSTER_NAME --version=1.17 --without-nodegroup --auto-kubeconfig
kubectl --kubeconfig delete daemonset -n kube-system aws-node
kubectl kustomize ./yaml/overlays/eks | kubectl --kubeconfig apply -f -
eksctl create nodegroup --cluster $CLUSTER_NAME --nodes 2 --ssh-access --ssh-public-key=<MYKEY>
````
 ✅ kube-system pods
 ✅ user pods
 ✅ iperf node-node
 ✅ nslookup
 ✅ curl http://
❓ remove / reinstall

### GCP + kubeadm
````bash
export CLUSTER_NAME=test-dpdk
# TODO
````
❓ kube-system pods
❓ user pods
❓ iperf node-node
❓ nslookup
❓ curl http://
❓ remove / reinstall