### PR TITLE
routing: use node addresses for BGP listener

### DIFF
--- a/calico-vpp-agent/routing/routing_server_init.go
+++ b/calico-vpp-agent/routing/routing_server_init.go
@@ -155,7 +155,7 @@ func (s *Server) fetchNodeIPs() (node *calicov3.Node, err error) {
 }
 
 func (s *Server) createAndStartBGP() error {
-	globalConfig, err := s.getGlobalConfig()
+	globalConfig, err := s.getGoBGPGlobalConfig()
 	if err != nil {
 		return fmt.Errorf("cannot get global configuration: %v", err)
 	}


### PR DESCRIPTION
This prevents an issue starting up on nodes with ipv6 disabled
