### PR TITLE
agent: Fix no BGP config found

### DIFF
--- a/calico-vpp-agent/policy/policy_server.go
+++ b/calico-vpp-agent/policy/policy_server.go
@@ -148,6 +148,11 @@ func InstallFelixPlugin() (err error) {
 }
 
 func (s *Server) setNodeIPs(nodeSpec *calicoapi.NodeSpec) {
+	if nodeSpec == nil {
+		return
+	} else if nodeSpec.BGP == nil {
+		return
+	}
 	if nodeSpec.BGP.IPv4Address != "" {
 		addr, _, err := net.ParseCIDR(nodeSpec.BGP.IPv4Address)
 		if err != nil {

--- a/calico-vpp-agent/services/service_server.go
+++ b/calico-vpp-agent/services/service_server.go
@@ -65,6 +65,11 @@ type Server struct {
 }
 
 func (s *Server) setSpecAddresses(nodeSpec *calicov3.NodeSpec) {
+	if nodeSpec == nil {
+		return
+	} else if nodeSpec.BGP == nil {
+		return
+	}
 	if nodeSpec.BGP.IPv4Address != "" {
 		addr, _, err := net.ParseCIDR(nodeSpec.BGP.IPv4Address)
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: Nathan Skrzypczak <nathan.skrzypczak@gmail.com>

This can happen if we start Felix without any address configured.
Typically a misconfigured v6 cluster with no v4 addresses, but felix
still searching for one.