### PR TITLE
Feature: memif & vcl

### DIFF
--- a/calico-vpp-agent/cni/cni_server.go
+++ b/calico-vpp-agent/cni/cni_server.go
@@ -23,6 +23,7 @@ import (
 	"syscall"
 
 	"github.com/pkg/errors"
+	"github.com/projectcalico/vpp-dataplane/calico-vpp-agent/cni/pod_interface"
 	"github.com/projectcalico/vpp-dataplane/calico-vpp-agent/cni/storage"
 	"github.com/projectcalico/vpp-dataplane/calico-vpp-agent/common"
 	"github.com/projectcalico/vpp-dataplane/calico-vpp-agent/config"
@@ -47,15 +48,20 @@ type Server struct {
 	policyServer    *policy.Server
 	podInterfaceMap map[string]storage.LocalPodSpec
 	/* without main thread */
-	NumVPPWorkers int
-	lock          sync.Mutex
+	lock           sync.Mutex
+	memifDriver    *pod_interface.MemifPodInterfaceDriver
+	tuntapDriver   *pod_interface.TunTapPodInterfaceDriver
+	vclDriver      *pod_interface.VclPodInterfaceDriver
+	loopbackDriver *pod_interface.LoopbackPodInterfaceDriver
+
+	indexAllocator *vpplink.IndexAllocator
 }
 
 func swIfIdxToIfName(idx uint32) string {
 	return fmt.Sprintf("vpp-tun-%d", idx)
 }
 
-func NewLocalPodSpecFromAdd(request *pb.AddRequest) (*storage.LocalPodSpec, error) {
+func (s *Server) newLocalPodSpecFromAdd(request *pb.AddRequest) (*storage.LocalPodSpec, error) {
 	podSpec := storage.LocalPodSpec{
 		InterfaceName:     request.GetInterfaceName(),
 		NetnsName:         request.GetNetns(),
@@ -64,9 +70,18 @@ func NewLocalPodSpecFromAdd(request *pb.AddRequest) (*storage.LocalPodSpec, erro
 		ContainerIps:      make([]storage.LocalIP, 0),
 		Mtu:               int(request.GetSettings().GetMtu()),
 
+		IfPortConfigs: make([]storage.LocalIfPortConfigs, 0),
+
 		OrchestratorID: request.Workload.Orchestrator,
 		WorkloadID:     request.Workload.Namespace + "/" + request.Workload.Pod,
 		EndpointID:     request.Workload.Endpoint,
+
+		/* defaults */
+		MemifIsL3:  false,
+		TunTapIsL3: true,
+
+		MemifSwIfIndex:  vpplink.InvalidID,
+		TunTapSwIfIndex: vpplink.InvalidID,
 	}
 	for _, routeStr := range request.GetContainerRoutes() {
 		_, route, err := net.ParseCIDR(routeStr)
@@ -87,6 +102,17 @@ func NewLocalPodSpecFromAdd(request *pb.AddRequest) (*storage.LocalPodSpec, erro
 		// for a tun it doesn't make sense
 		podSpec.ContainerIps = append(podSpec.ContainerIps, storage.LocalIP{IP: containerIp})
 	}
+	workload := request.GetWorkload()
+	if workload != nil {
+		err := s.ParsePodAnnotations(&podSpec, workload.Annotations)
+		if err != nil {
+			return nil, errors.Wrapf(err, "Cannot parse pod Annotations")
+		}
+	}
+
+	if podSpec.DefaultIfType == storage.VppIfTypeUnknown {
+		podSpec.DefaultIfType = storage.VppIfTypeTunTap
+	}
 
 	return &podSpec, nil
 }
@@ -99,10 +125,8 @@ func NewLocalPodSpecFromDel(request *pb.DelRequest) *storage.LocalPodSpec {
 }
 
 func (s *Server) Add(ctx context.Context, request *pb.AddRequest) (*pb.AddReply, error) {
-	if request.GetDesiredHostInterfaceName() != "" {
-		s.log.Warn("Desired host side interface name passed, this is not supported with VPP, ignoring it")
-	}
-	podSpec, err := NewLocalPodSpecFromAdd(request)
+	/* We don't support request.GetDesiredHostInterfaceName() */
+	podSpec, err := s.newLocalPodSpecFromAdd(request)
 	if err != nil {
 		s.log.Errorf("Error parsing interface add request %v %v", request, err)
 		return &pb.AddReply{
@@ -110,13 +134,24 @@ func (s *Server) Add(ctx context.Context, request *pb.AddRequest) (*pb.AddReply,
 			ErrorMessage: err.Error(),
 		}, nil
 	}
+	if podSpec.NetnsName == "" {
+		s.log.Debugf("no netns passed, skipping")
+		return &pb.AddReply{
+			Successful: true,
+		}, nil
+	}
 
-	s.log.Infof("Add request %s", podSpec.String())
 	s.BarrierSync()
 	s.lock.Lock()
 	defer s.lock.Unlock()
+
+	s.log.Infof("Adding Pod %s", podSpec.String())
+	podSpec.VrfId = s.indexAllocator.AllocateIndex()
+	s.log.Infof("Allocated VrfId:%d", podSpec.VrfId)
+
 	swIfIndex, err := s.AddVppInterface(podSpec, true /* doHostSideConf */)
 	if err != nil {
+		s.indexAllocator.FreeIndex(podSpec.VrfId)
 		s.log.Errorf("Interface add failed %s : %v", podSpec.String(), err)
 		return &pb.AddReply{
 			Successful:   false,
@@ -129,7 +164,7 @@ func (s *Server) Add(ctx context.Context, request *pb.AddRequest) (*pb.AddReply,
 	if err != nil {
 		s.log.Errorf("CNI state persist errored %v", err)
 	}
-	s.log.Infof("Interface add successful: %s", podSpec.String())
+	s.log.Infof("Done Adding Pod %s", podSpec.String())
 	// XXX: container MAC doesn't make sense anymore, we just pass back a constant one.
 	// How does calico / k8s use it?
 	return &pb.AddReply{
@@ -143,21 +178,42 @@ func (p *Server) IPNetNeedsSNAT(prefix *net.IPNet) bool {
 	return p.routingServer.IPNetNeedsSNAT(prefix)
 }
 
-func (s *Server) rescanState() error {
-	numVPPWorkers, err := s.vpp.GetNumVPPWorkers()
-	s.NumVPPWorkers = numVPPWorkers
+func (s *Server) FetchNDataThreads() {
+	nVppWorkers, err := s.vpp.GetNumVPPWorkers()
 	if err != nil {
 		s.log.Panicf("Error getting number of VPP workers: %v", err)
 	}
+	nDataThreads := nVppWorkers
+	if config.IpsecNbAsyncCryptoThread > 0 {
+		nDataThreads = nVppWorkers - config.IpsecNbAsyncCryptoThread
+		if nDataThreads <= 0 {
+			s.log.Error("Couldn't fullfill request [crypto=%d total=%d]", config.IpsecNbAsyncCryptoThread, nVppWorkers)
+			nDataThreads = nVppWorkers
+		}
+		s.log.Info("Using [data=%d crypto=%d]", nDataThreads, nVppWorkers-nDataThreads)
+
+	}
+	s.memifDriver.NDataThreads = nDataThreads
+	s.tuntapDriver.NDataThreads = nDataThreads
+}
+
+func (s *Server) rescanState() error {
+	s.FetchNDataThreads()
 
 	podSpecs, err := storage.LoadCniServerState(config.CniServerStateFile)
 	if err != nil {
 		s.log.Errorf("Error getting pods %v", err)
 		return err
 	}
+
+	s.log.Infof("RescanState: re-creating all interfaces")
 	for _, podSpec := range podSpecs {
-		s.log.Infof("Rescanning pod %v", podSpec.String())
-		_, err2 := s.AddVppInterface(&podSpec, false /* doHostSideConf */)
+		err2 := s.indexAllocator.TakeIndex(podSpec.VrfId)
+		if err2 != nil {
+			s.log.Errorf("Error Taking back index %d : %v", podSpec.VrfId, err2)
+			continue
+		}
+		_, err2 = s.AddVppInterface(&podSpec, false /* doHostSideConf */)
 		if err2 != nil {
 			// TODO: some errors are probably not critical, for instance if the interface
 			// can't be created because the netns disappeared (may happen when the host reboots)
@@ -170,44 +226,56 @@ func (s *Server) rescanState() error {
 	return err
 }
 
-func (p *Server) OnVppRestart() {
-	for name, podSpec := range p.podInterfaceMap {
-		_, err := p.AddVppInterface(&podSpec, false /* doHostSideConf */)
+func (s *Server) OnVppRestart() {
+	s.log.Infof("VppRestart: re-creating all interfaces")
+	for name, podSpec := range s.podInterfaceMap {
+		err := s.indexAllocator.TakeIndex(podSpec.VrfId)
 		if err != nil {
-			p.log.Errorf("Error re-injecting interface %s : %v", name, err)
+			s.log.Errorf("Error Taking back index %d : %v", podSpec.VrfId, err)
+			continue
+		}
+		_, err = s.AddVppInterface(&podSpec, false /* doHostSideConf */)
+		if err != nil {
+			s.log.Errorf("Error re-injecting interface %s : %v", name, err)
 		}
 	}
 }
 
 func (s *Server) Del(ctx context.Context, request *pb.DelRequest) (*pb.DelReply, error) {
-	podSpec := NewLocalPodSpecFromDel(request)
-
-	s.log.Infof("Del request %s", podSpec.Key())
+	partialPodSpec := NewLocalPodSpecFromDel(request)
+	// Only try to delete the device if a namespace was passed in.
+	if partialPodSpec.NetnsName == "" {
+		s.log.Debugf("no netns passed, skipping")
+		return &pb.DelReply{
+			Successful: true,
+		}, nil
+	}
 	s.BarrierSync()
 	s.lock.Lock()
 	defer s.lock.Unlock()
-	err := s.DelVppInterface(podSpec)
-	if err != nil {
-		s.log.Warnf("Interface del failed %s : %v", podSpec.Key(), err)
-		return &pb.DelReply{
-			Successful:   false,
-			ErrorMessage: err.Error(),
-		}, nil
-	}
 
-	initialSpec, ok := s.podInterfaceMap[podSpec.Key()]
+	s.log.Infof("Deleting pod %s", partialPodSpec.Key())
+	initialSpec, ok := s.podInterfaceMap[partialPodSpec.Key()]
 	if !ok {
-		s.log.Warnf("Deleting interface but initial spec not found")
+		s.log.Warnf("Unknown pod to delete")
 	} else {
 		s.policyServer.WorkloadRemoved(&policy.WorkloadEndpointID{
 			OrchestratorID: initialSpec.OrchestratorID,
 			WorkloadID:     initialSpec.WorkloadID,
 			EndpointID:     initialSpec.EndpointID,
 		})
+		s.log.Infof("Deleting pod %s", initialSpec.String())
+		s.DelVppInterface(&initialSpec)
+		s.log.Infof("Freeing VRF Index %d", initialSpec.VrfId)
+		s.indexAllocator.FreeIndex(initialSpec.VrfId)
+		s.log.Infof("Done Deleting pod %s", initialSpec.String())
 	}
 
-	delete(s.podInterfaceMap, podSpec.Key())
-	s.log.Infof("Interface del successful %s", podSpec.Key())
+	delete(s.podInterfaceMap, initialSpec.Key())
+	err := storage.PersistCniServerState(s.podInterfaceMap, config.CniServerStateFile)
+	if err != nil {
+		s.log.Errorf("CNI state persist errored %v", err)
+	}
 	return &pb.DelReply{
 		Successful: true,
 	}, nil
@@ -244,6 +312,11 @@ func NewServer(v *vpplink.VppLink, rs *routing.Server, ps *policy.Server, l *log
 		client:          client,
 		grpcServer:      grpc.NewServer(),
 		podInterfaceMap: make(map[string]storage.LocalPodSpec),
+		tuntapDriver:    pod_interface.NewTunTapPodInterfaceDriver(v, l),
+		memifDriver:     pod_interface.NewMemifPodInterfaceDriver(v, l),
+		vclDriver:       pod_interface.NewVclPodInterfaceDriver(v, l),
+		loopbackDriver:  pod_interface.NewLoopbackPodInterfaceDriver(v, l),
+		indexAllocator:  vpplink.NewIndexAllocator(common.PerPodVRFIndexStart),
 	}
 	pb.RegisterCniDataplaneServer(server.grpcServer, server)
 	l.Infof("Server starting")

--- a/calico-vpp-agent/cni/network_vpp.go
+++ b/calico-vpp-agent/cni/network_vpp.go
@@ -16,437 +16,153 @@
 package cni
 
 import (
-	"bytes"
 	"fmt"
-	"io"
-	"net"
-	"os"
-
-	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/pkg/errors"
 	"github.com/projectcalico/vpp-dataplane/calico-vpp-agent/cni/storage"
-	"github.com/projectcalico/vpp-dataplane/calico-vpp-agent/common"
 	"github.com/projectcalico/vpp-dataplane/calico-vpp-agent/config"
 	"github.com/projectcalico/vpp-dataplane/calico-vpp-agent/policy"
 	"github.com/projectcalico/vpp-dataplane/vpplink"
 	"github.com/projectcalico/vpp-dataplane/vpplink/types"
-	"github.com/vishvananda/netlink"
-	"golang.org/x/sys/unix"
 )
 
-// writeProcSys takes the sysctl path and a string value to set i.e. "0" or "1" and sets the sysctl.
-// This method was copied from cni-plugin/internal/pkg/utils/network_linux.go
-func writeProcSys(path, value string) error {
-	f, err := os.OpenFile(path, os.O_WRONLY, 0)
-	if err != nil {
-		return err
-	}
-	n, err := f.Write([]byte(value))
-	if err == nil && n < len(value) {
-		err = io.ErrShortWrite
-	}
-	if err1 := f.Close(); err == nil {
-		err = err1
-	}
-	return err
-}
-
-// configureContainerSysctls configures necessary sysctls required inside the container netns.
-// This method was adapted from cni-plugin/internal/pkg/utils/network_linux.go
-func (s *Server) configureContainerSysctls(podSpec *storage.LocalPodSpec) error {
-	hasv4, hasv6 := podSpec.Hasv46()
-	ipFwd := "0"
-	if podSpec.AllowIpForwarding {
-		ipFwd = "1"
-	}
-	// If an IPv4 address is assigned, then configure IPv4 sysctls.
-	if hasv4 {
-		s.log.Info("Configuring IPv4 forwarding")
-		if err := writeProcSys("/proc/sys/net/ipv4/ip_forward", ipFwd); err != nil {
-			return err
-		}
-	}
-	// If an IPv6 address is assigned, then configure IPv6 sysctls.
-	if hasv6 {
-		s.log.Info("Configuring IPv6 forwarding")
-		if err := writeProcSys("/proc/sys/net/ipv6/conf/all/forwarding", ipFwd); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// SetupRoutes sets up the routes for the host side of the veth pair.
-func (s *Server) SetupVppRoutes(swIfIndex uint32, podSpec *storage.LocalPodSpec) error {
-	// Go through all the IPs and add routes for each IP in the result.
-	for _, containerIP := range podSpec.GetContainerIps() {
-		route := types.Route{
-			Dst: containerIP,
-			Paths: []types.RoutePath{{
-				SwIfIndex: swIfIndex,
-			}},
-		}
-		s.log.Infof("Adding vpp route %s", route.String())
-		err := s.vpp.RouteAdd(&route)
-		if err != nil {
-			return errors.Wrapf(err, "Cannot add route in VPP")
-		}
-	}
-	return nil
-}
-
-func (s *Server) tunErrorCleanup(podSpec *storage.LocalPodSpec, err error, msg string, args ...interface{}) error {
-	s.log.Errorf("Error creating or configuring tun: %s", err)
-	delErr := s.DelVppInterface(podSpec)
-	if delErr != nil {
-		s.log.Errorf("Error deleting tun on error %s %v", podSpec.InterfaceName, delErr)
-	}
-	return errors.Wrapf(err, msg, args...)
-}
-
-func getMaxCIDRLen(isv6 bool) int {
-	if isv6 {
-		return 128
-	} else {
-		return 32
-	}
-}
-
-func getMaxCIDRMask(addr net.IP) net.IPMask {
-	maxCIDRLen := getMaxCIDRLen(vpplink.IsIP6(addr))
-	return net.CIDRMask(maxCIDRLen, maxCIDRLen)
-}
-
-func (s *Server) announceLocalAddress(addr *net.IPNet, isWithdrawal bool) {
-	s.routingServer.AnnounceLocalAddress(addr, isWithdrawal)
-}
-
-func (s *Server) configureNamespaceSideTun(swIfIndex uint32, podSpec *storage.LocalPodSpec) func(hostNS ns.NetNS) error {
-	return func(hostNS ns.NetNS) error {
-		contTun, err := netlink.LinkByName(podSpec.InterfaceName)
-		if err != nil {
-			return errors.Wrapf(err, "failed to lookup %q: %v", podSpec.InterfaceName, err)
-		}
-		hasv4, hasv6 := podSpec.Hasv46()
-
-		// Do the per-IP version set-up.  Add gateway routes etc.
-		if hasv6 {
-			s.log.Infof("tun %d in NS has v6", swIfIndex)
-			// Make sure ipv6 is enabled in the container/pod network namespace.
-			if err = writeProcSys("/proc/sys/net/ipv6/conf/all/disable_ipv6", "0"); err != nil {
-				return fmt.Errorf("failed to set net.ipv6.conf.all.disable_ipv6=0: %s", err)
-			}
-			if err = writeProcSys("/proc/sys/net/ipv6/conf/default/disable_ipv6", "0"); err != nil {
-				return fmt.Errorf("failed to set net.ipv6.conf.default.disable_ipv6=0: %s", err)
-			}
-			if err = writeProcSys("/proc/sys/net/ipv6/conf/lo/disable_ipv6", "0"); err != nil {
-				return fmt.Errorf("failed to set net.ipv6.conf.lo.disable_ipv6=0: %s", err)
-			}
-		}
-
-		for _, route := range podSpec.GetRoutes() {
-			isV6 := route.IP.To4() == nil
-			if (isV6 && !hasv6) || (!isV6 && !hasv4) {
-				s.log.Infof("Skipping tun[%d] route for %s", swIfIndex, route.String())
-				continue
-			}
-			s.log.Infof("Add tun[%d] linux%d route for %s", swIfIndex, contTun.Attrs().Index, route.String())
-			err = netlink.RouteAdd(&netlink.Route{
-				LinkIndex: contTun.Attrs().Index,
-				Scope:     netlink.SCOPE_UNIVERSE,
-				Dst:       route,
-			})
-			if err != nil {
-				// TODO : in ipv6 '::' already exists
-				s.log.Errorf("Error adding tun[%d] route for %s", swIfIndex, route.String())
-			}
-		}
-
-		// Now add the IPs to the container side of the tun.
-		for _, containerIP := range podSpec.GetContainerIps() {
-			s.log.Infof("Add tun[%d] linux%d ip %s", swIfIndex, contTun.Attrs().Index, containerIP.String())
-			err = netlink.AddrAdd(contTun, &netlink.Addr{IPNet: containerIP})
-			if err != nil {
-				return errors.Wrapf(err, "failed to add IP addr to %s: %v", contTun.Attrs().Name, err)
-			}
-			s.announceLocalAddress(containerIP, false /* isWithdrawal */)
-		}
-
-		if err = s.configureContainerSysctls(podSpec); err != nil {
-			return errors.Wrapf(err, "error configuring sysctls for the container netns, error: %s", err)
-		}
-
-		return nil
-	}
-}
-
-func (s *Server) PodSpecNeedsSnat(ps *storage.LocalPodSpec) (needsSnat bool) {
-	needsSnat = false
-	for _, containerIP := range ps.GetContainerIps() {
-		needsSnat = needsSnat || s.IPNetNeedsSNAT(containerIP)
-	}
-	return needsSnat
+func getInterfaceVrfName(podSpec *storage.LocalPodSpec, suffix string) string {
+	return fmt.Sprintf("pod-%s-table-%s", podSpec.Key(), suffix)
 }
 
 // AddVppInterface performs the networking for the given config and IPAM result
-func (s *Server) AddVppInterface(podSpec *storage.LocalPodSpec, doHostSideConf bool) (swIfIndex uint32, err error) {
-	// Select the first 11 characters of the containerID for the host veth.
-	tunTag := podSpec.NetnsName + "-" + podSpec.InterfaceName
+func (s *Server) AddVppInterface(podSpec *storage.LocalPodSpec, doHostSideConf bool) (tunTapSwIfIndex uint32, err error) {
+	podSpec.NeedsSnat = false
+	for _, containerIP := range podSpec.GetContainerIps() {
+		podSpec.NeedsSnat = podSpec.NeedsSnat || s.IPNetNeedsSNAT(containerIP)
+	}
 
-	s.log.Infof("Creating container interface using VPP networking")
-	s.log.Infof("Setting tun tag to %s", tunTag)
+	stack := s.vpp.NewCleanupStack()
 
-	// Clean up old tun if one is found with this tag
-	err, swIfIndex = s.vpp.SearchInterfaceWithTag(tunTag)
+	s.log.Infof("Creating Pod VRF")
+	err = s.CreatePodVRF(podSpec, stack)
 	if err != nil {
-		s.log.Errorf("Error while searching tun %s : %v", tunTag, err)
-	} else if swIfIndex != vpplink.INVALID_SW_IF_INDEX {
-		return swIfIndex, nil
+		goto err
 	}
 
-	// configure MTU from env var if present or calculate it from host mtu
-	var podMtu = podSpec.Mtu
-	if podMtu <= 0 {
-		podMtu = config.PodMtu
-	}
-	s.log.Debugf("Add request pod MTU: %d, computed %d", podSpec.Mtu, podMtu)
-
-	// Create new tun
-	tun := &types.TapV2{
-		GenericVppInterface: types.GenericVppInterface{
-			NumRxQueues:       config.TapNumRxQueues,
-			NumTxQueues:       config.TapNumTxQueues,
-			RxQueueSize:       config.TapRxQueueSize,
-			TxQueueSize:       config.TapTxQueueSize,
-			HostInterfaceName: podSpec.InterfaceName,
-		},
-		HostNamespace: podSpec.NetnsName,
-		Tag:           tunTag,
-		Flags:         types.TapFlagTun,
-		HostMtu:       podMtu,
-	}
-	if config.TapGSOEnabled {
-		tun.Flags |= types.TapFlagGSO | types.TapGROCoalesce
-	}
-	swIfIndex, err = s.vpp.CreateOrAttachTapV2(tun)
+	s.log.Infof("Creating Pod loopback")
+	err = s.loopbackDriver.CreateInterface(podSpec, stack)
 	if err != nil {
-		return 0, s.tunErrorCleanup(podSpec, err, "Error creating tun")
+		goto err
 	}
-	s.log.Infof("created tun[%d]", swIfIndex)
 
-	nbDataThread := int(s.NumVPPWorkers)
-	if config.IpsecNbAsyncCryptoThread > 0 {
-		nbDataThread = s.NumVPPWorkers - config.IpsecNbAsyncCryptoThread
-		if nbDataThread <= 0 {
-			s.log.Error("Couldn't fullfill request [crypto=%d total=%d]", config.IpsecNbAsyncCryptoThread, s.NumVPPWorkers)
-			nbDataThread = s.NumVPPWorkers
+	s.log.Infof("Creating Pod tuntap")
+	err = s.tuntapDriver.CreateInterface(podSpec, stack, doHostSideConf)
+	if err != nil {
+		goto err
+	}
+
+	if podSpec.EnableMemif && config.MemifEnabled {
+		s.log.Infof("Creating Pod memif")
+		err := s.memifDriver.CreateInterface(podSpec, stack)
+		if err != nil {
+			goto err
 		}
-		s.log.Info("Using [data=%d crypto=%d]", nbDataThread, s.NumVPPWorkers-nbDataThread)
-
 	}
 
-	if nbDataThread > 0 {
-		for i := 0; i < tun.NumRxQueues; i++ {
-			worker := (int(swIfIndex)*tun.NumRxQueues+i) % nbDataThread
-			err = s.vpp.SetInterfaceRxPlacement(swIfIndex, i, worker, false)
+	if podSpec.EnableVCL && config.VCLEnabled {
+		s.log.Infof("Creating Pod VCL socket")
+		err = s.vclDriver.CreateInterface(podSpec, stack)
+		if err != nil {
+			goto err
+		}
+	}
+
+	/* Routes */
+	if podSpec.EnableVCL {
+		s.log.Infof("Setting up Pod Punt routes")
+		err = s.SetupPuntRoutes(podSpec, stack, podSpec.TunTapSwIfIndex)
+		if err != nil {
+			goto err
+		}
+		err = s.CreateVRFRoutesToPod(podSpec, stack)
+		if err != nil {
+			goto err
+		}
+	} else {
+		swIfIndex, isL3 := podSpec.GetParamsForIfType(podSpec.DefaultIfType)
+		if swIfIndex != types.InvalidID {
+			s.log.Infof("Adding Pod default routes to %d l3?:%t", swIfIndex, isL3)
+			err = s.RoutePodInterface(podSpec, stack, swIfIndex, isL3)
 			if err != nil {
-				s.log.Warnf("failed to set tun[%d] queue%d worker%d (tot workers %d): %v", swIfIndex, i, worker, nbDataThread, err)
+				goto err
+			}
+		} else {
+			s.log.Warn("No default if type for pod")
+		}
+
+		swIfIndex, isL3 = podSpec.GetParamsForIfType(podSpec.PortFilteredIfType)
+		if swIfIndex != types.InvalidID {
+			s.log.Infof("Adding Pod PBL routes to %d l3?:%t", swIfIndex, isL3)
+			err = s.RoutePblPortsPodInterface(podSpec, stack, swIfIndex, isL3)
+			if err != nil {
+				goto err
 			}
 		}
 	}
 
-	// configure vpp side tun
-	for _, ipFamily := range vpplink.IpFamilies {
-		err = s.vpp.SetInterfaceVRF(swIfIndex, common.PodVRFIndex, ipFamily.IsIp6)
-		if err != nil {
-			return 0, s.tunErrorCleanup(podSpec, err, "error setting vpp tun %d in pod vrf", swIfIndex)
-		}
+	s.log.Infof("Announcing Pod Addresses")
+	for _, containerIP := range podSpec.GetContainerIps() {
+		s.routingServer.AnnounceLocalAddress(containerIP, false /* isWithdrawal */)
 	}
-
-	err = s.vpp.InterfaceSetUnnumbered(swIfIndex, config.DataInterfaceSwIfIndex)
-	if err != nil {
-		return 0, s.tunErrorCleanup(podSpec, err, "error setting vpp tun %d unnumbered", swIfIndex)
-	}
-	hasv4, hasv6 := podSpec.Hasv46()
-	needsSnat := s.PodSpecNeedsSnat(podSpec)
-	if hasv4 && needsSnat {
-		s.log.Infof("Enable tun[%d] SNAT v4", swIfIndex)
-		err = s.vpp.EnableCnatSNAT(swIfIndex, false)
-		if err != nil {
-			return 0, s.tunErrorCleanup(podSpec, err, "Error enabling ip4 snat")
-		}
-	}
-	if hasv6 && needsSnat {
-		s.log.Infof("Enable tun[%d] SNAT v6", swIfIndex)
-		err = s.vpp.EnableCnatSNAT(swIfIndex, true)
-		if err != nil {
-			return 0, s.tunErrorCleanup(podSpec, err, "Error enabling ip6 snat")
-		}
-	}
-
-	err = s.vpp.SetInterfaceMtu(swIfIndex, vpplink.MAX_MTU)
-	if err != nil {
-		return 0, s.tunErrorCleanup(podSpec, err, "Error setting MTU on tun interface")
-	}
-
-	err = s.vpp.RegisterPodInterface(swIfIndex)
-	if err != nil {
-		return 0, s.tunErrorCleanup(podSpec, err, "error registering pod interface")
-	}
-
-	err = s.vpp.CnatEnableFeatures(swIfIndex)
-	if err != nil {
-		return 0, s.tunErrorCleanup(podSpec, err, "error configuring nat on pod interface")
-	}
-
-	if doHostSideConf {
-		err = ns.WithNetNSPath(podSpec.NetnsName, s.configureNamespaceSideTun(swIfIndex, podSpec))
-		if err != nil {
-			return 0, s.tunErrorCleanup(podSpec, err, "Error enabling ip6")
-		}
-	}
-
-	err = s.vpp.InterfaceAdminUp(swIfIndex)
-	if err != nil {
-		return 0, s.tunErrorCleanup(podSpec, err, "error setting new tun up")
-	}
-
-	// Now that the host side of the veth is moved, state set to UP, and configured with sysctls, we can add the routes to it in the host namespace.
-	err = s.SetupVppRoutes(swIfIndex, podSpec)
-	if err != nil {
-		return 0, s.tunErrorCleanup(podSpec, err, "error adding vpp side routes for interface: %s", tunTag)
-	}
-
-	err = s.vpp.SetInterfaceRxMode(swIfIndex, types.AllQueues, config.TapRxMode)
-	if err != nil {
-		return 0, s.tunErrorCleanup(podSpec, err, "error SetInterfaceRxMode on tun interface")
-	}
-
-	s.log.Infof("Setup tun[%d] complete", swIfIndex)
 
 	s.policyServer.WorkloadAdded(&policy.WorkloadEndpointID{
 		OrchestratorID: podSpec.OrchestratorID,
 		WorkloadID:     podSpec.WorkloadID,
 		EndpointID:     podSpec.EndpointID,
-	}, swIfIndex)
+	}, podSpec.TunTapSwIfIndex)
 
-	return swIfIndex, err
-}
+	return podSpec.TunTapSwIfIndex, err
 
-func (s *Server) delVppInterfaceHandleRoutes(swIfIndex uint32, isIPv6 bool) error {
-	// Delete connected routes
-	// TODO: Make TableID configurable?
-	routes, err := s.vpp.GetRoutes(0, isIPv6)
-	if err != nil {
-		return errors.Wrap(err, "GetRoutes errored")
-	}
-	for _, route := range routes {
-		// Our routes aren't multipath
-		if len(route.Paths) != 1 {
-			continue
-		}
-		// Filter routes we don't want to delete
-		if route.Paths[0].SwIfIndex != swIfIndex {
-			continue // Routes on other interfaces
-		}
-		maskSize, _ := route.Dst.Mask.Size()
-		if isIPv6 {
-			if maskSize != 128 {
-				continue
-			}
-			if bytes.Equal(route.Dst.IP[0:2], []uint8{0xfe, 0x80}) {
-				continue // Link locals
-			}
-		} else {
-			if maskSize != 32 {
-				continue
-			}
-			if bytes.Equal(route.Dst.IP[0:2], []uint8{169, 254}) {
-				continue // Addresses configured on VPP side
-			}
-		}
+err:
+	stack.Execute()
+	return vpplink.InvalidID, errors.Wrapf(err, "Error creating interface")
 
-		s.log.Infof("Delete VPP route %s", route.String())
-		err = s.vpp.RouteDel(&route)
-		if err != nil {
-			s.log.Errorf("Delete VPP route %s errored: %v", route.String(), err)
-		}
-	}
-	return nil
 }
 
 // CleanUpVPPNamespace deletes the devices in the network namespace.
-func (s *Server) DelVppInterface(podSpec *storage.LocalPodSpec) error {
-	// Only try to delete the device if a namespace was passed in.
-	if podSpec.NetnsName == "" {
-		s.log.Infof("no netns passed, skipping")
-		return nil
+func (s *Server) DelVppInterface(podSpec *storage.LocalPodSpec) {
+
+	for _, containerIP := range podSpec.GetContainerIps() {
+		s.routingServer.AnnounceLocalAddress(containerIP, true /* isWithdrawal */)
 	}
 
-	devErr := ns.WithNetNSPath(podSpec.NetnsName, func(_ ns.NetNS) error {
-		dev, err := netlink.LinkByName(podSpec.InterfaceName)
-		if err != nil {
-			return err
+	/* Routes */
+	if podSpec.EnableVCL {
+		if podSpec.TunTapSwIfIndex != vpplink.InvalidID {
+			s.log.Infof("Deleting routes to podVRF")
+			s.DeleteVRFRoutesToPod(podSpec)
+			s.log.Infof("Deleting Pod punt routes")
+			s.RemovePuntRoutes(podSpec, podSpec.TunTapSwIfIndex)
 		}
-		addresses, err := netlink.AddrList(dev, netlink.FAMILY_ALL)
-		if err != nil {
-			return err
+	} else {
+		swIfIndex, _ := podSpec.GetParamsForIfType(podSpec.PortFilteredIfType)
+		if swIfIndex != types.InvalidID {
+			s.log.Infof("Deleting Pod PBL routes to %d", swIfIndex)
+			s.UnroutePblPortsPodInterface(podSpec, swIfIndex)
 		}
-		for _, addr := range addresses {
-			s.log.Infof("Found address %s on interface, scope %d", addr.IP.String(), addr.Scope)
-			if addr.Scope == unix.RT_SCOPE_LINK {
-				continue
-			}
-			s.announceLocalAddress(&net.IPNet{IP: addr.IP, Mask: addr.Mask}, true /* isWithdrawal */)
-		}
-		return nil
-	})
-	if devErr != nil {
-		switch devErr.(type) {
-		case netlink.LinkNotFoundError:
-			s.log.Infof("Device to delete not found")
-			return nil
-		default:
-			s.log.Warnf("error withdrawing interface addresses: %v", devErr)
-			return errors.Wrap(devErr, "error withdrawing interface addresses")
+		swIfIndex, _ = podSpec.GetParamsForIfType(podSpec.DefaultIfType)
+		if swIfIndex != types.InvalidID {
+			s.log.Infof("Deleting Pod default routes to %d", swIfIndex)
+			s.UnroutePodInterface(podSpec, swIfIndex)
 		}
 	}
 
-	tag := podSpec.NetnsName + "-" + podSpec.InterfaceName
-	s.log.Infof("looking for tag %s", tag)
-	err, swIfIndex := s.vpp.SearchInterfaceWithTag(tag)
-	if err != nil {
-		return errors.Wrapf(err, "error searching interface with tag %s", tag)
-	} else if swIfIndex == vpplink.INVALID_SW_IF_INDEX {
-		return errors.Wrapf(err, "No interface found with tag %s", tag)
-	}
+	/* Interfaces */
+	s.log.Infof("Deleting Pod VCL")
+	s.vclDriver.DeleteInterface(podSpec)
+	s.log.Infof("Deleting Pod memif")
+	s.memifDriver.DeleteInterface(podSpec)
+	s.log.Infof("Deleting Pod tuntap")
+	s.tuntapDriver.DeleteInterface(podSpec)
 
-	s.log.Infof("found matching VPP tun[%d]", swIfIndex)
-	err = s.vpp.InterfaceAdminDown(swIfIndex)
-	if err != nil {
-		return errors.Wrap(err, "InterfaceAdminDown errored")
-	}
+	s.log.Infof("Deleting Pod loopback")
+	s.loopbackDriver.DeleteInterface(podSpec)
 
-	err = s.delVppInterfaceHandleRoutes(swIfIndex, true /* isIp6 */)
-	if err != nil {
-		return errors.Wrap(err, "Error deleting ip6 routes")
-	}
-	err = s.delVppInterfaceHandleRoutes(swIfIndex, false /* isIp6 */)
-	if err != nil {
-		return errors.Wrap(err, "Error deleting ip4 routes")
-	}
-
-	err = s.vpp.RemovePodInterface(swIfIndex)
-	if err != nil {
-		s.log.Errorf("error deregistering pod interface: %v", err)
-	}
-
-	// Delete tun
-	err = s.vpp.DelTap(swIfIndex)
-	if err != nil {
-		return errors.Wrap(err, "tun deletion failed")
-	}
-	s.log.Infof("deleted tun[%d]", swIfIndex)
-
-	return nil
+	s.log.Infof("Deleting Pod VRF")
+	s.DeletePodVRF(podSpec)
 }

--- a/calico-vpp-agent/cni/network_vpp_routes.go
+++ b/calico-vpp-agent/cni/network_vpp_routes.go
@@ -1,0 +1,252 @@
+// Copyright (C) 2021 Cisco Systems Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cni
+
+import (
+	"github.com/pkg/errors"
+	"github.com/projectcalico/vpp-dataplane/calico-vpp-agent/cni/storage"
+	"github.com/projectcalico/vpp-dataplane/calico-vpp-agent/common"
+	"github.com/projectcalico/vpp-dataplane/calico-vpp-agent/config"
+	"github.com/projectcalico/vpp-dataplane/vpplink"
+	"github.com/projectcalico/vpp-dataplane/vpplink/types"
+)
+
+func (s *Server) RoutePodInterface(podSpec *storage.LocalPodSpec, stack *vpplink.CleanupStack, swIfIndex uint32, isL3 bool) error {
+	for _, containerIP := range podSpec.GetContainerIps() {
+		route := types.Route{
+			Dst: containerIP,
+			Paths: []types.RoutePath{{
+				SwIfIndex: swIfIndex,
+			}},
+		}
+		s.log.Infof("Add route [podVRF ->MainIF] %s", route.String())
+		err := s.vpp.RouteAdd(&route)
+		if err != nil {
+			return errors.Wrapf(err, "Cannot adding route [podVRF ->MainIF] %s", route.String())
+		} else {
+			stack.Push(s.vpp.RouteDel, &route)
+		}
+		if !isL3 {
+			s.log.Infof("Adding neighbor if[%d] %s", swIfIndex, containerIP.IP.String())
+			err = s.vpp.AddNeighbor(&types.Neighbor{
+				SwIfIndex:    swIfIndex,
+				IP:           containerIP.IP,
+				HardwareAddr: config.ContainerSideMacAddress,
+			})
+			if err != nil {
+				return errors.Wrapf(err, "Error adding neighbor if[%d] %s", swIfIndex, containerIP.IP.String())
+			}
+		}
+	}
+	return nil
+}
+
+func (s *Server) UnroutePodInterface(podSpec *storage.LocalPodSpec, swIfIndex uint32) {
+	for _, containerIP := range podSpec.GetContainerIps() {
+		route := types.Route{
+			Dst: containerIP,
+			Paths: []types.RoutePath{{
+				SwIfIndex: swIfIndex,
+			}},
+		}
+		s.log.Infof("Del route [podVRF ->MainIF] %s", route.String())
+		err := s.vpp.RouteDel(&route)
+		if err != nil {
+			s.log.Warnf("Error deleting route [podVRF ->MainIF] %s : %s", route.String(), err)
+		}
+	}
+}
+
+func (s *Server) RoutePblPortsPodInterface(podSpec *storage.LocalPodSpec, stack *vpplink.CleanupStack, swIfIndex uint32, isL3 bool) (err error) {
+	for _, containerIP := range podSpec.GetContainerIps() {
+		path := types.RoutePath{
+			SwIfIndex: swIfIndex,
+		}
+		if !isL3 {
+			path.Gw = containerIP.IP
+		}
+
+		portRanges := make([]types.PblPortRange, 0)
+		for _, pc := range podSpec.IfPortConfigs {
+			portRanges = append(portRanges, types.PblPortRange{
+				Start: pc.Start,
+				End:   pc.End,
+				Proto: pc.Proto,
+			})
+		}
+
+		client := types.PblClient{
+			ID: vpplink.InvalidID,
+			// TableId:    podSpec.VrfId,
+			Addr:       containerIP.IP,
+			Path:       path,
+			PortRanges: portRanges,
+		}
+		s.log.Infof("Adding PBL client for %s VRF %d", containerIP.IP, podSpec.VrfId)
+		pblIndex, err := s.vpp.AddPblClient(&client)
+		if err != nil {
+			return errors.Wrapf(err, "error adding PBL client for %s VRF %d", containerIP.IP, podSpec.VrfId)
+		} else {
+			stack.Push(s.vpp.DelPblClient, pblIndex)
+		}
+		podSpec.PblIndexes = append(podSpec.PblIndexes, pblIndex)
+
+		if !isL3 {
+			s.log.Infof("Adding neighbor if[%d] %s", swIfIndex, containerIP.IP.String())
+			err = s.vpp.AddNeighbor(&types.Neighbor{
+				SwIfIndex:    swIfIndex,
+				IP:           containerIP.IP,
+				HardwareAddr: config.ContainerSideMacAddress,
+			})
+			if err != nil {
+				return errors.Wrapf(err, "Cannot adding neighbor if[%d] %s", swIfIndex, containerIP.IP.String())
+			}
+		}
+	}
+	return nil
+}
+
+func (s *Server) UnroutePblPortsPodInterface(podSpec *storage.LocalPodSpec, swIfIndex uint32) {
+	for _, pblIndex := range podSpec.PblIndexes {
+		s.log.Infof("Deleting PBL client[%d]", pblIndex)
+		err := s.vpp.DelPblClient(pblIndex)
+		if err != nil {
+			s.log.Warnf("Error deleting pbl conf %s", err)
+		}
+	}
+}
+
+func (s *Server) CreatePodVRF(podSpec *storage.LocalPodSpec, stack *vpplink.CleanupStack) (err error) {
+	/* Create and Setup the per-pod VRF */
+	for _, ipFamily := range vpplink.IpFamilies {
+		s.log.Infof("Adding VRF %d %s", podSpec.VrfId, ipFamily.Str)
+		vrfName := getInterfaceVrfName(podSpec, ipFamily.Str)
+		err = s.vpp.AddVRF(podSpec.VrfId, ipFamily.IsIp6, vrfName)
+		if err != nil {
+			return errors.Wrapf(err, "error adding VRF %d %s", podSpec.VrfId, ipFamily.Str)
+		} else {
+			stack.Push(s.vpp.DelVRF, podSpec.VrfId, ipFamily.IsIp6, vrfName)
+		}
+	}
+
+	for _, ipFamily := range vpplink.IpFamilies {
+		s.log.Infof("Adding VRF %d %s default route via VRF %d", podSpec.VrfId, ipFamily.Str, common.PodVRFIndex)
+		err = s.vpp.AddDefaultRouteViaTable(podSpec.VrfId, common.PodVRFIndex, ipFamily.IsIp6)
+		if err != nil {
+			return errors.Wrapf(err, "error adding VRF %d %s default route via VRF %d", podSpec.VrfId, ipFamily.Str, common.PodVRFIndex)
+		} else {
+			stack.Push(s.vpp.DelDefaultRouteViaTable, podSpec.VrfId, common.PodVRFIndex, ipFamily.IsIp6)
+		}
+	}
+	return nil
+}
+
+func (s *Server) DeletePodVRF(podSpec *storage.LocalPodSpec) {
+	var err error
+	for _, ipFamily := range vpplink.IpFamilies {
+		s.log.Infof("Deleting VRF %d %s default route via VRF %d", podSpec.VrfId, ipFamily.Str, common.PodVRFIndex)
+		err = s.vpp.DelDefaultRouteViaTable(podSpec.VrfId, common.PodVRFIndex, ipFamily.IsIp6)
+		if err != nil {
+			s.log.Errorf("Error  VRF %d %s default route via VRF %d : %s", podSpec.VrfId, ipFamily.Str, common.PodVRFIndex, err)
+		}
+	}
+
+	for _, ipFamily := range vpplink.IpFamilies {
+		vrfName := getInterfaceVrfName(podSpec, ipFamily.Str)
+		s.log.Infof("Deleting VRF %d %s", podSpec.VrfId, ipFamily.Str)
+		err = s.vpp.DelVRF(podSpec.VrfId, ipFamily.IsIp6, vrfName)
+		if err != nil {
+			s.log.Errorf("Error deleting VRF %d %s : %s", podSpec.VrfId, ipFamily.Str, err)
+		}
+	}
+}
+
+func (s *Server) CreateVRFRoutesToPod(podSpec *storage.LocalPodSpec, stack *vpplink.CleanupStack) (err error) {
+	for _, containerIP := range podSpec.GetContainerIps() {
+		/* In the main table route the container address to its VRF */
+		route := types.Route{
+			Dst: containerIP,
+			Paths: []types.RoutePath{{
+				Table:     podSpec.VrfId,
+				SwIfIndex: types.InvalidID,
+			}},
+		}
+		s.log.Infof("Adding route [mainVRF ->PodVRF] %s", route.String())
+		err := s.vpp.RouteAdd(&route)
+		if err != nil {
+			return errors.Wrapf(err, "error adding route [mainVRF ->PodVRF] %s", route.String())
+		} else {
+			stack.Push(s.vpp.RouteDel, &route)
+		}
+	}
+	return nil
+}
+
+func (s *Server) DeleteVRFRoutesToPod(podSpec *storage.LocalPodSpec) {
+	var err error = nil
+	for _, containerIP := range podSpec.GetContainerIps() {
+		/* In the main table route the container address to its VRF */
+		route := types.Route{
+			Dst: containerIP,
+			Paths: []types.RoutePath{{
+				Table:     podSpec.VrfId,
+				SwIfIndex: types.InvalidID,
+			}},
+		}
+		s.log.Infof("Deleting route [mainVRF ->PodVRF] %s", route.String())
+		err = s.vpp.RouteDel(&route)
+		if err != nil {
+			s.log.Errorf("error deleting vpp side routes route [mainVRF ->PodVRF] %s : %s", route.String(), err)
+		}
+	}
+}
+
+func (s *Server) SetupPuntRoutes(podSpec *storage.LocalPodSpec, stack *vpplink.CleanupStack, swIfIndex uint32) (err error) {
+	for _, containerIP := range podSpec.GetContainerIps() {
+		/* In the punt table (where all punted traffics ends),
+		 * route the container to the tun */
+		route := types.Route{
+			Table: common.PuntTableId,
+			Dst:   containerIP,
+			Paths: []types.RoutePath{{SwIfIndex: swIfIndex}},
+		}
+		s.log.Infof("Adding route [puntVRF ->PuntIF] %s", route.String())
+		err = s.vpp.RouteAdd(&route)
+		if err != nil {
+			return errors.Wrapf(err, "error adding vpp side routes for interface")
+		} else {
+			stack.Push(s.vpp.RouteDel, &route)
+		}
+	}
+	return nil
+}
+
+func (s *Server) RemovePuntRoutes(podSpec *storage.LocalPodSpec, swIfIndex uint32) {
+	var err error = nil
+	for _, containerIP := range podSpec.GetContainerIps() {
+		/* In the punt table (where all punted traffics ends), route the container to the tun */
+		route := types.Route{
+			Table: common.PuntTableId,
+			Dst:   containerIP,
+			Paths: []types.RoutePath{{SwIfIndex: swIfIndex}},
+		}
+		s.log.Infof("Deleting route [puntVRF ->PuntIF] %s", route.String())
+		err = s.vpp.RouteDel(&route)
+		if err != nil {
+			s.log.Errorf("error deleting route [puntVRF ->PuntIF] %s : %s", route.String(), err)
+		}
+	}
+}

--- a/calico-vpp-agent/cni/pod_annotations.go
+++ b/calico-vpp-agent/cni/pod_annotations.go
@@ -1,0 +1,152 @@
+// Copyright (C) 2021 Cisco Systems Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cni
+
+import (
+	"fmt"
+	"github.com/pkg/errors"
+	"github.com/projectcalico/vpp-dataplane/calico-vpp-agent/cni/storage"
+	"github.com/projectcalico/vpp-dataplane/vpplink/types"
+	"strconv"
+	"strings"
+)
+
+const (
+	VppAnnotationPrefix  string = "cni.projectcalico.org-vpp."
+	MemifPortAnnotation  string = "memif.ports"
+	TunTapPortAnnotation string = "tuntap.ports"
+	Memifl3Annotation  string = "memif.l3"
+	TunTapl3Annotation string = "tuntap.l3"
+	VclAnnotation        string = "vcl"
+)
+
+func (s *Server) ParsePortSpec(value string) (ifPortConfigs *storage.LocalIfPortConfigs, err error) {
+	ifPortConfigs = &storage.LocalIfPortConfigs{}
+	parts := strings.Split(value, ":") /* tcp:1234[-4567] */
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("Value should start with protocol e.g. 'tcp:'")
+	}
+	ifPortConfigs.Proto, err = types.UnformatProto(parts[0])
+	if err != nil {
+		return nil, errors.Wrapf(err, "Error parsing proto %s", parts[0])
+	}
+
+	portParts := strings.Split(parts[1], "-") /* tcp:1234[-4567] */
+	if len(portParts) != 2 && len(portParts) != 1 {
+		return nil, fmt.Errorf("Please specify a port or a port range e.g. '1234-5678'")
+	}
+
+	start, err := strconv.ParseInt(portParts[0], 10, 32)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Error parsing port %s", portParts[0])
+	}
+	ifPortConfigs.Start = uint16(start)
+	ifPortConfigs.End = uint16(start)
+
+	if len(portParts) == 2 {
+		end, err := strconv.ParseInt(portParts[1], 10, 32)
+		if err != nil {
+			return nil, errors.Wrapf(err, "Error parsing end port %s", portParts[1])
+		}
+		ifPortConfigs.End = uint16(end)
+	}
+	return ifPortConfigs, nil
+}
+
+func (s *Server) ParsePortMappingAnnotation(podSpec *storage.LocalPodSpec, ifType storage.VppInterfaceType, value string) (err error) {
+	if podSpec.PortFilteredIfType != storage.VppIfTypeUnknown && podSpec.PortFilteredIfType != ifType {
+		return fmt.Errorf("Cannot use port filters on different interface type")
+	}
+	podSpec.PortFilteredIfType = ifType
+	// value is expected to be like "tcp:1234-1236,udp:4456"
+	portSpecs := strings.Split(value, ",")
+	for idx, portSpec := range portSpecs {
+		ifPortConfig, err := s.ParsePortSpec(portSpec)
+		if err != nil {
+			return errors.Wrapf(err, "Error parsing portSpec[%d] %s", idx, portSpec)
+		}
+		podSpec.IfPortConfigs = append(podSpec.IfPortConfigs, *ifPortConfig)
+	}
+	return nil
+}
+
+func (s *Server) ParseDefaultIfType(podSpec *storage.LocalPodSpec, ifType storage.VppInterfaceType) (err error) {
+	if podSpec.DefaultIfType != storage.VppIfTypeUnknown && podSpec.DefaultIfType != ifType {
+		return fmt.Errorf("Cannot set two different default interface type")
+	}
+	podSpec.DefaultIfType = ifType
+	return nil
+}
+
+func (s *Server) ParseEnableDisableAnnotation(value string) (bool, error) {
+	switch value {
+	case "enable":
+		return true, nil
+	case "disable":
+		return false, nil
+	default:
+		return false, errors.Errorf("Unknown value %s", value)
+	}
+}
+
+func (s *Server) ParseTrueFalseAnnotation(value string) (bool, error) {
+	switch value {
+	case "true":
+		return true, nil
+	case "false":
+		return false, nil
+	default:
+		return false, errors.Errorf("Unknown value %s", value)
+	}
+}
+
+func (s *Server) ParsePodAnnotations(podSpec *storage.LocalPodSpec, annotations map[string]string) (err error) {
+	for key, value := range annotations {
+		if !strings.HasPrefix(key, VppAnnotationPrefix) {
+			continue
+		}
+		switch key {
+		case VppAnnotationPrefix + MemifPortAnnotation:
+			podSpec.EnableMemif = true
+			if value == "default" {
+				err = s.ParseDefaultIfType(podSpec, storage.VppIfTypeMemif)
+			} else {
+				err = s.ParsePortMappingAnnotation(podSpec, storage.VppIfTypeMemif, value)
+			}
+		case VppAnnotationPrefix + TunTapPortAnnotation:
+			if value == "default" {
+				err = s.ParseDefaultIfType(podSpec, storage.VppIfTypeTunTap)
+			} else {
+				err = s.ParsePortMappingAnnotation(podSpec, storage.VppIfTypeTunTap, value)
+			}
+		case VppAnnotationPrefix + VclAnnotation:
+			podSpec.EnableVCL, err = s.ParseEnableDisableAnnotation(value)
+		case VppAnnotationPrefix + Memifl3Annotation:
+			podSpec.MemifIsL3, err = s.ParseTrueFalseAnnotation(value)
+		case VppAnnotationPrefix + TunTapl3Annotation:
+			podSpec.TunTapIsL3, err = s.ParseTrueFalseAnnotation(value)
+			if err != nil {
+				podSpec.TunTapIsL3 = true /* default on error */
+			}
+		default:
+			continue
+		}
+		if err != nil {
+			s.log.Warnf("Error parsing key %s %s", key, err)
+		}
+	}
+	return nil
+}

--- a/calico-vpp-agent/cni/pod_interface/common.go
+++ b/calico-vpp-agent/cni/pod_interface/common.go
@@ -1,0 +1,144 @@
+// Copyright (C) 2021 Cisco Systems Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pod_interface
+
+import (
+	"github.com/pkg/errors"
+	"github.com/projectcalico/vpp-dataplane/calico-vpp-agent/cni/storage"
+	"github.com/projectcalico/vpp-dataplane/calico-vpp-agent/config"
+	"github.com/projectcalico/vpp-dataplane/vpplink"
+	"github.com/projectcalico/vpp-dataplane/vpplink/types"
+	"github.com/sirupsen/logrus"
+)
+
+type PodInterfaceDriverData struct {
+	log          *logrus.Entry
+	vpp          *vpplink.VppLink
+	name         string
+	NDataThreads int
+}
+
+func (i *PodInterfaceDriverData) SearchPodInterface(podSpec *storage.LocalPodSpec) (swIfIndex uint32) {
+	tag := podSpec.GetInterfaceTag(i.name)
+	i.log.Infof("looking for tag %s", tag)
+	err, swIfIndex := i.vpp.SearchInterfaceWithTag(tag)
+	if err != nil {
+		i.log.Warnf("error searching interface with tag %s %s", tag, err)
+		return vpplink.InvalidID
+	} else if swIfIndex == vpplink.InvalidID {
+		return vpplink.InvalidID
+	}
+	return swIfIndex
+}
+
+func (i *PodInterfaceDriverData) UndoPodIfNatConfiguration(swIfIndex uint32) {
+	var err error
+	err = i.vpp.RemovePodInterface(swIfIndex)
+	if err != nil {
+		i.log.Errorf("error deregistering pod interface: %v", err)
+	}
+
+	for _, ipFamily := range vpplink.IpFamilies {
+		err = i.vpp.DisableCnatSNAT(swIfIndex, ipFamily.IsIp6)
+		if err != nil {
+			i.log.Errorf("Error disabling %s snat %v", ipFamily.Str, err)
+		}
+	}
+}
+
+func (i *PodInterfaceDriverData) DoPodIfNatConfiguration(podSpec *storage.LocalPodSpec, stack *vpplink.CleanupStack, swIfIndex uint32) (err error) {
+	if podSpec.NeedsSnat {
+		i.log.Infof("Enable interface[%d] SNAT", swIfIndex)
+		for _, ipFamily := range vpplink.IpFamilies {
+			err = i.vpp.EnableCnatSNAT(swIfIndex, ipFamily.IsIp6)
+			if err != nil {
+				return errors.Wrapf(err, "Error enabling %s snat", ipFamily.Str)
+			} else {
+				stack.Push(i.vpp.DisableCnatSNAT, swIfIndex, false)
+			}
+		}
+	}
+
+	err = i.vpp.RegisterPodInterface(swIfIndex)
+	if err != nil {
+		return errors.Wrapf(err, "error registering pod interface")
+	} else {
+		stack.Push(i.vpp.RemovePodInterface, swIfIndex)
+	}
+
+	err = i.vpp.CnatEnableFeatures(swIfIndex)
+	if err != nil {
+		return errors.Wrapf(err, "error configuring nat on pod interface")
+	}
+
+	return nil
+}
+
+func (i *PodInterfaceDriverData) UndoPodInterfaceConfiguration(swIfIndex uint32) {
+	err := i.vpp.InterfaceAdminDown(swIfIndex)
+	if err != nil {
+		i.log.Errorf("InterfaceAdminDown errored %s", err)
+	}
+}
+
+func (i *PodInterfaceDriverData) DoPodInterfaceConfiguration(podSpec *storage.LocalPodSpec, stack *vpplink.CleanupStack, swIfIndex uint32, isL3 bool) (err error) {
+	if i.NDataThreads > 0 {
+		for queue := 0; queue < config.TapNumRxQueues; queue++ {
+			worker := (int(swIfIndex)*config.TapNumRxQueues + queue) % i.NDataThreads
+			err = i.vpp.SetInterfaceRxPlacement(swIfIndex, queue, worker, false /*main*/)
+			if err != nil {
+				i.log.Warnf("failed to set if[%d] queue%d worker%d (tot workers %d): %v", swIfIndex, queue, worker, i.NDataThreads, err)
+			}
+		}
+	}
+
+	for _, ipFamily := range vpplink.IpFamilies {
+		err = i.vpp.SetInterfaceVRF(swIfIndex, podSpec.VrfId, ipFamily.IsIp6)
+		if err != nil {
+			return errors.Wrapf(err, "error setting vpp if[%d] in pod vrf", swIfIndex)
+		}
+	}
+
+	if !isL3 {
+		/* L2 */
+		err = i.vpp.SetPromiscOn(swIfIndex)
+		if err != nil {
+			return errors.Wrapf(err, "Error setting memif promisc")
+		}
+	}
+
+	err = i.vpp.SetInterfaceMtu(swIfIndex, vpplink.MAX_MTU)
+	if err != nil {
+		return errors.Wrapf(err, "Error setting MTU on pod interface")
+	}
+
+	err = i.vpp.InterfaceAdminUp(swIfIndex)
+	if err != nil {
+		return errors.Wrapf(err, "error setting new pod if up")
+	}
+
+	err = i.vpp.SetInterfaceRxMode(swIfIndex, types.AllQueues, config.TapRxMode)
+	if err != nil {
+		return errors.Wrapf(err, "error SetInterfaceRxMode on pod if interface")
+	}
+
+	err = i.vpp.InterfaceSetUnnumbered(swIfIndex, podSpec.LoopbackSwIfIndex)
+	if err != nil {
+		return errors.Wrapf(err, "error setting interface unnumbered")
+	}
+
+	return nil
+}

--- a/calico-vpp-agent/cni/pod_interface/loopback.go
+++ b/calico-vpp-agent/cni/pod_interface/loopback.go
@@ -1,0 +1,75 @@
+// Copyright (C) 2021 Cisco Systems Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pod_interface
+
+import (
+	"github.com/pkg/errors"
+
+	"github.com/projectcalico/vpp-dataplane/calico-vpp-agent/cni/storage"
+	"github.com/projectcalico/vpp-dataplane/calico-vpp-agent/config"
+	"github.com/projectcalico/vpp-dataplane/vpplink"
+	"github.com/sirupsen/logrus"
+)
+
+type LoopbackPodInterfaceDriver struct {
+	PodInterfaceDriverData
+}
+
+func NewLoopbackPodInterfaceDriver(vpp *vpplink.VppLink, log *logrus.Entry) *LoopbackPodInterfaceDriver {
+	i := &LoopbackPodInterfaceDriver{}
+	i.vpp = vpp
+	i.log = log
+	i.name = "loopback"
+	return i
+}
+
+func (i *LoopbackPodInterfaceDriver) CreateInterface(podSpec *storage.LocalPodSpec, stack *vpplink.CleanupStack) (err error) {
+	swIfIndex, err := i.vpp.CreateLoopback(&config.ContainerSideMacAddress)
+	if err != nil {
+		return errors.Wrapf(err, "Error creating loopback")
+	} else {
+		stack.Push(i.vpp.DeleteLoopback, swIfIndex)
+	}
+	podSpec.LoopbackSwIfIndex = swIfIndex
+
+	for _, ipFamily := range vpplink.IpFamilies {
+		err = i.vpp.SetInterfaceVRF(swIfIndex, podSpec.VrfId, ipFamily.IsIp6)
+		if err != nil {
+			return errors.Wrapf(err, "Error setting loopback %d in per pod vrf", swIfIndex)
+		}
+	}
+
+	err = i.DoPodIfNatConfiguration(podSpec, stack, podSpec.LoopbackSwIfIndex)
+	if err != nil {
+		return err
+	}
+
+	for _, containerIP := range podSpec.GetContainerIps() {
+		err = i.vpp.AddInterfaceAddress(swIfIndex, containerIP)
+		if err != nil {
+			return errors.Wrapf(err, "Error adding address %s to pod loopback interface", containerIP)
+		}
+	}
+
+	return nil
+}
+
+func (i *LoopbackPodInterfaceDriver) DeleteInterface(podSpec *storage.LocalPodSpec) {
+	err := i.vpp.DeleteLoopback(podSpec.LoopbackSwIfIndex)
+	if err != nil {
+		i.log.Errorf("Error deleting Loopback %s", err)
+	}
+}

--- a/calico-vpp-agent/cni/pod_interface/memif.go
+++ b/calico-vpp-agent/cni/pod_interface/memif.go
@@ -1,0 +1,122 @@
+// Copyright (C) 2021 Cisco Systems Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pod_interface
+
+import (
+	"github.com/pkg/errors"
+	"github.com/projectcalico/vpp-dataplane/calico-vpp-agent/cni/storage"
+	"github.com/projectcalico/vpp-dataplane/calico-vpp-agent/config"
+	"github.com/projectcalico/vpp-dataplane/vpplink"
+	"github.com/projectcalico/vpp-dataplane/vpplink/types"
+	"github.com/sirupsen/logrus"
+)
+
+type MemifPodInterfaceDriver struct {
+	PodInterfaceDriverData
+}
+
+func NewMemifPodInterfaceDriver(vpp *vpplink.VppLink, log *logrus.Entry) *MemifPodInterfaceDriver {
+	i := &MemifPodInterfaceDriver{}
+	i.vpp = vpp
+	i.log = log
+	i.name = "memif"
+	return i
+}
+
+func (i *MemifPodInterfaceDriver) CreateInterface(podSpec *storage.LocalPodSpec, stack *vpplink.CleanupStack) (err error) {
+	swIfIndex := i.SearchPodInterface(podSpec)
+	if swIfIndex != vpplink.InvalidID {
+		/* If something is found under this name, try a cleanup before going on */
+		i.DeleteInterface(podSpec)
+	}
+
+	socketId, err := i.vpp.AddMemifSocketFileName("@memif", podSpec.NetnsName)
+	if err != nil {
+		return err
+	} else {
+		stack.Push(i.vpp.DelMemifSocketFileName, socketId)
+	}
+	podSpec.MemifSocketId = socketId
+
+	// Create new tun
+	memif := &types.Memif{
+		Role:        types.MemifMaster,
+		Mode:        types.MemifModeEthernet,
+		NumRxQueues: config.TapNumRxQueues,
+		NumTxQueues: config.TapNumTxQueues,
+		QueueSize:   config.TapRxQueueSize,
+		SocketId:    socketId,
+	}
+	if podSpec.MemifIsL3 {
+		memif.Mode = types.MemifModeIP
+	}
+
+	err = i.vpp.CreateMemif(memif)
+	if err != nil {
+		return err
+	} else {
+		stack.Push(i.vpp.DeleteMemif, memif.SwIfIndex)
+	}
+	podSpec.MemifSwIfIndex = memif.SwIfIndex
+
+	err = i.vpp.SetInterfaceTag(memif.SwIfIndex, podSpec.GetInterfaceTag(i.name))
+	if err != nil {
+		return err
+	}
+
+	if config.PodGSOEnabled {
+		err = i.vpp.EnableGSOFeature(memif.SwIfIndex)
+		if err != nil {
+			return errors.Wrap(err, "Error enabling GSO on memif")
+		}
+	}
+
+	err = i.DoPodIfNatConfiguration(podSpec, stack, memif.SwIfIndex)
+	if err != nil {
+		return err
+	}
+
+	err = i.DoPodInterfaceConfiguration(podSpec, stack, memif.SwIfIndex, false /*isL3*/)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (i *MemifPodInterfaceDriver) DeleteInterface(podSpec *storage.LocalPodSpec) {
+	if podSpec.MemifSwIfIndex == vpplink.InvalidID {
+		return
+	}
+
+	i.UndoPodInterfaceConfiguration(podSpec.MemifSwIfIndex)
+	i.UndoPodIfNatConfiguration(podSpec.MemifSwIfIndex)
+
+	err := i.vpp.DeleteMemif(podSpec.MemifSwIfIndex)
+	if err != nil {
+		i.log.Warnf("Error deleting memif[%d] %s", podSpec.MemifSwIfIndex, err)
+	}
+
+	if podSpec.MemifSocketId != 0 {
+		err = i.vpp.DelMemifSocketFileName(podSpec.MemifSocketId)
+		if err != nil {
+			i.log.Warnf("Error deleting memif[%d] socket[%d] %s", podSpec.MemifSwIfIndex, podSpec.MemifSocketId, err)
+		}
+	}
+
+	i.log.Infof("Deleted memif[%d]", podSpec.MemifSwIfIndex)
+
+}

--- a/calico-vpp-agent/cni/pod_interface/tuntap.go
+++ b/calico-vpp-agent/cni/pod_interface/tuntap.go
@@ -1,0 +1,261 @@
+// Copyright (C) 2021 Cisco Systems Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pod_interface
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"os"
+
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/pkg/errors"
+	"github.com/projectcalico/vpp-dataplane/calico-vpp-agent/cni/storage"
+	"github.com/projectcalico/vpp-dataplane/calico-vpp-agent/config"
+	"github.com/projectcalico/vpp-dataplane/vpplink"
+	"github.com/projectcalico/vpp-dataplane/vpplink/types"
+	"github.com/sirupsen/logrus"
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+)
+
+type TunTapPodInterfaceDriver struct {
+	PodInterfaceDriverData
+}
+
+func NewTunTapPodInterfaceDriver(vpp *vpplink.VppLink, log *logrus.Entry) *TunTapPodInterfaceDriver {
+	i := &TunTapPodInterfaceDriver{}
+	i.vpp = vpp
+	i.log = log
+	i.name = "tun"
+	return i
+}
+
+func (i *TunTapPodInterfaceDriver) CreateInterface(podSpec *storage.LocalPodSpec, stack *vpplink.CleanupStack, doHostSideConf bool) error {
+	swIfIndex := i.SearchPodInterface(podSpec)
+	if swIfIndex != vpplink.InvalidID {
+		/* If something is found under this name, try a cleanup before going on */
+		i.log.Warnf("Found tuntap already existing %d. Trying cleanup", swIfIndex)
+		i.DeleteInterface(podSpec)
+	}
+
+	tun := &types.TapV2{
+		GenericVppInterface: types.GenericVppInterface{
+			NumRxQueues:       config.TapNumRxQueues,
+			NumTxQueues:       config.TapNumTxQueues,
+			RxQueueSize:       config.TapRxQueueSize,
+			TxQueueSize:       config.TapTxQueueSize,
+			HostInterfaceName: podSpec.InterfaceName,
+		},
+		HostNamespace: podSpec.NetnsName,
+		Tag:           podSpec.GetInterfaceTag(i.name),
+		HostMtu:       podSpec.GetPodMtu(),
+	}
+
+	if podSpec.TunTapIsL3 {
+		tun.Flags |= types.TapFlagTun
+	}
+
+	if config.PodGSOEnabled {
+		tun.Flags |= types.TapFlagGSO | types.TapGROCoalesce
+	}
+
+	i.log.Debugf("Add request pod MTU: %d, computed %d", podSpec.Mtu, tun.HostMtu)
+
+	swIfIndex, err := i.vpp.CreateOrAttachTapV2(tun)
+	if err != nil {
+		return errors.Wrapf(err, "Error creating tun")
+	} else {
+		stack.Push(i.vpp.DelTap, swIfIndex)
+	}
+
+	podSpec.TunTapSwIfIndex = swIfIndex
+	i.log.Infof("created tun[%d]", swIfIndex)
+
+	err = i.DoPodIfNatConfiguration(podSpec, stack, swIfIndex)
+	if err != nil {
+		return err
+	}
+
+	err = i.DoPodInterfaceConfiguration(podSpec, stack, swIfIndex, true /*isL3*/)
+	if err != nil {
+		return err
+	}
+
+	if doHostSideConf {
+		err = i.configureLinux(podSpec, swIfIndex)
+		if err != nil {
+			return err
+		}
+	}
+	i.log.Infof("Created tun[%d]", swIfIndex)
+
+	return nil
+}
+
+func (i *TunTapPodInterfaceDriver) DeleteInterface(podSpec *storage.LocalPodSpec) {
+	i.unconfigureLinux(podSpec)
+
+	i.UndoPodInterfaceConfiguration(podSpec.TunTapSwIfIndex)
+	i.UndoPodIfNatConfiguration(podSpec.TunTapSwIfIndex)
+
+	err := i.vpp.DelTap(podSpec.TunTapSwIfIndex)
+	if err != nil {
+		i.log.Warnf("Error deleting tun[%d] %s", podSpec.TunTapSwIfIndex, err)
+	}
+	i.log.Infof("deleted tun[%d]", podSpec.TunTapSwIfIndex)
+
+}
+
+func (i *TunTapPodInterfaceDriver) configureLinux(podSpec *storage.LocalPodSpec, swIfIndex uint32) error {
+	/* linux side configuration */
+	err := ns.WithNetNSPath(podSpec.NetnsName, i.configureNamespaceSideTun(swIfIndex, podSpec))
+	if err != nil {
+		return errors.Wrapf(err, "Error in linux NS config")
+	}
+	return nil
+}
+
+func (i *TunTapPodInterfaceDriver) unconfigureLinux(podSpec *storage.LocalPodSpec) []net.IPNet {
+	containerIPs := make([]net.IPNet, 0)
+	devErr := ns.WithNetNSPath(podSpec.NetnsName, func(_ ns.NetNS) error {
+		dev, err := netlink.LinkByName(podSpec.InterfaceName)
+		if err != nil {
+			return err
+		}
+		addresses, err := netlink.AddrList(dev, netlink.FAMILY_ALL)
+		if err != nil {
+			return err
+		}
+		for _, addr := range addresses {
+			i.log.Infof("Found address %s on interface, scope %d", addr.IP.String(), addr.Scope)
+			if addr.Scope == unix.RT_SCOPE_LINK {
+				continue
+			}
+			containerIPs = append(containerIPs, net.IPNet{IP: addr.IP, Mask: addr.Mask})
+		}
+		return nil
+	})
+	if devErr != nil {
+		switch devErr.(type) {
+		case netlink.LinkNotFoundError:
+			i.log.Warnf("Device to delete not found")
+		default:
+			i.log.Warnf("error withdrawing interface addresses: %v", devErr)
+		}
+	}
+	return containerIPs
+}
+
+// writeProcSys takes the sysctl path and a string value to set i.e. "0" or "1" and sets the sysctl.
+// This method was copied from cni-plugin/internal/pkg/utils/network_linux.go
+func writeProcSys(path, value string) error {
+	f, err := os.OpenFile(path, os.O_WRONLY, 0)
+	if err != nil {
+		return err
+	}
+	n, err := f.Write([]byte(value))
+	if err == nil && n < len(value) {
+		err = io.ErrShortWrite
+	}
+	if err1 := f.Close(); err == nil {
+		err = err1
+	}
+	return err
+}
+
+// configureContainerSysctls configures necessary sysctls required inside the container netns.
+// This method was adapted from cni-plugin/internal/pkg/utils/network_linux.go
+func (i *TunTapPodInterfaceDriver) configureContainerSysctls(podSpec *storage.LocalPodSpec) error {
+	hasv4, hasv6 := podSpec.Hasv46()
+	ipFwd := "0"
+	if podSpec.AllowIpForwarding {
+		ipFwd = "1"
+	}
+	// If an IPv4 address is assigned, then configure IPv4 sysctls.
+	if hasv4 {
+		i.log.Info("Configuring IPv4 forwarding")
+		if err := writeProcSys("/proc/sys/net/ipv4/ip_forward", ipFwd); err != nil {
+			return err
+		}
+	}
+	// If an IPv6 address is assigned, then configure IPv6 sysctls.
+	if hasv6 {
+		i.log.Info("Configuring IPv6 forwarding")
+		if err := writeProcSys("/proc/sys/net/ipv6/conf/all/forwarding", ipFwd); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (i *TunTapPodInterfaceDriver) configureNamespaceSideTun(swIfIndex uint32, podSpec *storage.LocalPodSpec) func(hostNS ns.NetNS) error {
+	return func(hostNS ns.NetNS) error {
+		contTun, err := netlink.LinkByName(podSpec.InterfaceName)
+		if err != nil {
+			return errors.Wrapf(err, "failed to lookup %q: %v", podSpec.InterfaceName, err)
+		}
+		hasv4, hasv6 := podSpec.Hasv46()
+
+		// Do the per-IP version set-up.  Add gateway routes etc.
+		if hasv6 {
+			i.log.Infof("tun %d in NS has v6", swIfIndex)
+			// Make sure ipv6 is enabled in the container/pod network namespace.
+			if err = writeProcSys("/proc/sys/net/ipv6/conf/all/disable_ipv6", "0"); err != nil {
+				return fmt.Errorf("failed to set net.ipv6.conf.all.disable_ipv6=0: %s", err)
+			}
+			if err = writeProcSys("/proc/sys/net/ipv6/conf/default/disable_ipv6", "0"); err != nil {
+				return fmt.Errorf("failed to set net.ipv6.conf.default.disable_ipv6=0: %s", err)
+			}
+			if err = writeProcSys("/proc/sys/net/ipv6/conf/lo/disable_ipv6", "0"); err != nil {
+				return fmt.Errorf("failed to set net.ipv6.conf.lo.disable_ipv6=0: %s", err)
+			}
+		}
+
+		for _, route := range podSpec.GetRoutes() {
+			isV6 := route.IP.To4() == nil
+			if (isV6 && !hasv6) || (!isV6 && !hasv4) {
+				i.log.Infof("Skipping tun[%d] route for %s", swIfIndex, route.String())
+				continue
+			}
+			i.log.Infof("Add tun[%d] linux%d route for %s", swIfIndex, contTun.Attrs().Index, route.String())
+			err = netlink.RouteAdd(&netlink.Route{
+				LinkIndex: contTun.Attrs().Index,
+				Scope:     netlink.SCOPE_UNIVERSE,
+				Dst:       route,
+			})
+			if err != nil {
+				// TODO : in ipv6 '::' already exists
+				i.log.Errorf("Error adding tun[%d] route for %s", swIfIndex, route.String())
+			}
+		}
+
+		// Now add the IPs to the container side of the tun.
+		for _, containerIP := range podSpec.GetContainerIps() {
+			i.log.Infof("Add tun[%d] linux%d ip %s", swIfIndex, contTun.Attrs().Index, containerIP.String())
+			err = netlink.AddrAdd(contTun, &netlink.Addr{IPNet: containerIP})
+			if err != nil {
+				return errors.Wrapf(err, "failed to add IP addr to %s: %v", contTun.Attrs().Name, err)
+			}
+		}
+
+		if err = i.configureContainerSysctls(podSpec); err != nil {
+			return errors.Wrapf(err, "error configuring sysctls for the container netns, error: %s", err)
+		}
+
+		return nil
+	}
+}

--- a/calico-vpp-agent/cni/pod_interface/vcl.go
+++ b/calico-vpp-agent/cni/pod_interface/vcl.go
@@ -1,0 +1,69 @@
+// Copyright (C) 2021 Cisco Systems Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pod_interface
+
+import (
+	// "net"
+
+	"github.com/projectcalico/vpp-dataplane/calico-vpp-agent/cni/storage"
+	"github.com/projectcalico/vpp-dataplane/vpplink"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	vclSocketName = "@vpp/session"
+)
+
+type VclPodInterfaceDriver struct {
+	PodInterfaceDriverData
+}
+
+func NewVclPodInterfaceDriver(vpp *vpplink.VppLink, log *logrus.Entry) *VclPodInterfaceDriver {
+	i := &VclPodInterfaceDriver{}
+	i.vpp = vpp
+	i.log = log
+	i.name = "vcl"
+	return i
+}
+
+func (i *VclPodInterfaceDriver) CreateInterface(podSpec *storage.LocalPodSpec, stack *vpplink.CleanupStack) (err error) {
+	err = i.vpp.EnableSessionLayer()
+	if err != nil {
+		return err
+	}
+
+	// TODO
+	// err = i.vpp.EnableSessionSAPI()
+	// if err != nil {
+	// 	return err
+	// }
+
+	err = i.vpp.AddSessionAppNamespace(vclSocketName, podSpec.NetnsName, podSpec.LoopbackSwIfIndex)
+	if err != nil {
+		return err
+	}
+
+	err = i.vpp.InterfaceAdminUp(podSpec.LoopbackSwIfIndex)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (i *VclPodInterfaceDriver) DeleteInterface(podSpec *storage.LocalPodSpec) {
+	// TODO
+}

--- a/calico-vpp-agent/common/common.go
+++ b/calico-vpp-agent/common/common.go
@@ -42,6 +42,7 @@ const (
 	DefaultVRFIndex     = uint32(0)
 	PuntTableId         = uint32(1)
 	PodVRFIndex         = uint32(2)
+	PerPodVRFIndexStart = uint32(10) /* per pod VRFs will be this ID and above */
 )
 
 type CalicoVppServer interface {

--- a/vpp-manager/images/dev/Dockerfile
+++ b/vpp-manager/images/dev/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update \
  && apt-get install -y openssl libapr1 libnuma1 libasan5 \
 	  libmbedcrypto3 libmbedtls12 libmbedx509-0 libsubunit0 \
 	  iptables iproute2 iputils-ping inetutils-traceroute \
-	  netcat-openbsd ethtool gdb \
+	  netcat-openbsd ethtool gdb openssl \
  && rm -rf /var/lib/apt/lists/*
 
 ADD entrypoint.sh /usr/bin/entrypoint


### PR DESCRIPTION
The resulting network looks as follows. We should support tun only, tun+memif, memif+tun & tun+VCL
loop interfaces carry the pod Address, they are down (grey) for tun+memif/memif+tun & tun only
Other interfaces (memif/tun) inside the VRF are unnumbered on the loopback
 
![Networking model](https://user-images.githubusercontent.com/3398628/129049140-7a581ebe-8d39-4f7a-b6b9-1d764f062177.png)
