### PR TITLE
dpdk-21.05 ena interrupt support

### DIFF
--- a/vpplink/binapi/vpp_clone_current.sh
+++ b/vpplink/binapi/vpp_clone_current.sh
@@ -55,4 +55,4 @@ git_cherry_pick refs/changes/83/28083/16 # 28083: acl: acl-plugin custom policie
 git_cherry_pick refs/changes/13/28513/20 # 25813: capo: Calico Policies plugin | https://gerrit.fd.io/r/c/vpp/+/28513
 # ------------- Policies patches -------------
 
-git_cherry_pick refs/changes/35/32235/1  # 32235: dpdk: enable ena interrupt support | https://gerrit.fd.io/r/c/vpp/+/32235
+git_cherry_pick refs/changes/64/33164/3  # 33164: dpdk: enable ena interrupt support in dpdk version 21.05 | https://gerrit.fd.io/r/c/vpp/+/33164

--- a/yaml/generated/calico-vpp-eks-dpdk.yaml
+++ b/yaml/generated/calico-vpp-eks-dpdk.yaml
@@ -3567,7 +3567,7 @@ data:
         workers 0
     }
     dpdk {
-      uio-driver igb_uio
+      uio-driver vfio-pci
       dev __PCI_DEVICE_ID__ { num-rx-queues 1  num-tx-queues 1 }
     }
     socksvr {

--- a/yaml/overlays/eks-dpdk/eks-config.yaml
+++ b/yaml/overlays/eks-dpdk/eks-config.yaml
@@ -17,7 +17,7 @@ data:  # Configuration template for VPP in EKS
         workers 0
     }
     dpdk {
-      uio-driver igb_uio
+      uio-driver vfio-pci
       dev __PCI_DEVICE_ID__ { num-rx-queues 1  num-tx-queues 1 }
     }
     socksvr {


### PR DESCRIPTION
Cherry-pick the dpdk-21.05 ena interrupt support patch which is based on the
following patch:

https://patches.dpdk.org/project/dpdk/patch/20210713154118.32111-5-mk@semihalf.com/