### PR TITLE
vpp-manager: Set uplink MTU to host val

### DIFF
--- a/vpp-manager/config/config.go
+++ b/vpp-manager/config/config.go
@@ -38,6 +38,7 @@ const (
 	HostIfName             = "vpptap0"
 	HostIfTag              = "hosttap"
 	VppSigKillTimeout      = 2
+	DefaultEncapSize       = 60 // Used to lower the MTU of the routes to the cluster
 )
 
 const (
@@ -65,7 +66,7 @@ type VppManagerParams struct {
 	TapTxQueueSize           int
 	RxQueueSize              int
 	TxQueueSize              int
-	TapMtu                   int
+	UserSpecifiedMtu         int
 	NumRxQueues              int
 	NewDriverName            string
 	DefaultGWs               []net.IP
@@ -102,6 +103,18 @@ type KernelVersion struct {
 	Major  int
 	Minor  int
 	Patch  int
+}
+
+func GetUplinkMtu(params *VppManagerParams, conf *InterfaceConfig, includeEncap bool) int {
+	encapSize := 0
+	if includeEncap {
+		encapSize = DefaultEncapSize
+	}
+	// Use the linux interface MTU as default value if nothing is configured from env
+	if params.UserSpecifiedMtu == 0 {
+		return conf.Mtu - encapSize
+	}
+	return params.UserSpecifiedMtu - encapSize
 }
 
 func (ver *KernelVersion) String() string {

--- a/vpp-manager/pool_sync.go
+++ b/vpp-manager/pool_sync.go
@@ -27,7 +27,6 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/options"
 	"github.com/projectcalico/libcalico-go/lib/watch"
 	"github.com/projectcalico/vpp-dataplane/vpp-manager/config"
-	"github.com/projectcalico/vpp-dataplane/vpp-manager/startup"
 	log "github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 )
@@ -35,7 +34,8 @@ import (
 type PoolWatcher struct {
 	stop         chan struct{}
 	RouteWatcher *RouteWatcher
-	Params       *config.VppManagerParams
+	params       *config.VppManagerParams
+	conf         *config.InterfaceConfig
 }
 
 func (p *PoolWatcher) Stop() {
@@ -59,7 +59,7 @@ func (p *PoolWatcher) getNetworkRoute(network string) (route *netlink.Route, err
 		Dst:      cidr,
 		Gw:       gw,
 		Protocol: syscall.RTPROT_STATIC,
-		MTU:      p.Params.TapMtu - startup.DefaultEncapSize,
+		MTU:      config.GetUplinkMtu(p.params, p.conf, true /* includeEncap */),
 	}, nil
 }
 

--- a/vpp-manager/uplink/af_xdp.go
+++ b/vpp-manager/uplink/af_xdp.go
@@ -83,10 +83,11 @@ func (d *AFXDPDriver) PreconfigureLinux() error {
 		if err != nil {
 			return errors.Wrapf(err, "Error reducing MTU to %d", maxAfXDPMTU)
 		}
-		if d.params.TapMtu > maxAfXDPMTU {
-			log.Infof("Reducing tap MTU to %d", maxAfXDPMTU)
-			d.params.TapMtu = maxAfXDPMTU
-		}
+		d.conf.Mtu = maxAfXDPMTU
+	}
+	if d.params.UserSpecifiedMtu > maxAfXDPMTU {
+		log.Infof("Reducing user specified MTU to %d", maxAfXDPMTU)
+		d.params.UserSpecifiedMtu = maxAfXDPMTU
 	}
 	return nil
 }

--- a/vpp-manager/vpp_runner.go
+++ b/vpp-manager/vpp_runner.go
@@ -396,13 +396,21 @@ func (v *VppRunner) configureVpp() (err error) {
 		HostMacAddress: v.conf.HardwareAddr,
 		MacAddress:     vppSideMac,
 	})
-
-	// Always set this tap on worker 0
-	err = v.vpp.SetInterfaceRxPlacement(uint32(tapSwIfIndex), uint32(0), uint32(0), false)
-
 	if err != nil {
 		return errors.Wrap(err, "Error creating tap")
 	}
+
+	// Always set this tap on worker 0
+	err = v.vpp.SetInterfaceRxPlacement(uint32(tapSwIfIndex), uint32(0), uint32(0), false)
+	if err != nil {
+		return errors.Wrap(err, "Error setting tap rx placement")
+	}
+
+	err = v.vpp.SetInterfaceMtu(uint32(tapSwIfIndex), uplinkMtu)
+	if err != nil {
+		return errors.Wrapf(err, "Error setting %d MTU on tap interface", uplinkMtu)
+	}
+
 	err = utils.WriteFile(strconv.FormatInt(int64(tapSwIfIndex), 10), config.VppManagerTapIdxFile)
 	if err != nil {
 		return errors.Wrap(err, "Error writing linux mtu")


### PR DESCRIPTION
Signed-off-by: Nathan Skrzypczak <nathan.skrzypczak@gmail.com>

This also renames `TapMtu` to `UserspecifiedMtu` for clarity
and adds a dedicated function for getting the Mtu 