### PR TITLE
Fix eks instability

### DIFF
--- a/vpp-manager/config/config.go
+++ b/vpp-manager/config/config.go
@@ -53,9 +53,6 @@ type VppManagerParams struct {
 	MainInterface            string
 	ConfigExecTemplate       string
 	ConfigTemplate           string
-	InitScriptTemplate       string
-	InitPostIfScriptTemplate string
-	FinalizeScriptTemplate   string
 	NodeName                 string
 	CorePattern              string
 	RxMode                   types.RxMode
@@ -187,4 +184,14 @@ func (c *InterfaceConfig) SortRoutes() {
 		j_len, _ := c.Routes[j].Dst.Mask.Size()
 		return i_len > j_len
 	})
+}
+
+func TemplateScriptReplace(input string, params *VppManagerParams, conf *InterfaceConfig) (template string) {
+	template = input
+	if conf != nil {
+		/* We might template scripts before reading interface conf */
+		template = strings.ReplaceAll(template, "__PCI_DEVICE_ID__", conf.PciId)
+	}
+	template = strings.ReplaceAll(template, "__VPP_DATAPLANE_IF__", params.MainInterface)
+	return template
 }

--- a/vpp-manager/config/config.go
+++ b/vpp-manager/config/config.go
@@ -54,6 +54,7 @@ type VppManagerParams struct {
 	ConfigExecTemplate       string
 	ConfigTemplate           string
 	InitScriptTemplate       string
+	FinalizeScriptTemplate   string
 	NodeName                 string
 	CorePattern              string
 	RxMode                   types.RxMode

--- a/vpp-manager/config/config.go
+++ b/vpp-manager/config/config.go
@@ -54,6 +54,7 @@ type VppManagerParams struct {
 	ConfigExecTemplate       string
 	ConfigTemplate           string
 	InitScriptTemplate       string
+	InitPostIfScriptTemplate string
 	FinalizeScriptTemplate   string
 	NodeName                 string
 	CorePattern              string

--- a/vpp-manager/hooks/hooks.go
+++ b/vpp-manager/hooks/hooks.go
@@ -1,0 +1,64 @@
+// Copyright (C) 2021 Cisco Systems Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hooks
+
+import (
+	"github.com/projectcalico/vpp-dataplane/vpp-manager/config"
+	"github.com/projectcalico/vpp-dataplane/vpp-manager/utils"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	/* Run this before getLinuxConfig() in case this is a script
+	 * that's responsible for creating the interface */
+	BEFORE_IF_READ = "BEFORE_IF_READ" // InitScriptTemplate
+	/* Bash script template run just after getting config
+	   from $CALICOVPP_INTERFACE & before starting VPP */
+	BEFORE_VPP_RUN = "BEFORE_VPP_RUN" // InitPostIfScriptTemplate
+	/* Bash script template run after VPP has started */
+	VPP_RUNNING = "VPP_RUNNING" // FinalizeScriptTemplate
+	/* Bash script template run when VPP stops gracefully */
+	VPP_DONE_OK = "VPP_DONE_OK"
+	/* Bash script template run when VPP stops with an error */
+	VPP_ERRORED = "VPP_ERRORED"
+)
+
+var (
+	AllHooks        = []string{BEFORE_IF_READ, BEFORE_VPP_RUN, VPP_RUNNING, VPP_DONE_OK, VPP_ERRORED}
+	vppManagerHooks = make(map[string][]func(params *config.VppManagerParams, conf *config.InterfaceConfig) error)
+)
+
+func RegisterBashHook(name string, bashTemplate string) {
+	RegisterHook(name, func(params *config.VppManagerParams, conf *config.InterfaceConfig) error {
+		return utils.RunBashScript(config.TemplateScriptReplace(bashTemplate, params, nil))
+	})
+}
+
+func RegisterHook(name string, hook func(params *config.VppManagerParams, conf *config.InterfaceConfig) error) {
+	vppManagerHooks[name] = append(vppManagerHooks[name], hook)
+}
+
+func RunHook(name string, params *config.VppManagerParams, conf *config.InterfaceConfig) {
+	if _, ok := vppManagerHooks[name]; !ok {
+		return
+	}
+	for i, hook := range vppManagerHooks[name] {
+		err := hook(params, conf)
+		if err != nil {
+			log.Warnf("Running hook %s [%d] errored with %s", name, i, err)
+		}
+	}
+}

--- a/vpp-manager/startup/startup.go
+++ b/vpp-manager/startup/startup.go
@@ -51,6 +51,10 @@ const (
 	   It contains the VPP startup configuration */
 	ConfigTemplateEnvVar = "CALICOVPP_CONFIG_TEMPLATE"
 
+	/* Bash script template run just after getting config
+	   from $CALICOVPP_INTERFACE */
+	InitPostIfScriptTemplateEnvVar = "CALICOVPP_POST_INIT_SCRIPT_TEMPLATE"
+
 	/* Template for VppConfigExecFile (/etc/vpp/startup.exec)
 	   It contains the CLI to be executed in vppctl after startup */
 	ConfigExecTemplateEnvVar = "CALICOVPP_CONFIG_EXEC_TEMPLATE"
@@ -174,6 +178,7 @@ func parseEnvVariables(params *config.VppManagerParams) (err error) {
 
 	params.ConfigExecTemplate = getEnvValue(ConfigExecTemplateEnvVar)
 	params.InitScriptTemplate = getEnvValue(InitScriptTemplateEnvVar)
+	params.InitPostIfScriptTemplate = getEnvValue(InitPostIfScriptTemplateEnvVar)
 	params.FinalizeScriptTemplate = getEnvValue(FinalizeScriptTemplateEnvVar)
 
 	params.ConfigTemplate = getEnvValue(ConfigTemplateEnvVar)
@@ -398,6 +403,12 @@ func PrepareConfiguration() (params *config.VppManagerParams, conf *config.Inter
 	conf, err = getInterfaceConfig(params)
 	if err != nil {
 		log.Fatalf("Error getting initial interface configuration: %s", err)
+	}
+
+	template = TemplateScriptReplace(params.InitPostIfScriptTemplate, params, nil)
+	err = utils.RunBashScript(template)
+	if err != nil {
+		log.Fatalf("Error running init script: %s", err)
 	}
 
 	return params, conf

--- a/vpp-manager/uplink/common.go
+++ b/vpp-manager/uplink/common.go
@@ -22,7 +22,6 @@ import (
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/pkg/errors"
 	"github.com/projectcalico/vpp-dataplane/vpp-manager/config"
-	"github.com/projectcalico/vpp-dataplane/vpp-manager/startup"
 	"github.com/projectcalico/vpp-dataplane/vpp-manager/utils"
 	"github.com/projectcalico/vpp-dataplane/vpplink"
 	log "github.com/sirupsen/logrus"
@@ -135,7 +134,7 @@ func (d *UplinkDriverData) restoreLinuxIfConf(link netlink.Link) {
 }
 
 func (d *UplinkDriverData) GenerateVppConfigExecFile() error {
-	template := startup.TemplateScriptReplace(d.params.ConfigExecTemplate, d.params, d.conf)
+	template := config.TemplateScriptReplace(d.params.ConfigExecTemplate, d.params, d.conf)
 	err := errors.Wrapf(
 		ioutil.WriteFile(config.VppConfigExecFile, []byte(template+"\n"), 0744),
 		"Error writing VPP Exec configuration to %s",
@@ -145,7 +144,7 @@ func (d *UplinkDriverData) GenerateVppConfigExecFile() error {
 }
 
 func (d *UplinkDriverData) GenerateVppConfigFile() error {
-	template := startup.TemplateScriptReplace(d.params.ConfigTemplate, d.params, d.conf)
+	template := config.TemplateScriptReplace(d.params.ConfigTemplate, d.params, d.conf)
 	return errors.Wrapf(
 		ioutil.WriteFile(config.VppConfigFile, []byte(template+"\n"), 0644),
 		"Error writing VPP configuration to %s",

--- a/vpp-manager/uplink/common.go
+++ b/vpp-manager/uplink/common.go
@@ -18,11 +18,11 @@ package uplink
 import (
 	"fmt"
 	"io/ioutil"
-	"strings"
 
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/pkg/errors"
 	"github.com/projectcalico/vpp-dataplane/vpp-manager/config"
+	"github.com/projectcalico/vpp-dataplane/vpp-manager/startup"
 	"github.com/projectcalico/vpp-dataplane/vpp-manager/utils"
 	"github.com/projectcalico/vpp-dataplane/vpplink"
 	log "github.com/sirupsen/logrus"
@@ -135,9 +135,7 @@ func (d *UplinkDriverData) restoreLinuxIfConf(link netlink.Link) {
 }
 
 func (d *UplinkDriverData) GenerateVppConfigExecFile() error {
-	// Trivial rendering for the moment...
-	template := strings.ReplaceAll(d.params.ConfigExecTemplate, "__PCI_DEVICE_ID__", d.conf.PciId)
-	template = strings.ReplaceAll(template, "__VPP_DATAPLANE_IF__", d.params.MainInterface)
+	template := startup.TemplateScriptReplace(d.params.ConfigExecTemplate, d.params, d.conf)
 	err := errors.Wrapf(
 		ioutil.WriteFile(config.VppConfigExecFile, []byte(template+"\n"), 0744),
 		"Error writing VPP Exec configuration to %s",
@@ -147,9 +145,7 @@ func (d *UplinkDriverData) GenerateVppConfigExecFile() error {
 }
 
 func (d *UplinkDriverData) GenerateVppConfigFile() error {
-	// Trivial rendering for the moment...
-	template := strings.ReplaceAll(d.params.ConfigTemplate, "__PCI_DEVICE_ID__", d.conf.PciId)
-	template = strings.ReplaceAll(template, "__VPP_DATAPLANE_IF__", d.params.MainInterface)
+	template := startup.TemplateScriptReplace(d.params.ConfigTemplate, d.params, d.conf)
 	return errors.Wrapf(
 		ioutil.WriteFile(config.VppConfigFile, []byte(template+"\n"), 0644),
 		"Error writing VPP configuration to %s",

--- a/vpp-manager/uplink/dpdk.go
+++ b/vpp-manager/uplink/dpdk.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/projectcalico/vpp-dataplane/vpp-manager/config"
-	"github.com/projectcalico/vpp-dataplane/vpp-manager/startup"
 	"github.com/projectcalico/vpp-dataplane/vpp-manager/utils"
 	"github.com/projectcalico/vpp-dataplane/vpplink"
 	log "github.com/sirupsen/logrus"
@@ -58,7 +57,7 @@ func (d *DPDKDriver) PreconfigureLinux() (err error) {
 }
 
 func (d *DPDKDriver) GenerateVppConfigFile() error {
-	template := startup.TemplateScriptReplace(d.params.ConfigTemplate, d.params, d.conf)
+	template := config.TemplateScriptReplace(d.params.ConfigTemplate, d.params, d.conf)
 	dpdkPluginRegex := regexp.MustCompile(`plugin\s+dpdk_plugin.so\s+{\s+disable\s+}`)
 	template = dpdkPluginRegex.ReplaceAllString(template, "plugin dpdk_plugin.so { enable }")
 

--- a/vpp-manager/uplink/dpdk.go
+++ b/vpp-manager/uplink/dpdk.go
@@ -19,11 +19,11 @@ import (
 	"fmt"
 	"io/ioutil"
 	"regexp"
-	"strings"
 	"time"
 
 	"github.com/pkg/errors"
 	"github.com/projectcalico/vpp-dataplane/vpp-manager/config"
+	"github.com/projectcalico/vpp-dataplane/vpp-manager/startup"
 	"github.com/projectcalico/vpp-dataplane/vpp-manager/utils"
 	"github.com/projectcalico/vpp-dataplane/vpplink"
 	log "github.com/sirupsen/logrus"
@@ -58,9 +58,7 @@ func (d *DPDKDriver) PreconfigureLinux() (err error) {
 }
 
 func (d *DPDKDriver) GenerateVppConfigFile() error {
-	template := d.params.ConfigTemplate
-	template = strings.ReplaceAll(template, "__PCI_DEVICE_ID__", d.conf.PciId)
-	template = strings.ReplaceAll(template, "__VPP_DATAPLANE_IF__", d.params.MainInterface)
+	template := startup.TemplateScriptReplace(d.params.ConfigTemplate, d.params, d.conf)
 	dpdkPluginRegex := regexp.MustCompile(`plugin\s+dpdk_plugin.so\s+{\s+disable\s+}`)
 	template = dpdkPluginRegex.ReplaceAllString(template, "plugin dpdk_plugin.so { enable }")
 

--- a/vpp-manager/utils/utils.go
+++ b/vpp-manager/utils/utils.go
@@ -528,3 +528,13 @@ func BroadcastAddr(n *net.IPNet) net.IP {
 	}
 	return broadcast
 }
+
+func RunBashScript(script string) error {
+	if script == "" {
+		return nil
+	}
+	cmd := exec.Command("/bin/bash", "-c", script)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/vpp-manager/vpp_runner.go
+++ b/vpp-manager/vpp_runner.go
@@ -32,6 +32,7 @@ import (
 	calicocli "github.com/projectcalico/libcalico-go/lib/clientv3"
 	calicoopts "github.com/projectcalico/libcalico-go/lib/options"
 	"github.com/projectcalico/vpp-dataplane/vpp-manager/config"
+	"github.com/projectcalico/vpp-dataplane/vpp-manager/startup"
 	"github.com/projectcalico/vpp-dataplane/vpp-manager/uplink"
 	"github.com/projectcalico/vpp-dataplane/vpp-manager/utils"
 	"github.com/projectcalico/vpp-dataplane/vpplink"
@@ -665,6 +666,12 @@ func (v *VppRunner) runVpp() (err error) {
 
 	utils.WriteFile("1", config.VppManagerStatusFile)
 	go v.poolWatcher.SyncPools()
+
+	template := startup.TemplateScriptReplace(v.params.FinalizeScriptTemplate, v.params, v.conf)
+	err = utils.RunBashScript(template)
+	if err != nil {
+		log.Errorf("Error running finalize script: %s", err)
+	}
 
 	<-vppDeadChan
 	log.Infof("VPP Exited: status %v", err)

--- a/yaml/base/calico.yaml
+++ b/yaml/base/calico.yaml
@@ -3669,8 +3669,11 @@ spec:
             # The default IPv4 pool to create on startup if none exists. Pod IPs will be
             # chosen from this range. Changing this value after installation will have
             # no effect. This should fall within `--cluster-cidr`.
-            # - name: CALICO_IPV4POOL_CIDR
-            #   value: "192.168.0.0/16"
+            - name: CALICO_IPV4POOL_CIDR
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: default_ipv4_pool_cidr
             # Disable file logging so `kubectl logs` works.
             - name: CALICO_DISABLE_FILE_LOGGING
               value: "true"

--- a/yaml/generated/calico-vpp-dpdk.yaml
+++ b/yaml/generated/calico-vpp-dpdk.yaml
@@ -3589,6 +3589,11 @@ spec:
             configMapKeyRef:
               key: veth_mtu
               name: calico-config
+        - name: CALICO_IPV4POOL_CIDR
+          valueFrom:
+            configMapKeyRef:
+              key: default_ipv4_pool_cidr
+              name: calico-config
         - name: CALICO_DISABLE_FILE_LOGGING
           value: "true"
         - name: FELIX_DEFAULTENDPOINTTOHOSTACTION

--- a/yaml/generated/calico-vpp-dpdk.yaml
+++ b/yaml/generated/calico-vpp-dpdk.yaml
@@ -3796,6 +3796,45 @@ spec:
     spec:
       containers:
       - env:
+        - name: DATASTORE_TYPE
+          value: kubernetes
+        - name: WAIT_FOR_DATASTORE
+          value: "true"
+        - name: NODENAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: CALICOVPP_TAP_MTU
+          valueFrom:
+            configMapKeyRef:
+              key: veth_mtu
+              name: calico-config
+        - name: SERVICE_PREFIX
+          valueFrom:
+            configMapKeyRef:
+              key: service_prefix
+              name: calico-config
+        image: docker.io/calicovpp/agent:prerelease
+        imagePullPolicy: IfNotPresent
+        name: agent
+        resources:
+          requests:
+            cpu: 250m
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /var/run/calico
+          name: var-run-calico
+          readOnly: false
+        - mountPath: /var/lib/calico/felix-plugins
+          name: felix-plugins
+          readOnly: false
+        - mountPath: /var/run/vpp
+          name: vpp-rundir
+        - mountPath: /run/netns/
+          mountPropagation: Bidirectional
+          name: netns
+      - env:
         - name: CALICOVPP_NATIVE_DRIVER
           valueFrom:
             configMapKeyRef:
@@ -3850,45 +3889,6 @@ spec:
           name: devices
         - mountPath: /sys
           name: hostsys
-        - mountPath: /run/netns/
-          mountPropagation: Bidirectional
-          name: netns
-      - env:
-        - name: DATASTORE_TYPE
-          value: kubernetes
-        - name: WAIT_FOR_DATASTORE
-          value: "true"
-        - name: NODENAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        - name: CALICOVPP_TAP_MTU
-          valueFrom:
-            configMapKeyRef:
-              key: veth_mtu
-              name: calico-config
-        - name: SERVICE_PREFIX
-          valueFrom:
-            configMapKeyRef:
-              key: service_prefix
-              name: calico-config
-        image: docker.io/calicovpp/agent:prerelease
-        imagePullPolicy: IfNotPresent
-        name: agent
-        resources:
-          requests:
-            cpu: 250m
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /var/run/calico
-          name: var-run-calico
-          readOnly: false
-        - mountPath: /var/lib/calico/felix-plugins
-          name: felix-plugins
-          readOnly: false
-        - mountPath: /var/run/vpp
-          name: vpp-rundir
         - mountPath: /run/netns/
           mountPropagation: Bidirectional
           name: netns

--- a/yaml/generated/calico-vpp-eks-dpdk.yaml
+++ b/yaml/generated/calico-vpp-eks-dpdk.yaml
@@ -3888,10 +3888,14 @@ spec:
           mountPropagation: Bidirectional
           name: netns
       - env:
-        - name: CALICOVPP_POST_INIT_SCRIPT_TEMPLATE
+        - name: CALICOVPP_HOOK_BEFORE_VPP_RUN
           value: echo 'sudo systemctl stop network' | chroot /host
-        - name: CALICOVPP_FINALIZE_SCRIPT_TEMPLATE
+        - name: CALICOVPP_HOOK_VPP_RUNNING
           value: echo 'sudo systemctl start network' | chroot /host
+        - name: CALICOVPP_HOOK_VPP_DONE_OK
+          value: echo 'sudo systemctl restart network' | chroot /host
+        - name: CALICOVPP_HOOK_VPP_ERRORED
+          value: echo 'sudo systemctl restart network' | chroot /host
         - name: CALICOVPP_NATIVE_DRIVER
           valueFrom:
             configMapKeyRef:

--- a/yaml/generated/calico-vpp-eks-dpdk.yaml
+++ b/yaml/generated/calico-vpp-eks-dpdk.yaml
@@ -3552,7 +3552,7 @@ spec:
       - env:
         - name: HUGEPAGES
           value: "512"
-        image: calicovpp/init-eks:latest
+        image: calicovpp/init-eks:prerelease
         imagePullPolicy: IfNotPresent
         name: calicovpp-init-eks
         securityContext:
@@ -3636,6 +3636,11 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: veth_mtu
+              name: calico-config
+        - name: CALICO_IPV4POOL_CIDR
+          valueFrom:
+            configMapKeyRef:
+              key: default_ipv4_pool_cidr
               name: calico-config
         - name: CALICO_DISABLE_FILE_LOGGING
           value: "true"
@@ -3862,7 +3867,7 @@ spec:
             configMapKeyRef:
               key: service_prefix
               name: calico-config
-        image: docker.io/calicovpp/agent:latest
+        image: docker.io/calicovpp/agent:prerelease
         imagePullPolicy: IfNotPresent
         name: agent
         resources:
@@ -3919,7 +3924,7 @@ spec:
               fieldPath: spec.nodeName
         - name: CALICOVPP_CORE_PATTERN
           value: /var/lib/vpp/vppcore.%e.%p
-        image: docker.io/calicovpp/vpp:latest
+        image: docker.io/calicovpp/vpp:prerelease
         imagePullPolicy: IfNotPresent
         name: vpp
         resources:

--- a/yaml/generated/calico-vpp-eks-dpdk.yaml
+++ b/yaml/generated/calico-vpp-eks-dpdk.yaml
@@ -3552,7 +3552,7 @@ spec:
       - env:
         - name: HUGEPAGES
           value: "512"
-        image: calicovpp/init-eks:prerelease
+        image: calicovpp/init-eks:latest
         imagePullPolicy: IfNotPresent
         name: calicovpp-init-eks
         securityContext:
@@ -3843,9 +3843,109 @@ spec:
         k8s-app: calico-vpp-node
     spec:
       containers:
+      - env:
+        - name: DATASTORE_TYPE
+          value: kubernetes
+        - name: WAIT_FOR_DATASTORE
+          value: "true"
+        - name: NODENAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: CALICOVPP_TAP_MTU
+          valueFrom:
+            configMapKeyRef:
+              key: veth_mtu
+              name: calico-config
+        - name: SERVICE_PREFIX
+          valueFrom:
+            configMapKeyRef:
+              key: service_prefix
+              name: calico-config
+        image: docker.io/calicovpp/agent:latest
+        imagePullPolicy: IfNotPresent
+        name: agent
+        resources:
+          requests:
+            cpu: 250m
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /var/run/calico
+          name: var-run-calico
+          readOnly: false
+        - mountPath: /var/lib/calico/felix-plugins
+          name: felix-plugins
+          readOnly: false
+        - mountPath: /var/run/vpp
+          name: vpp-rundir
+        - mountPath: /run/netns/
+          mountPropagation: Bidirectional
+          name: netns
+      - env:
+        - name: CALICOVPP_POST_INIT_SCRIPT_TEMPLATE
+          value: echo 'sudo systemctl stop network' | chroot /host
+        - name: CALICOVPP_FINALIZE_SCRIPT_TEMPLATE
+          value: echo 'sudo systemctl start network' | chroot /host
+        - name: CALICOVPP_NATIVE_DRIVER
+          valueFrom:
+            configMapKeyRef:
+              key: vpp_uplink_driver
+              name: calico-config
+        - name: CALICOVPP_IP_CONFIG
+          value: linux
+        - name: CALICOVPP_INTERFACE
+          valueFrom:
+            configMapKeyRef:
+              key: vpp_dataplane_interface
+              name: calico-config
+        - name: CALICOVPP_CONFIG_TEMPLATE
+          valueFrom:
+            configMapKeyRef:
+              key: vpp_config_template
+              name: calico-config
+        - name: SERVICE_PREFIX
+          valueFrom:
+            configMapKeyRef:
+              key: service_prefix
+              name: calico-config
+        - name: DATASTORE_TYPE
+          value: kubernetes
+        - name: WAIT_FOR_DATASTORE
+          value: "true"
+        - name: NODENAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: CALICOVPP_CORE_PATTERN
+          value: /var/lib/vpp/vppcore.%e.%p
+        image: docker.io/calicovpp/vpp:latest
+        imagePullPolicy: IfNotPresent
+        name: vpp
         resources:
           limits:
             hugepages-2Mi: 512Mi
+          requests:
+            cpu: 500m
+            memory: 128Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /host
+          name: host-root
+        - mountPath: /var/run/vpp
+          name: vpp-rundir
+        - mountPath: /var/lib/vpp
+          name: vpp-data
+        - mountPath: /etc/vpp
+          name: vpp-config
+        - mountPath: /dev
+          name: devices
+        - mountPath: /sys
+          name: hostsys
+        - mountPath: /run/netns/
+          mountPropagation: Bidirectional
+          name: netns
       hostNetwork: true
       hostPID: true
       nodeSelector:

--- a/yaml/generated/calico-vpp-eks-dpdk.yaml
+++ b/yaml/generated/calico-vpp-eks-dpdk.yaml
@@ -3444,7 +3444,7 @@ data:
   default_ipv4_pool_cidr: 10.10.0.0/16
   service_prefix: 10.100.0.0/16
   typha_service_name: none
-  veth_mtu: "1410"
+  veth_mtu: "0"
   vpp_config_template: |-
     unix {
       nodaemon
@@ -3591,6 +3591,10 @@ spec:
     spec:
       containers:
       - env:
+        - name: FELIX_AWSSRCDSTCHECK
+          value: Disable
+        - name: IP_AUTODETECTION_METHOD
+          value: interface=eth0
         - name: FELIX_USEINTERNALDATAPLANEDRIVER
           value: "false"
         - name: FELIX_DATAPLANEDRIVER
@@ -3839,111 +3843,9 @@ spec:
         k8s-app: calico-vpp-node
     spec:
       containers:
-      - env:
-        - name: CALICOVPP_NATIVE_DRIVER
-          valueFrom:
-            configMapKeyRef:
-              key: vpp_uplink_driver
-              name: calico-config
-        - name: CALICOVPP_IP_CONFIG
-          value: linux
-        - name: CALICOVPP_INTERFACE
-          valueFrom:
-            configMapKeyRef:
-              key: vpp_dataplane_interface
-              name: calico-config
-        - name: CALICOVPP_CONFIG_TEMPLATE
-          valueFrom:
-            configMapKeyRef:
-              key: vpp_config_template
-              name: calico-config
-        - name: SERVICE_PREFIX
-          valueFrom:
-            configMapKeyRef:
-              key: service_prefix
-              name: calico-config
-        - name: DATASTORE_TYPE
-          value: kubernetes
-        - name: WAIT_FOR_DATASTORE
-          value: "true"
-        - name: NODENAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        - name: CALICOVPP_CORE_PATTERN
-          value: /var/lib/vpp/vppcore.%e.%p
-        image: docker.io/calicovpp/vpp:prerelease
-        imagePullPolicy: IfNotPresent
-        name: vpp
         resources:
           limits:
             hugepages-2Mi: 512Mi
-          requests:
-            cpu: 1
-            memory: 128Mi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /hugepages
-          name: hugepage
-        - mountPath: /var/run/vpp
-          name: vpp-rundir
-        - mountPath: /var/lib/vpp
-          name: vpp-data
-        - mountPath: /etc/vpp
-          name: vpp-config
-        - mountPath: /dev
-          name: devices
-        - mountPath: /sys
-          name: hostsys
-        - mountPath: /run/netns/
-          mountPropagation: Bidirectional
-          name: netns
-      - env:
-        - name: CALICO_IPV4POOL_IPIP
-          value: Always
-        - name: FELIX_AWSSRCDSTCHECK
-          value: Disable
-        name: calico-node
-      - env:
-        - name: DATASTORE_TYPE
-          value: kubernetes
-        - name: WAIT_FOR_DATASTORE
-          value: "true"
-        - name: NODENAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        - name: CALICOVPP_TAP_MTU
-          valueFrom:
-            configMapKeyRef:
-              key: veth_mtu
-              name: calico-config
-        - name: SERVICE_PREFIX
-          valueFrom:
-            configMapKeyRef:
-              key: service_prefix
-              name: calico-config
-        image: docker.io/calicovpp/agent:prerelease
-        imagePullPolicy: IfNotPresent
-        name: agent
-        resources:
-          requests:
-            cpu: 250m
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /var/run/calico
-          name: var-run-calico
-          readOnly: false
-        - mountPath: /var/lib/calico/felix-plugins
-          name: felix-plugins
-          readOnly: false
-        - mountPath: /var/run/vpp
-          name: vpp-rundir
-        - mountPath: /run/netns/
-          mountPropagation: Bidirectional
-          name: netns
       hostNetwork: true
       hostPID: true
       nodeSelector:
@@ -3959,9 +3861,6 @@ spec:
       - effect: NoExecute
         operator: Exists
       volumes:
-      - emptyDir:
-          medium: HugePages
-        name: hugepage
       - hostPath:
           path: /
         name: host-root

--- a/yaml/generated/calico-vpp-eks.yaml
+++ b/yaml/generated/calico-vpp-eks.yaml
@@ -3593,6 +3593,11 @@ spec:
             configMapKeyRef:
               key: veth_mtu
               name: calico-config
+        - name: CALICO_IPV4POOL_CIDR
+          valueFrom:
+            configMapKeyRef:
+              key: default_ipv4_pool_cidr
+              name: calico-config
         - name: CALICO_DISABLE_FILE_LOGGING
           value: "true"
         - name: FELIX_DEFAULTENDPOINTTOHOSTACTION

--- a/yaml/generated/calico-vpp-eks.yaml
+++ b/yaml/generated/calico-vpp-eks.yaml
@@ -3839,6 +3839,8 @@ spec:
           mountPropagation: Bidirectional
           name: netns
       - env:
+        - name: CALICOVPP_FINALIZE_SCRIPT_TEMPLATE
+          value: echo 'sudo systemctl restart network' | chroot /host
         - name: CALICOVPP_NATIVE_DRIVER
           valueFrom:
             configMapKeyRef:
@@ -3881,6 +3883,8 @@ spec:
         securityContext:
           privileged: true
         volumeMounts:
+        - mountPath: /host
+          name: host-root
         - mountPath: /var/run/vpp
           name: vpp-rundir
         - mountPath: /var/lib/vpp
@@ -3909,6 +3913,9 @@ spec:
       - effect: NoExecute
         operator: Exists
       volumes:
+      - hostPath:
+          path: /
+        name: host-root
       - hostPath:
           path: /var/run/vpp
         name: vpp-rundir

--- a/yaml/generated/calico-vpp-eks.yaml
+++ b/yaml/generated/calico-vpp-eks.yaml
@@ -3844,10 +3844,14 @@ spec:
           mountPropagation: Bidirectional
           name: netns
       - env:
-        - name: CALICOVPP_POST_INIT_SCRIPT_TEMPLATE
+        - name: CALICOVPP_HOOK_BEFORE_VPP_RUN
           value: echo 'sudo systemctl stop network' | chroot /host
-        - name: CALICOVPP_FINALIZE_SCRIPT_TEMPLATE
+        - name: CALICOVPP_HOOK_VPP_RUNNING
           value: echo 'sudo systemctl start network' | chroot /host
+        - name: CALICOVPP_HOOK_VPP_DONE_OK
+          value: echo 'sudo systemctl restart network' | chroot /host
+        - name: CALICOVPP_HOOK_VPP_ERRORED
+          value: echo 'sudo systemctl restart network' | chroot /host
         - name: CALICOVPP_NATIVE_DRIVER
           valueFrom:
             configMapKeyRef:

--- a/yaml/generated/calico-vpp-eks.yaml
+++ b/yaml/generated/calico-vpp-eks.yaml
@@ -3839,8 +3839,10 @@ spec:
           mountPropagation: Bidirectional
           name: netns
       - env:
+        - name: CALICOVPP_POST_INIT_SCRIPT_TEMPLATE
+          value: echo 'sudo systemctl stop network' | chroot /host
         - name: CALICOVPP_FINALIZE_SCRIPT_TEMPLATE
-          value: echo 'sudo systemctl restart network' | chroot /host
+          value: echo 'sudo systemctl start network' | chroot /host
         - name: CALICOVPP_NATIVE_DRIVER
           valueFrom:
             configMapKeyRef:

--- a/yaml/generated/calico-vpp-nohuge.yaml
+++ b/yaml/generated/calico-vpp-nohuge.yaml
@@ -3589,6 +3589,11 @@ spec:
             configMapKeyRef:
               key: veth_mtu
               name: calico-config
+        - name: CALICO_IPV4POOL_CIDR
+          valueFrom:
+            configMapKeyRef:
+              key: default_ipv4_pool_cidr
+              name: calico-config
         - name: CALICO_DISABLE_FILE_LOGGING
           value: "true"
         - name: FELIX_DEFAULTENDPOINTTOHOSTACTION

--- a/yaml/generated/calico-vpp.yaml
+++ b/yaml/generated/calico-vpp.yaml
@@ -3589,6 +3589,11 @@ spec:
             configMapKeyRef:
               key: veth_mtu
               name: calico-config
+        - name: CALICO_IPV4POOL_CIDR
+          valueFrom:
+            configMapKeyRef:
+              key: default_ipv4_pool_cidr
+              name: calico-config
         - name: CALICO_DISABLE_FILE_LOGGING
           value: "true"
         - name: FELIX_DEFAULTENDPOINTTOHOSTACTION

--- a/yaml/generated/calico-vpp.yaml
+++ b/yaml/generated/calico-vpp.yaml
@@ -3796,6 +3796,45 @@ spec:
     spec:
       containers:
       - env:
+        - name: DATASTORE_TYPE
+          value: kubernetes
+        - name: WAIT_FOR_DATASTORE
+          value: "true"
+        - name: NODENAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: CALICOVPP_TAP_MTU
+          valueFrom:
+            configMapKeyRef:
+              key: veth_mtu
+              name: calico-config
+        - name: SERVICE_PREFIX
+          valueFrom:
+            configMapKeyRef:
+              key: service_prefix
+              name: calico-config
+        image: docker.io/calicovpp/agent:prerelease
+        imagePullPolicy: IfNotPresent
+        name: agent
+        resources:
+          requests:
+            cpu: 250m
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /var/run/calico
+          name: var-run-calico
+          readOnly: false
+        - mountPath: /var/lib/calico/felix-plugins
+          name: felix-plugins
+          readOnly: false
+        - mountPath: /var/run/vpp
+          name: vpp-rundir
+        - mountPath: /run/netns/
+          mountPropagation: Bidirectional
+          name: netns
+      - env:
         - name: CALICOVPP_NATIVE_DRIVER
           valueFrom:
             configMapKeyRef:
@@ -3850,45 +3889,6 @@ spec:
           name: devices
         - mountPath: /sys
           name: hostsys
-        - mountPath: /run/netns/
-          mountPropagation: Bidirectional
-          name: netns
-      - env:
-        - name: DATASTORE_TYPE
-          value: kubernetes
-        - name: WAIT_FOR_DATASTORE
-          value: "true"
-        - name: NODENAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        - name: CALICOVPP_TAP_MTU
-          valueFrom:
-            configMapKeyRef:
-              key: veth_mtu
-              name: calico-config
-        - name: SERVICE_PREFIX
-          valueFrom:
-            configMapKeyRef:
-              key: service_prefix
-              name: calico-config
-        image: docker.io/calicovpp/agent:prerelease
-        imagePullPolicy: IfNotPresent
-        name: agent
-        resources:
-          requests:
-            cpu: 250m
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /var/run/calico
-          name: var-run-calico
-          readOnly: false
-        - mountPath: /var/lib/calico/felix-plugins
-          name: felix-plugins
-          readOnly: false
-        - mountPath: /var/run/vpp
-          name: vpp-rundir
         - mountPath: /run/netns/
           mountPropagation: Bidirectional
           name: netns

--- a/yaml/overlays/eks-dpdk/eks-config.yaml
+++ b/yaml/overlays/eks-dpdk/eks-config.yaml
@@ -4,11 +4,7 @@ metadata:
   name: calico-config
   namespace: kube-system
 data:  # Configuration template for VPP in EKS
-  service_prefix: 10.100.0.0/16
-  vpp_dataplane_interface: eth0
-  veth_mtu: "1410"
-  default_ipv4_pool_cidr: 10.10.0.0/16
-  vpp_uplink_driver: "none"
+  vpp_uplink_driver: none
   vpp_config_template: |-
     unix {
       nodaemon
@@ -43,25 +39,6 @@ spec:
   template:
     spec:
       containers:
-        - name: vpp
-          volumeMounts:
-            - mountPath: /hugepages
-              name: hugepage
           resources:
-            requests:
-              cpu: 1
             limits:
               hugepages-2Mi: 512Mi
-        - name: calico-node
-          env:
-            - name: CALICO_IPV4POOL_IPIP
-              value: "Always"
-            - name: FELIX_AWSSRCDSTCHECK
-              value: Disable
-      volumes:
-        - name: hugepage
-          emptyDir:
-            medium: HugePages
-        - name: host-root
-          hostPath:
-            path: /

--- a/yaml/overlays/eks-dpdk/eks-config.yaml
+++ b/yaml/overlays/eks-dpdk/eks-config.yaml
@@ -39,6 +39,7 @@ spec:
   template:
     spec:
       containers:
+        - name: vpp
           resources:
             limits:
               hugepages-2Mi: 512Mi

--- a/yaml/overlays/eks-dpdk/kustomization.yaml
+++ b/yaml/overlays/eks-dpdk/kustomization.yaml
@@ -1,6 +1,6 @@
 resources:
 - eks-init.yaml
 bases:
-- ../../base
+- ../eks
 patchesStrategicMerge:
 - eks-config.yaml

--- a/yaml/overlays/eks/eks-config.yaml
+++ b/yaml/overlays/eks/eks-config.yaml
@@ -36,10 +36,14 @@ spec:
       containers:
         - name: vpp
           env:
-            - name: CALICOVPP_POST_INIT_SCRIPT_TEMPLATE
+            - name: CALICOVPP_HOOK_BEFORE_VPP_RUN
               value: "echo 'sudo systemctl stop network' | chroot /host"
-            - name: CALICOVPP_FINALIZE_SCRIPT_TEMPLATE
+            - name: CALICOVPP_HOOK_VPP_RUNNING
               value: "echo 'sudo systemctl start network' | chroot /host"
+            - name: CALICOVPP_HOOK_VPP_DONE_OK
+              value: "echo 'sudo systemctl restart network' | chroot /host"
+            - name: CALICOVPP_HOOK_VPP_ERRORED
+              value: "echo 'sudo systemctl restart network' | chroot /host"
           volumeMounts:
             - mountPath: /host
               name: host-root

--- a/yaml/overlays/eks/eks-config.yaml
+++ b/yaml/overlays/eks/eks-config.yaml
@@ -20,7 +20,28 @@ spec:
       containers:
         - name: calico-node
           env:
-          - name: FELIX_AWSSRCDSTCHECK
-            value: Disable
-          - name: IP_AUTODETECTION_METHOD
-            value: interface=eth0
+            - name: FELIX_AWSSRCDSTCHECK
+              value: Disable
+            - name: IP_AUTODETECTION_METHOD
+              value: interface=eth0
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: calico-vpp-node
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      containers:
+        - name: vpp
+          env:
+            - name: CALICOVPP_FINALIZE_SCRIPT_TEMPLATE
+              value: "echo 'sudo systemctl restart network' | chroot /host"
+          volumeMounts:
+            - mountPath: /host
+              name: host-root
+      volumes:
+        - hostPath:
+            path: /
+          name: host-root

--- a/yaml/overlays/eks/eks-config.yaml
+++ b/yaml/overlays/eks/eks-config.yaml
@@ -36,8 +36,10 @@ spec:
       containers:
         - name: vpp
           env:
+            - name: CALICOVPP_POST_INIT_SCRIPT_TEMPLATE
+              value: "echo 'sudo systemctl stop network' | chroot /host"
             - name: CALICOVPP_FINALIZE_SCRIPT_TEMPLATE
-              value: "echo 'sudo systemctl restart network' | chroot /host"
+              value: "echo 'sudo systemctl start network' | chroot /host"
           volumeMounts:
             - mountPath: /host
               name: host-root


### PR DESCRIPTION
Instability seems to be related to dhclient, which doesn't get restarted after uplink swap
and fails to send DHCP broadcasts.

Issuing a `systemctl restart network` after uplink swap solves the issue, even if not ideal

````bash
journalctl -u network.service
...
dhclient[2767]: DHCPREQUEST on eth0 to 192.168.32.1 port 67 (xid=0x7c1b4f61)
dhclient[2767]: DHCPREQUEST on eth0 to 192.168.32.1 port 67 (xid=0x7c1b4f61)
dhclient[2767]: DHCPREQUEST on eth0 to 192.168.32.1 port 67 (xid=0x7c1b4f61)
dhclient[2767]: DHCPREQUEST on eth0 to 255.255.255.255 port 67 (xid=0x7c1b4f61)
dhclient[2767]: send_packet: No such device or address
dhclient[2767]: dhclient.c:2736: Failed to send 300 byte long packet over eth0 interface.
...
````