### PR TITLE
routing: send pod->node traffic into tunnels

### DIFF
--- a/calico-vpp-agent/cmd/calico_vpp_dataplane.go
+++ b/calico-vpp-agent/cmd/calico_vpp_dataplane.go
@@ -71,6 +71,13 @@ func main() {
 		return
 	}
 
+	// This needs to be the first thing created in VPP as multiple servers depend on that
+	err = common.SetupPodVRF(vpp)
+	if err != nil {
+		log.Errorf("Failed to create pod vrf")
+		log.Fatal(err)
+	}
+
 	serviceServer, err := services.NewServer(vpp, log.WithFields(logrus.Fields{"component": "services"}))
 	if err != nil {
 		log.Errorf("Failed to create services server")

--- a/calico-vpp-agent/cni/network_vpp.go
+++ b/calico-vpp-agent/cni/network_vpp.go
@@ -25,6 +25,7 @@ import (
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/pkg/errors"
 	"github.com/projectcalico/vpp-dataplane/calico-vpp-agent/cni/storage"
+	"github.com/projectcalico/vpp-dataplane/calico-vpp-agent/common"
 	"github.com/projectcalico/vpp-dataplane/calico-vpp-agent/config"
 	"github.com/projectcalico/vpp-dataplane/calico-vpp-agent/policy"
 	"github.com/projectcalico/vpp-dataplane/vpplink"
@@ -260,6 +261,11 @@ func (s *Server) AddVppInterface(podSpec *storage.LocalPodSpec, doHostSideConf b
 	}
 
 	// configure vpp side tun
+	err = s.vpp.SetInterfaceVRF(swIfIndex, common.PodVRFIndex)
+	if err != nil {
+		return 0, s.tunErrorCleanup(podSpec, err, "error setting vpp tun %d in pod vrf", swIfIndex)
+	}
+
 	err = s.vpp.InterfaceSetUnnumbered(swIfIndex, config.DataInterfaceSwIfIndex)
 	if err != nil {
 		return 0, s.tunErrorCleanup(podSpec, err, "error setting vpp tun %d unnumbered", swIfIndex)

--- a/calico-vpp-agent/common/common.go
+++ b/calico-vpp-agent/common/common.go
@@ -123,6 +123,11 @@ func HandleVppManagerRestart(log *logrus.Logger, vpp *vpplink.VppLink, servers .
 			log.Fatalf("Timed out waiting for vpp-manager: %v", err)
 			os.Exit(1)
 		}
+		err = SetupPodVRF(vpp)
+		if err != nil {
+			log.Fatalf("Error reconfiguring pod vrf in VPP: %v", err)
+			os.Exit(1)
+		}
 		for i, srv := range servers {
 			srv.OnVppRestart()
 			log.Infof("SR:server %d restarted", i)

--- a/calico-vpp-agent/routing/routing_server.go
+++ b/calico-vpp-agent/routing/routing_server.go
@@ -211,7 +211,7 @@ func (s *Server) fetchNodeIPs() (node *calicov3.Node, err error) {
 func (s *Server) createAndStartBGP() error {
 	globalConfig, err := s.getGlobalConfig()
 	if err != nil {
-		return fmt.Errorf("cannot get global configuration: ", err)
+		return fmt.Errorf("cannot get global configuration: %v", err)
 	}
 	maxSize := 256 << 20
 	grpcOpts := []grpc.ServerOption{

--- a/vpplink/binapi/vpp_clone_current.sh
+++ b/vpplink/binapi/vpp_clone_current.sh
@@ -32,7 +32,7 @@ git fetch "https://gerrit.fd.io/r/vpp" refs/changes/49/31449/4 && git cherry-pic
 
 # ------------- Policies patches -------------
 git fetch "https://gerrit.fd.io/r/vpp" refs/changes/83/28083/16 && git cherry-pick FETCH_HEAD # 28083: acl: acl-plugin custom policies |  https://gerrit.fd.io/r/c/vpp/+/28083
-git fetch "https://gerrit.fd.io/r/vpp" refs/changes/13/28513/19 && git cherry-pick FETCH_HEAD # 25813: capo: Calico Policies plugin | https://gerrit.fd.io/r/c/vpp/+/28513
+git fetch "https://gerrit.fd.io/r/vpp" refs/changes/13/28513/20 && git cherry-pick FETCH_HEAD # 25813: capo: Calico Policies plugin | https://gerrit.fd.io/r/c/vpp/+/28513
 # ------------- Policies patches -------------
 
 

--- a/vpplink/binapi/vpp_clone_current.sh
+++ b/vpplink/binapi/vpp_clone_current.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-VPP_COMMIT=9cc765559c39a299bdb55f3f7279abbcbe00a556
+VPP_COMMIT=cf0e257dcf3d23a3b38129e1a3375f1c38c10973
 
 if [ ! -d $1/.git ]; then
 	rm -rf $1
@@ -13,19 +13,17 @@ else
 	git fetch "https://gerrit.fd.io/r/vpp" && git reset --hard ${VPP_COMMIT}
 fi
 
-git fetch "https://gerrit.fd.io/r/vpp" refs/changes/18/31818/1 && git cherry-pick FETCH_HEAD # 31818: af_packet: use netlink to get/set mtu | https://gerrit.fd.io/r/c/vpp/+/31818
+git fetch "https://gerrit.fd.io/r/vpp" refs/changes/02/32002/1 && git cherry-pick FETCH_HEAD # 32002: ip: fix offload flags handling | https://gerrit.fd.io/r/c/vpp/+/32002
 git fetch "https://gerrit.fd.io/r/vpp" refs/changes/86/29386/9 && git cherry-pick FETCH_HEAD # 29386: virtio: DRAFT: multi tx support | https://gerrit.fd.io/r/c/vpp/+/29386
 git fetch "https://gerrit.fd.io/r/vpp" refs/changes/21/31321/7 && git cherry-pick FETCH_HEAD # 31321: devices: add support for pseudo header checksum | https://gerrit.fd.io/r/c/vpp/+/31321
-git fetch "https://gerrit.fd.io/r/vpp" refs/changes/49/31249/4 && git cherry-pick FETCH_HEAD # 31249: dpdk: implement interrupt mode | https://gerrit.fd.io/r/c/vpp/+/31249
-git fetch "https://gerrit.fd.io/r/vpp" refs/changes/69/31869/7 && git cherry-pick FETCH_HEAD # 31869: gso: fix packet length when padding is present | https://gerrit.fd.io/r/c/vpp/+/31869
+git fetch "https://gerrit.fd.io/r/vpp" refs/changes/69/31869/8 && git cherry-pick FETCH_HEAD # 31869: gso: do not try gro on small packets | https://gerrit.fd.io/r/c/vpp/+/31869
 git fetch "https://gerrit.fd.io/r/vpp" refs/changes/05/31905/1 && git cherry-pick FETCH_HEAD # 31905: vpp: Fix session flag initialization | https://gerrit.fd.io/r/c/vpp/+/31905
-git fetch "https://gerrit.fd.io/r/vpp" refs/changes/69/31969/3 && git cherry-pick FETCH_HEAD # 31969: punt: ensure ttl doesn't decrease to 0 when punting | https://gerrit.fd.io/r/c/vpp/+/31969
+git fetch "https://gerrit.fd.io/r/vpp" refs/changes/69/31969/4 && git cherry-pick FETCH_HEAD # 31969: punt: ensure ttl doesn't decrease to 0 when punting | https://gerrit.fd.io/r/c/vpp/+/31969
 
 # IPv6 ND patch (temporary)
 git fetch "https://gerrit.fd.io/r/vpp" refs/changes/68/31868/1 && git cherry-pick FETCH_HEAD # 31868: ip6-nd: silent the source and target checks on given interface | https://gerrit.fd.io/r/c/vpp/+/31868
 
 # --------------- Cnat patches ---------------
-git fetch "https://gerrit.fd.io/r/vpp" refs/changes/51/31551/1 && git cherry-pick FETCH_HEAD # 31551: cnat: maglev fixes | https://gerrit.fd.io/r/c/vpp/+/31551
 git fetch "https://gerrit.fd.io/r/vpp" refs/changes/88/31588/1 && git cherry-pick FETCH_HEAD # 31588: cnat: [WIP] no k8s maglev from pods | https://gerrit.fd.io/r/c/vpp/+/31588
 git fetch "https://gerrit.fd.io/r/vpp" refs/changes/49/31449/4 && git cherry-pick FETCH_HEAD # 31449: cnat: fix cnat feature partial cksum | https://gerrit.fd.io/r/c/vpp/+/31449
 # --------------- Cnat patches ---------------
@@ -34,5 +32,3 @@ git fetch "https://gerrit.fd.io/r/vpp" refs/changes/49/31449/4 && git cherry-pic
 git fetch "https://gerrit.fd.io/r/vpp" refs/changes/83/28083/16 && git cherry-pick FETCH_HEAD # 28083: acl: acl-plugin custom policies |  https://gerrit.fd.io/r/c/vpp/+/28083
 git fetch "https://gerrit.fd.io/r/vpp" refs/changes/13/28513/20 && git cherry-pick FETCH_HEAD # 25813: capo: Calico Policies plugin | https://gerrit.fd.io/r/c/vpp/+/28513
 # ------------- Policies patches -------------
-
-

--- a/vpplink/ip.go
+++ b/vpplink/ip.go
@@ -1,0 +1,44 @@
+// Copyright (C) 2019 Cisco Systems Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vpplink
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/projectcalico/vpp-dataplane/vpplink/binapi/vppapi/ip"
+)
+
+func (v *VppLink) AddVRF(index uint32, isIP6 bool, name string) error {
+	v.lock.Lock()
+	defer v.lock.Unlock()
+	response := &ip.IPTableAddDelReply{}
+	request := &ip.IPTableAddDel{
+		IsAdd: true,
+		Table: ip.IPTable{
+			TableID: index,
+			IsIP6:   isIP6,
+			Name:    name,
+		},
+	}
+	err := v.ch.SendRequest(request).ReceiveReply(response)
+	if err != nil {
+		return errors.Wrapf(err, "IPTableAddDel failed: req %+v reply %+v", request, response)
+	} else if response.Retval != 0 {
+		return fmt.Errorf("IPTableAddDel failed (retval %d). Request: %+v", response.Retval, request)
+	}
+	return nil
+}


### PR DESCRIPTION
This also includes a couple fixes in VPP:
- One for a crash in the checksum computation
- One that clears all established sessions when reconfiguring policies on an interface