### PR TITLE
Integrate updated memif API

### DIFF
--- a/calico-vpp-agent/cni/pod_interface/memif.go
+++ b/calico-vpp-agent/cni/pod_interface/memif.go
@@ -16,6 +16,7 @@
 package pod_interface
 
 import (
+	"fmt"
 	"github.com/pkg/errors"
 	"github.com/projectcalico/vpp-dataplane/calico-vpp-agent/cni/storage"
 	"github.com/projectcalico/vpp-dataplane/calico-vpp-agent/config"
@@ -43,7 +44,7 @@ func (i *MemifPodInterfaceDriver) CreateInterface(podSpec *storage.LocalPodSpec,
 		i.DeleteInterface(podSpec)
 	}
 
-	socketId, err := i.vpp.AddMemifSocketFileName(config.MemifSocketName, podSpec.NetnsName)
+	socketId, err := i.vpp.AddMemifSocketFileName(fmt.Sprintf("@netns:%s%s", podSpec.NetnsName, config.MemifSocketName))
 	if err != nil {
 		return err
 	} else {

--- a/calico-vpp-agent/routing/routing_server.go
+++ b/calico-vpp-agent/routing/routing_server.go
@@ -189,6 +189,7 @@ func (s *Server) serveOne() error {
 
 	s.ipam.WaitReady()
 	ServerRunning <- 1
+	s.log.Infof("Routing server is running ")
 	<-s.t.Dying()
 	s.log.Warnf("routing tomb returned %v", s.t.Err())
 

--- a/vpplink/binapi/vpp_clone_current.sh
+++ b/vpplink/binapi/vpp_clone_current.sh
@@ -84,18 +84,16 @@ function git_clone_cd_and_reset ()
 
 # --------------- Things to cherry pick ---------------
 
-git_clone_cd_and_reset "$1" 312b4cd841c94551e1de54df973891747306c390
+git_clone_cd_and_reset "$1" 88019c40725704e6998625937c764d1d0c827975
 
-git_cherry_pick refs/changes/86/29386/9 # 29386: virtio: DRAFT: multi tx support | https://gerrit.fd.io/r/c/vpp/+/29386
-git_cherry_pick refs/changes/71/32271/7 # 32271: memif: add support for ns abstract sockets | https://gerrit.fd.io/r/c/vpp/+/32271
-git_cherry_pick refs/changes/57/33557/5 # 33557: ip: unlock_fib on if delete | https://gerrit.fd.io/r/c/vpp/+/33557
-git_cherry_pick refs/changes/49/34249/2 # 34249: devices: default mode eth in the api | https://gerrit.fd.io/r/c/vpp/+/34249
+git_cherry_pick refs/changes/13/34713/3 # 34713: vppinfra: improve & test abstract socket | https://gerrit.fd.io/r/c/vpp/+/34713
+git_cherry_pick refs/changes/71/32271/15 # 32271: memif: add support for ns abstract sockets | https://gerrit.fd.io/r/c/vpp/+/32271
+git_cherry_pick refs/changes/34/34734/2 # 34734: memif: autogenerate socket_ids | https://gerrit.fd.io/r/c/vpp/+/34734
 git_cherry_pick refs/changes/26/34726/1 # 34726: interface: add buffer stats api | https://gerrit.fd.io/r/c/vpp/+/34726
-
-git_cherry_pick refs/changes/85/34585/1 # 34585: devices: fix af_packet GSO check | https://gerrit.fd.io/r/c/vpp/+/34585
+git_cherry_pick refs/changes/57/34757/1 # 34757: tap: add num_tx_queues API | https://gerrit.fd.io/r/c/vpp/+/34757
 
 # --------------- Dedicated plugins ---------------
-git_cherry_pick refs/changes/64/33264/3 # 33264: pbl: Port based balancer | https://gerrit.fd.io/r/c/vpp/+/33264
+git_cherry_pick refs/changes/64/33264/7 # 33264: pbl: Port based balancer | https://gerrit.fd.io/r/c/vpp/+/33264
 git_cherry_pick refs/changes/88/31588/1 # 31588: cnat: [WIP] no k8s maglev from pods | https://gerrit.fd.io/r/c/vpp/+/31588
 git_cherry_pick refs/changes/83/28083/20 # 28083: acl: acl-plugin custom policies |  https://gerrit.fd.io/r/c/vpp/+/28083
 git_cherry_pick refs/changes/13/28513/24 # 25813: capo: Calico Policies plugin | https://gerrit.fd.io/r/c/vpp/+/28513

--- a/vpplink/binapi/vppapi/af_xdp/af_xdp.ba.go
+++ b/vpplink/binapi/vppapi/af_xdp/af_xdp.ba.go
@@ -4,7 +4,7 @@
 //
 // Contents:
 //   2 enums
-//   4 messages
+//   6 messages
 //
 package af_xdp
 
@@ -25,7 +25,7 @@ const _ = api.GoVppAPIPackageIsVersion2
 const (
 	APIFile    = "af_xdp"
 	APIVersion = "0.2.0"
-	VersionCrc = 0x31450826
+	VersionCrc = 0x346626ce
 )
 
 // AfXdpMode defines enum 'af_xdp_mode'.
@@ -201,6 +201,110 @@ func (m *AfXdpCreateReply) Unmarshal(b []byte) error {
 	return nil
 }
 
+// AfXdpCreateV2 defines message 'af_xdp_create_v2'.
+// InProgress: the message form may change in the future versions
+type AfXdpCreateV2 struct {
+	HostIf    string    `binapi:"string[64],name=host_if" json:"host_if,omitempty"`
+	Name      string    `binapi:"string[64],name=name" json:"name,omitempty"`
+	RxqNum    uint16    `binapi:"u16,name=rxq_num,default=1" json:"rxq_num,omitempty"`
+	RxqSize   uint16    `binapi:"u16,name=rxq_size,default=0" json:"rxq_size,omitempty"`
+	TxqSize   uint16    `binapi:"u16,name=txq_size,default=0" json:"txq_size,omitempty"`
+	Mode      AfXdpMode `binapi:"af_xdp_mode,name=mode,default=0" json:"mode,omitempty"`
+	Flags     AfXdpFlag `binapi:"af_xdp_flag,name=flags,default=0" json:"flags,omitempty"`
+	Prog      string    `binapi:"string[256],name=prog" json:"prog,omitempty"`
+	Namespace string    `binapi:"string[64],name=namespace" json:"namespace,omitempty"`
+}
+
+func (m *AfXdpCreateV2) Reset()               { *m = AfXdpCreateV2{} }
+func (*AfXdpCreateV2) GetMessageName() string { return "af_xdp_create_v2" }
+func (*AfXdpCreateV2) GetCrcString() string   { return "e17ec2eb" }
+func (*AfXdpCreateV2) GetMessageType() api.MessageType {
+	return api.RequestMessage
+}
+
+func (m *AfXdpCreateV2) Size() (size int) {
+	if m == nil {
+		return 0
+	}
+	size += 64  // m.HostIf
+	size += 64  // m.Name
+	size += 2   // m.RxqNum
+	size += 2   // m.RxqSize
+	size += 2   // m.TxqSize
+	size += 4   // m.Mode
+	size += 1   // m.Flags
+	size += 256 // m.Prog
+	size += 64  // m.Namespace
+	return size
+}
+func (m *AfXdpCreateV2) Marshal(b []byte) ([]byte, error) {
+	if b == nil {
+		b = make([]byte, m.Size())
+	}
+	buf := codec.NewBuffer(b)
+	buf.EncodeString(m.HostIf, 64)
+	buf.EncodeString(m.Name, 64)
+	buf.EncodeUint16(m.RxqNum)
+	buf.EncodeUint16(m.RxqSize)
+	buf.EncodeUint16(m.TxqSize)
+	buf.EncodeUint32(uint32(m.Mode))
+	buf.EncodeUint8(uint8(m.Flags))
+	buf.EncodeString(m.Prog, 256)
+	buf.EncodeString(m.Namespace, 64)
+	return buf.Bytes(), nil
+}
+func (m *AfXdpCreateV2) Unmarshal(b []byte) error {
+	buf := codec.NewBuffer(b)
+	m.HostIf = buf.DecodeString(64)
+	m.Name = buf.DecodeString(64)
+	m.RxqNum = buf.DecodeUint16()
+	m.RxqSize = buf.DecodeUint16()
+	m.TxqSize = buf.DecodeUint16()
+	m.Mode = AfXdpMode(buf.DecodeUint32())
+	m.Flags = AfXdpFlag(buf.DecodeUint8())
+	m.Prog = buf.DecodeString(256)
+	m.Namespace = buf.DecodeString(64)
+	return nil
+}
+
+// AfXdpCreateV2Reply defines message 'af_xdp_create_v2_reply'.
+// InProgress: the message form may change in the future versions
+type AfXdpCreateV2Reply struct {
+	Retval    int32                          `binapi:"i32,name=retval" json:"retval,omitempty"`
+	SwIfIndex interface_types.InterfaceIndex `binapi:"interface_index,name=sw_if_index" json:"sw_if_index,omitempty"`
+}
+
+func (m *AfXdpCreateV2Reply) Reset()               { *m = AfXdpCreateV2Reply{} }
+func (*AfXdpCreateV2Reply) GetMessageName() string { return "af_xdp_create_v2_reply" }
+func (*AfXdpCreateV2Reply) GetCrcString() string   { return "5383d31f" }
+func (*AfXdpCreateV2Reply) GetMessageType() api.MessageType {
+	return api.ReplyMessage
+}
+
+func (m *AfXdpCreateV2Reply) Size() (size int) {
+	if m == nil {
+		return 0
+	}
+	size += 4 // m.Retval
+	size += 4 // m.SwIfIndex
+	return size
+}
+func (m *AfXdpCreateV2Reply) Marshal(b []byte) ([]byte, error) {
+	if b == nil {
+		b = make([]byte, m.Size())
+	}
+	buf := codec.NewBuffer(b)
+	buf.EncodeInt32(m.Retval)
+	buf.EncodeUint32(uint32(m.SwIfIndex))
+	return buf.Bytes(), nil
+}
+func (m *AfXdpCreateV2Reply) Unmarshal(b []byte) error {
+	buf := codec.NewBuffer(b)
+	m.Retval = buf.DecodeInt32()
+	m.SwIfIndex = interface_types.InterfaceIndex(buf.DecodeUint32())
+	return nil
+}
+
 // AfXdpDelete defines message 'af_xdp_delete'.
 // InProgress: the message form may change in the future versions
 type AfXdpDelete struct {
@@ -273,6 +377,8 @@ func init() { file_af_xdp_binapi_init() }
 func file_af_xdp_binapi_init() {
 	api.RegisterMessage((*AfXdpCreate)(nil), "af_xdp_create_21226c99")
 	api.RegisterMessage((*AfXdpCreateReply)(nil), "af_xdp_create_reply_5383d31f")
+	api.RegisterMessage((*AfXdpCreateV2)(nil), "af_xdp_create_v2_e17ec2eb")
+	api.RegisterMessage((*AfXdpCreateV2Reply)(nil), "af_xdp_create_v2_reply_5383d31f")
 	api.RegisterMessage((*AfXdpDelete)(nil), "af_xdp_delete_f9e6675e")
 	api.RegisterMessage((*AfXdpDeleteReply)(nil), "af_xdp_delete_reply_e8d4e804")
 }
@@ -282,6 +388,8 @@ func AllMessages() []api.Message {
 	return []api.Message{
 		(*AfXdpCreate)(nil),
 		(*AfXdpCreateReply)(nil),
+		(*AfXdpCreateV2)(nil),
+		(*AfXdpCreateV2Reply)(nil),
 		(*AfXdpDelete)(nil),
 		(*AfXdpDeleteReply)(nil),
 	}

--- a/vpplink/binapi/vppapi/af_xdp/af_xdp_rpc.ba.go
+++ b/vpplink/binapi/vppapi/af_xdp/af_xdp_rpc.ba.go
@@ -11,6 +11,7 @@ import (
 // RPCService defines RPC service af_xdp.
 type RPCService interface {
 	AfXdpCreate(ctx context.Context, in *AfXdpCreate) (*AfXdpCreateReply, error)
+	AfXdpCreateV2(ctx context.Context, in *AfXdpCreateV2) (*AfXdpCreateV2Reply, error)
 	AfXdpDelete(ctx context.Context, in *AfXdpDelete) (*AfXdpDeleteReply, error)
 }
 
@@ -24,6 +25,15 @@ func NewServiceClient(conn api.Connection) RPCService {
 
 func (c *serviceClient) AfXdpCreate(ctx context.Context, in *AfXdpCreate) (*AfXdpCreateReply, error) {
 	out := new(AfXdpCreateReply)
+	err := c.conn.Invoke(ctx, in, out)
+	if err != nil {
+		return nil, err
+	}
+	return out, api.RetvalToVPPApiError(out.Retval)
+}
+
+func (c *serviceClient) AfXdpCreateV2(ctx context.Context, in *AfXdpCreateV2) (*AfXdpCreateV2Reply, error) {
+	out := new(AfXdpCreateV2Reply)
 	err := c.conn.Invoke(ctx, in, out)
 	if err != nil {
 		return nil, err

--- a/vpplink/binapi/vppapi/generate.log
+++ b/vpplink/binapi/vppapi/generate.log
@@ -1,15 +1,14 @@
-VPP Version                 : 22.02-rc0~166-gaf267615b
+VPP Version                 : 22.02-rc0~407-g484a2d434
 Binapi-generator version    : govpp v0.4.0-dev
-VPP Base commit             : 312b4cd84 arp: fix for source address selection
+VPP Base commit             : 88019c407 vppinfra: toeplitz hash four in parallel
 ------------------ Cherry picked commits --------------------
 gerrit:28513/24 capo: Calico Policies plugin
 gerrit:28083/20 acl: acl-plugin custom policies
 gerrit:31588/1 cnat: [WIP] no k8s maglev from pods
-gerrit:33264/3 pbl: Port based balancer
-gerrit:34585/1 devices: fix af_packet GSO check
+gerrit:33264/7 pbl: Port based balancer
+gerrit:34757/1 tap: add num_tx_queues API
 gerrit:34726/1 interface: add buffer stats api
-gerrit:34249/2 devices: default mode eth in the api
-gerrit:33557/5 ip: unlock_fib on if delete
-gerrit:32271/7 memif: add support for ns abstract sockets
-gerrit:29386/9 virtio: DRAFT: multi tx support
+gerrit:34734/2 memif: autogenerate socket_ids
+gerrit:32271/15 memif: add support for ns abstract sockets
+gerrit:34713/3 vppinfra: improve & test abstract socket
 -------------------------------------------------------------

--- a/vpplink/binapi/vppapi/interface/interface.ba.go
+++ b/vpplink/binapi/vppapi/interface/interface.ba.go
@@ -3,7 +3,7 @@
 // Package interfaces contains generated bindings for API file interface.api.
 //
 // Contents:
-//  63 messages
+//  68 messages
 //
 package interfaces
 
@@ -24,7 +24,7 @@ const _ = api.GoVppAPIPackageIsVersion2
 const (
 	APIFile    = "interface"
 	APIVersion = "3.2.3"
-	VersionCrc = 0x32cbf532
+	VersionCrc = 0xddff3487
 )
 
 // CollectDetailedInterfaceStats defines message 'collect_detailed_interface_stats'.
@@ -2242,6 +2242,95 @@ func (m *SwInterfaceSetTableReply) Unmarshal(b []byte) error {
 	return nil
 }
 
+// SwInterfaceSetTxPlacement defines message 'sw_interface_set_tx_placement'.
+type SwInterfaceSetTxPlacement struct {
+	SwIfIndex interface_types.InterfaceIndex `binapi:"interface_index,name=sw_if_index" json:"sw_if_index,omitempty"`
+	QueueID   uint32                         `binapi:"u32,name=queue_id" json:"queue_id,omitempty"`
+	ArraySize uint32                         `binapi:"u32,name=array_size" json:"-"`
+	Threads   []uint32                       `binapi:"u32[array_size],name=threads" json:"threads,omitempty"`
+}
+
+func (m *SwInterfaceSetTxPlacement) Reset()               { *m = SwInterfaceSetTxPlacement{} }
+func (*SwInterfaceSetTxPlacement) GetMessageName() string { return "sw_interface_set_tx_placement" }
+func (*SwInterfaceSetTxPlacement) GetCrcString() string   { return "4e0cd5ff" }
+func (*SwInterfaceSetTxPlacement) GetMessageType() api.MessageType {
+	return api.RequestMessage
+}
+
+func (m *SwInterfaceSetTxPlacement) Size() (size int) {
+	if m == nil {
+		return 0
+	}
+	size += 4                  // m.SwIfIndex
+	size += 4                  // m.QueueID
+	size += 4                  // m.ArraySize
+	size += 4 * len(m.Threads) // m.Threads
+	return size
+}
+func (m *SwInterfaceSetTxPlacement) Marshal(b []byte) ([]byte, error) {
+	if b == nil {
+		b = make([]byte, m.Size())
+	}
+	buf := codec.NewBuffer(b)
+	buf.EncodeUint32(uint32(m.SwIfIndex))
+	buf.EncodeUint32(m.QueueID)
+	buf.EncodeUint32(uint32(len(m.Threads)))
+	for i := 0; i < len(m.Threads); i++ {
+		var x uint32
+		if i < len(m.Threads) {
+			x = uint32(m.Threads[i])
+		}
+		buf.EncodeUint32(x)
+	}
+	return buf.Bytes(), nil
+}
+func (m *SwInterfaceSetTxPlacement) Unmarshal(b []byte) error {
+	buf := codec.NewBuffer(b)
+	m.SwIfIndex = interface_types.InterfaceIndex(buf.DecodeUint32())
+	m.QueueID = buf.DecodeUint32()
+	m.ArraySize = buf.DecodeUint32()
+	m.Threads = make([]uint32, m.ArraySize)
+	for i := 0; i < len(m.Threads); i++ {
+		m.Threads[i] = buf.DecodeUint32()
+	}
+	return nil
+}
+
+// SwInterfaceSetTxPlacementReply defines message 'sw_interface_set_tx_placement_reply'.
+type SwInterfaceSetTxPlacementReply struct {
+	Retval int32 `binapi:"i32,name=retval" json:"retval,omitempty"`
+}
+
+func (m *SwInterfaceSetTxPlacementReply) Reset() { *m = SwInterfaceSetTxPlacementReply{} }
+func (*SwInterfaceSetTxPlacementReply) GetMessageName() string {
+	return "sw_interface_set_tx_placement_reply"
+}
+func (*SwInterfaceSetTxPlacementReply) GetCrcString() string { return "e8d4e804" }
+func (*SwInterfaceSetTxPlacementReply) GetMessageType() api.MessageType {
+	return api.ReplyMessage
+}
+
+func (m *SwInterfaceSetTxPlacementReply) Size() (size int) {
+	if m == nil {
+		return 0
+	}
+	size += 4 // m.Retval
+	return size
+}
+func (m *SwInterfaceSetTxPlacementReply) Marshal(b []byte) ([]byte, error) {
+	if b == nil {
+		b = make([]byte, m.Size())
+	}
+	buf := codec.NewBuffer(b)
+	buf.EncodeInt32(m.Retval)
+	return buf.Bytes(), nil
+}
+func (m *SwInterfaceSetTxPlacementReply) Unmarshal(b []byte) error {
+	buf := codec.NewBuffer(b)
+	m.Retval = buf.DecodeInt32()
+	return nil
+}
+
 // SwInterfaceSetUnnumbered defines message 'sw_interface_set_unnumbered'.
 type SwInterfaceSetUnnumbered struct {
 	SwIfIndex           interface_types.InterfaceIndex `binapi:"interface_index,name=sw_if_index" json:"sw_if_index,omitempty"`
@@ -2392,6 +2481,142 @@ func (m *SwInterfaceTagAddDelReply) Unmarshal(b []byte) error {
 	return nil
 }
 
+// SwInterfaceTxPlacementDetails defines message 'sw_interface_tx_placement_details'.
+type SwInterfaceTxPlacementDetails struct {
+	SwIfIndex interface_types.InterfaceIndex `binapi:"interface_index,name=sw_if_index" json:"sw_if_index,omitempty"`
+	QueueID   uint32                         `binapi:"u32,name=queue_id" json:"queue_id,omitempty"`
+	Shared    uint8                          `binapi:"u8,name=shared" json:"shared,omitempty"`
+	ArraySize uint32                         `binapi:"u32,name=array_size" json:"-"`
+	Threads   []uint32                       `binapi:"u32[array_size],name=threads" json:"threads,omitempty"`
+}
+
+func (m *SwInterfaceTxPlacementDetails) Reset() { *m = SwInterfaceTxPlacementDetails{} }
+func (*SwInterfaceTxPlacementDetails) GetMessageName() string {
+	return "sw_interface_tx_placement_details"
+}
+func (*SwInterfaceTxPlacementDetails) GetCrcString() string { return "00381a2e" }
+func (*SwInterfaceTxPlacementDetails) GetMessageType() api.MessageType {
+	return api.RequestMessage
+}
+
+func (m *SwInterfaceTxPlacementDetails) Size() (size int) {
+	if m == nil {
+		return 0
+	}
+	size += 4                  // m.SwIfIndex
+	size += 4                  // m.QueueID
+	size += 1                  // m.Shared
+	size += 4                  // m.ArraySize
+	size += 4 * len(m.Threads) // m.Threads
+	return size
+}
+func (m *SwInterfaceTxPlacementDetails) Marshal(b []byte) ([]byte, error) {
+	if b == nil {
+		b = make([]byte, m.Size())
+	}
+	buf := codec.NewBuffer(b)
+	buf.EncodeUint32(uint32(m.SwIfIndex))
+	buf.EncodeUint32(m.QueueID)
+	buf.EncodeUint8(m.Shared)
+	buf.EncodeUint32(uint32(len(m.Threads)))
+	for i := 0; i < len(m.Threads); i++ {
+		var x uint32
+		if i < len(m.Threads) {
+			x = uint32(m.Threads[i])
+		}
+		buf.EncodeUint32(x)
+	}
+	return buf.Bytes(), nil
+}
+func (m *SwInterfaceTxPlacementDetails) Unmarshal(b []byte) error {
+	buf := codec.NewBuffer(b)
+	m.SwIfIndex = interface_types.InterfaceIndex(buf.DecodeUint32())
+	m.QueueID = buf.DecodeUint32()
+	m.Shared = buf.DecodeUint8()
+	m.ArraySize = buf.DecodeUint32()
+	m.Threads = make([]uint32, m.ArraySize)
+	for i := 0; i < len(m.Threads); i++ {
+		m.Threads[i] = buf.DecodeUint32()
+	}
+	return nil
+}
+
+// SwInterfaceTxPlacementGet defines message 'sw_interface_tx_placement_get'.
+type SwInterfaceTxPlacementGet struct {
+	Cursor    uint32                         `binapi:"u32,name=cursor" json:"cursor,omitempty"`
+	SwIfIndex interface_types.InterfaceIndex `binapi:"interface_index,name=sw_if_index" json:"sw_if_index,omitempty"`
+}
+
+func (m *SwInterfaceTxPlacementGet) Reset()               { *m = SwInterfaceTxPlacementGet{} }
+func (*SwInterfaceTxPlacementGet) GetMessageName() string { return "sw_interface_tx_placement_get" }
+func (*SwInterfaceTxPlacementGet) GetCrcString() string   { return "47250981" }
+func (*SwInterfaceTxPlacementGet) GetMessageType() api.MessageType {
+	return api.RequestMessage
+}
+
+func (m *SwInterfaceTxPlacementGet) Size() (size int) {
+	if m == nil {
+		return 0
+	}
+	size += 4 // m.Cursor
+	size += 4 // m.SwIfIndex
+	return size
+}
+func (m *SwInterfaceTxPlacementGet) Marshal(b []byte) ([]byte, error) {
+	if b == nil {
+		b = make([]byte, m.Size())
+	}
+	buf := codec.NewBuffer(b)
+	buf.EncodeUint32(m.Cursor)
+	buf.EncodeUint32(uint32(m.SwIfIndex))
+	return buf.Bytes(), nil
+}
+func (m *SwInterfaceTxPlacementGet) Unmarshal(b []byte) error {
+	buf := codec.NewBuffer(b)
+	m.Cursor = buf.DecodeUint32()
+	m.SwIfIndex = interface_types.InterfaceIndex(buf.DecodeUint32())
+	return nil
+}
+
+// SwInterfaceTxPlacementGetReply defines message 'sw_interface_tx_placement_get_reply'.
+type SwInterfaceTxPlacementGetReply struct {
+	Retval int32  `binapi:"i32,name=retval" json:"retval,omitempty"`
+	Cursor uint32 `binapi:"u32,name=cursor" json:"cursor,omitempty"`
+}
+
+func (m *SwInterfaceTxPlacementGetReply) Reset() { *m = SwInterfaceTxPlacementGetReply{} }
+func (*SwInterfaceTxPlacementGetReply) GetMessageName() string {
+	return "sw_interface_tx_placement_get_reply"
+}
+func (*SwInterfaceTxPlacementGetReply) GetCrcString() string { return "53b48f5d" }
+func (*SwInterfaceTxPlacementGetReply) GetMessageType() api.MessageType {
+	return api.ReplyMessage
+}
+
+func (m *SwInterfaceTxPlacementGetReply) Size() (size int) {
+	if m == nil {
+		return 0
+	}
+	size += 4 // m.Retval
+	size += 4 // m.Cursor
+	return size
+}
+func (m *SwInterfaceTxPlacementGetReply) Marshal(b []byte) ([]byte, error) {
+	if b == nil {
+		b = make([]byte, m.Size())
+	}
+	buf := codec.NewBuffer(b)
+	buf.EncodeInt32(m.Retval)
+	buf.EncodeUint32(m.Cursor)
+	return buf.Bytes(), nil
+}
+func (m *SwInterfaceTxPlacementGetReply) Unmarshal(b []byte) error {
+	buf := codec.NewBuffer(b)
+	m.Retval = buf.DecodeInt32()
+	m.Cursor = buf.DecodeUint32()
+	return nil
+}
+
 // WantInterfaceEvents defines message 'want_interface_events'.
 type WantInterfaceEvents struct {
 	EnableDisable uint32 `binapi:"u32,name=enable_disable" json:"enable_disable,omitempty"`
@@ -2521,10 +2746,15 @@ func file_interfaces_binapi_init() {
 	api.RegisterMessage((*SwInterfaceSetRxPlacementReply)(nil), "sw_interface_set_rx_placement_reply_e8d4e804")
 	api.RegisterMessage((*SwInterfaceSetTable)(nil), "sw_interface_set_table_df42a577")
 	api.RegisterMessage((*SwInterfaceSetTableReply)(nil), "sw_interface_set_table_reply_e8d4e804")
+	api.RegisterMessage((*SwInterfaceSetTxPlacement)(nil), "sw_interface_set_tx_placement_4e0cd5ff")
+	api.RegisterMessage((*SwInterfaceSetTxPlacementReply)(nil), "sw_interface_set_tx_placement_reply_e8d4e804")
 	api.RegisterMessage((*SwInterfaceSetUnnumbered)(nil), "sw_interface_set_unnumbered_154a6439")
 	api.RegisterMessage((*SwInterfaceSetUnnumberedReply)(nil), "sw_interface_set_unnumbered_reply_e8d4e804")
 	api.RegisterMessage((*SwInterfaceTagAddDel)(nil), "sw_interface_tag_add_del_426f8bc1")
 	api.RegisterMessage((*SwInterfaceTagAddDelReply)(nil), "sw_interface_tag_add_del_reply_e8d4e804")
+	api.RegisterMessage((*SwInterfaceTxPlacementDetails)(nil), "sw_interface_tx_placement_details_00381a2e")
+	api.RegisterMessage((*SwInterfaceTxPlacementGet)(nil), "sw_interface_tx_placement_get_47250981")
+	api.RegisterMessage((*SwInterfaceTxPlacementGetReply)(nil), "sw_interface_tx_placement_get_reply_53b48f5d")
 	api.RegisterMessage((*WantInterfaceEvents)(nil), "want_interface_events_476f5a08")
 	api.RegisterMessage((*WantInterfaceEventsReply)(nil), "want_interface_events_reply_e8d4e804")
 }
@@ -2589,10 +2819,15 @@ func AllMessages() []api.Message {
 		(*SwInterfaceSetRxPlacementReply)(nil),
 		(*SwInterfaceSetTable)(nil),
 		(*SwInterfaceSetTableReply)(nil),
+		(*SwInterfaceSetTxPlacement)(nil),
+		(*SwInterfaceSetTxPlacementReply)(nil),
 		(*SwInterfaceSetUnnumbered)(nil),
 		(*SwInterfaceSetUnnumberedReply)(nil),
 		(*SwInterfaceTagAddDel)(nil),
 		(*SwInterfaceTagAddDelReply)(nil),
+		(*SwInterfaceTxPlacementDetails)(nil),
+		(*SwInterfaceTxPlacementGet)(nil),
+		(*SwInterfaceTxPlacementGetReply)(nil),
 		(*WantInterfaceEvents)(nil),
 		(*WantInterfaceEventsReply)(nil),
 	}

--- a/vpplink/binapi/vppapi/interface/interface_rpc.ba.go
+++ b/vpplink/binapi/vppapi/interface/interface_rpc.ba.go
@@ -41,8 +41,10 @@ type RPCService interface {
 	SwInterfaceSetRxMode(ctx context.Context, in *SwInterfaceSetRxMode) (*SwInterfaceSetRxModeReply, error)
 	SwInterfaceSetRxPlacement(ctx context.Context, in *SwInterfaceSetRxPlacement) (*SwInterfaceSetRxPlacementReply, error)
 	SwInterfaceSetTable(ctx context.Context, in *SwInterfaceSetTable) (*SwInterfaceSetTableReply, error)
+	SwInterfaceSetTxPlacement(ctx context.Context, in *SwInterfaceSetTxPlacement) (*SwInterfaceSetTxPlacementReply, error)
 	SwInterfaceSetUnnumbered(ctx context.Context, in *SwInterfaceSetUnnumbered) (*SwInterfaceSetUnnumberedReply, error)
 	SwInterfaceTagAddDel(ctx context.Context, in *SwInterfaceTagAddDel) (*SwInterfaceTagAddDelReply, error)
+	SwInterfaceTxPlacementGet(ctx context.Context, in *SwInterfaceTxPlacementGet) (RPCService_SwInterfaceTxPlacementGetClient, error)
 	WantInterfaceEvents(ctx context.Context, in *WantInterfaceEvents) (*WantInterfaceEventsReply, error)
 }
 
@@ -374,6 +376,15 @@ func (c *serviceClient) SwInterfaceSetTable(ctx context.Context, in *SwInterface
 	return out, api.RetvalToVPPApiError(out.Retval)
 }
 
+func (c *serviceClient) SwInterfaceSetTxPlacement(ctx context.Context, in *SwInterfaceSetTxPlacement) (*SwInterfaceSetTxPlacementReply, error) {
+	out := new(SwInterfaceSetTxPlacementReply)
+	err := c.conn.Invoke(ctx, in, out)
+	if err != nil {
+		return nil, err
+	}
+	return out, api.RetvalToVPPApiError(out.Retval)
+}
+
 func (c *serviceClient) SwInterfaceSetUnnumbered(ctx context.Context, in *SwInterfaceSetUnnumbered) (*SwInterfaceSetUnnumberedReply, error) {
 	out := new(SwInterfaceSetUnnumberedReply)
 	err := c.conn.Invoke(ctx, in, out)
@@ -390,6 +401,46 @@ func (c *serviceClient) SwInterfaceTagAddDel(ctx context.Context, in *SwInterfac
 		return nil, err
 	}
 	return out, api.RetvalToVPPApiError(out.Retval)
+}
+
+func (c *serviceClient) SwInterfaceTxPlacementGet(ctx context.Context, in *SwInterfaceTxPlacementGet) (RPCService_SwInterfaceTxPlacementGetClient, error) {
+	stream, err := c.conn.NewStream(ctx)
+	if err != nil {
+		return nil, err
+	}
+	x := &serviceClient_SwInterfaceTxPlacementGetClient{stream}
+	if err := x.Stream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+type RPCService_SwInterfaceTxPlacementGetClient interface {
+	Recv() (*SwInterfaceTxPlacementDetails, error)
+	api.Stream
+}
+
+type serviceClient_SwInterfaceTxPlacementGetClient struct {
+	api.Stream
+}
+
+func (c *serviceClient_SwInterfaceTxPlacementGetClient) Recv() (*SwInterfaceTxPlacementDetails, error) {
+	msg, err := c.Stream.RecvMsg()
+	if err != nil {
+		return nil, err
+	}
+	switch m := msg.(type) {
+	case *SwInterfaceTxPlacementDetails:
+		return m, nil
+	case *SwInterfaceTxPlacementGetReply:
+		err = c.Stream.Close()
+		if err != nil {
+			return nil, err
+		}
+		return nil, io.EOF
+	default:
+		return nil, fmt.Errorf("unexpected message: %T %v", m, m)
+	}
 }
 
 func (c *serviceClient) WantInterfaceEvents(ctx context.Context, in *WantInterfaceEvents) (*WantInterfaceEventsReply, error) {

--- a/vpplink/binapi/vppapi/memif/memif.ba.go
+++ b/vpplink/binapi/vppapi/memif/memif.ba.go
@@ -4,7 +4,7 @@
 //
 // Contents:
 //   2 enums
-//  14 messages
+//  12 messages
 //
 package memif
 
@@ -26,7 +26,7 @@ const _ = api.GoVppAPIPackageIsVersion2
 const (
 	APIFile    = "memif"
 	APIVersion = "3.0.0"
-	VersionCrc = 0xb559017
+	VersionCrc = 0x9ec8c1e7
 )
 
 // MemifMode defines enum 'memif_mode'.
@@ -442,15 +442,14 @@ func (m *MemifSocketFilenameAddDelReply) Unmarshal(b []byte) error {
 type MemifSocketFilenameAddDelV2 struct {
 	IsAdd          bool   `binapi:"bool,name=is_add" json:"is_add,omitempty"`
 	SocketID       uint32 `binapi:"u32,name=socket_id,default=4294967295" json:"socket_id,omitempty"`
-	SocketFilename string `binapi:"string[108],name=socket_filename" json:"socket_filename,omitempty"`
-	Namespace      string `binapi:"string[],name=namespace" json:"namespace,omitempty"`
+	SocketFilename string `binapi:"string[],name=socket_filename" json:"socket_filename,omitempty"`
 }
 
 func (m *MemifSocketFilenameAddDelV2) Reset() { *m = MemifSocketFilenameAddDelV2{} }
 func (*MemifSocketFilenameAddDelV2) GetMessageName() string {
 	return "memif_socket_filename_add_del_v2"
 }
-func (*MemifSocketFilenameAddDelV2) GetCrcString() string { return "89588bb7" }
+func (*MemifSocketFilenameAddDelV2) GetCrcString() string { return "34223bdf" }
 func (*MemifSocketFilenameAddDelV2) GetMessageType() api.MessageType {
 	return api.RequestMessage
 }
@@ -459,10 +458,9 @@ func (m *MemifSocketFilenameAddDelV2) Size() (size int) {
 	if m == nil {
 		return 0
 	}
-	size += 1                    // m.IsAdd
-	size += 4                    // m.SocketID
-	size += 108                  // m.SocketFilename
-	size += 4 + len(m.Namespace) // m.Namespace
+	size += 1                         // m.IsAdd
+	size += 4                         // m.SocketID
+	size += 4 + len(m.SocketFilename) // m.SocketFilename
 	return size
 }
 func (m *MemifSocketFilenameAddDelV2) Marshal(b []byte) ([]byte, error) {
@@ -472,16 +470,14 @@ func (m *MemifSocketFilenameAddDelV2) Marshal(b []byte) ([]byte, error) {
 	buf := codec.NewBuffer(b)
 	buf.EncodeBool(m.IsAdd)
 	buf.EncodeUint32(m.SocketID)
-	buf.EncodeString(m.SocketFilename, 108)
-	buf.EncodeString(m.Namespace, 0)
+	buf.EncodeString(m.SocketFilename, 0)
 	return buf.Bytes(), nil
 }
 func (m *MemifSocketFilenameAddDelV2) Unmarshal(b []byte) error {
 	buf := codec.NewBuffer(b)
 	m.IsAdd = buf.DecodeBool()
 	m.SocketID = buf.DecodeUint32()
-	m.SocketFilename = buf.DecodeString(108)
-	m.Namespace = buf.DecodeString(0)
+	m.SocketFilename = buf.DecodeString(0)
 	return nil
 }
 
@@ -588,76 +584,6 @@ func (m *MemifSocketFilenameDump) Unmarshal(b []byte) error {
 	return nil
 }
 
-// MemifSocketFilenameV2Details defines message 'memif_socket_filename_v2_details'.
-type MemifSocketFilenameV2Details struct {
-	SocketID       uint32 `binapi:"u32,name=socket_id" json:"socket_id,omitempty"`
-	SocketFilename string `binapi:"string[108],name=socket_filename" json:"socket_filename,omitempty"`
-	Namespace      string `binapi:"string[],name=namespace" json:"namespace,omitempty"`
-}
-
-func (m *MemifSocketFilenameV2Details) Reset() { *m = MemifSocketFilenameV2Details{} }
-func (*MemifSocketFilenameV2Details) GetMessageName() string {
-	return "memif_socket_filename_v2_details"
-}
-func (*MemifSocketFilenameV2Details) GetCrcString() string { return "a21f3380" }
-func (*MemifSocketFilenameV2Details) GetMessageType() api.MessageType {
-	return api.ReplyMessage
-}
-
-func (m *MemifSocketFilenameV2Details) Size() (size int) {
-	if m == nil {
-		return 0
-	}
-	size += 4                    // m.SocketID
-	size += 108                  // m.SocketFilename
-	size += 4 + len(m.Namespace) // m.Namespace
-	return size
-}
-func (m *MemifSocketFilenameV2Details) Marshal(b []byte) ([]byte, error) {
-	if b == nil {
-		b = make([]byte, m.Size())
-	}
-	buf := codec.NewBuffer(b)
-	buf.EncodeUint32(m.SocketID)
-	buf.EncodeString(m.SocketFilename, 108)
-	buf.EncodeString(m.Namespace, 0)
-	return buf.Bytes(), nil
-}
-func (m *MemifSocketFilenameV2Details) Unmarshal(b []byte) error {
-	buf := codec.NewBuffer(b)
-	m.SocketID = buf.DecodeUint32()
-	m.SocketFilename = buf.DecodeString(108)
-	m.Namespace = buf.DecodeString(0)
-	return nil
-}
-
-// MemifSocketFilenameV2Dump defines message 'memif_socket_filename_v2_dump'.
-type MemifSocketFilenameV2Dump struct{}
-
-func (m *MemifSocketFilenameV2Dump) Reset()               { *m = MemifSocketFilenameV2Dump{} }
-func (*MemifSocketFilenameV2Dump) GetMessageName() string { return "memif_socket_filename_v2_dump" }
-func (*MemifSocketFilenameV2Dump) GetCrcString() string   { return "51077d14" }
-func (*MemifSocketFilenameV2Dump) GetMessageType() api.MessageType {
-	return api.RequestMessage
-}
-
-func (m *MemifSocketFilenameV2Dump) Size() (size int) {
-	if m == nil {
-		return 0
-	}
-	return size
-}
-func (m *MemifSocketFilenameV2Dump) Marshal(b []byte) ([]byte, error) {
-	if b == nil {
-		b = make([]byte, m.Size())
-	}
-	buf := codec.NewBuffer(b)
-	return buf.Bytes(), nil
-}
-func (m *MemifSocketFilenameV2Dump) Unmarshal(b []byte) error {
-	return nil
-}
-
 func init() { file_memif_binapi_init() }
 func file_memif_binapi_init() {
 	api.RegisterMessage((*MemifCreate)(nil), "memif_create_b1b25061")
@@ -668,12 +594,10 @@ func file_memif_binapi_init() {
 	api.RegisterMessage((*MemifDump)(nil), "memif_dump_51077d14")
 	api.RegisterMessage((*MemifSocketFilenameAddDel)(nil), "memif_socket_filename_add_del_a2ce1a10")
 	api.RegisterMessage((*MemifSocketFilenameAddDelReply)(nil), "memif_socket_filename_add_del_reply_e8d4e804")
-	api.RegisterMessage((*MemifSocketFilenameAddDelV2)(nil), "memif_socket_filename_add_del_v2_89588bb7")
+	api.RegisterMessage((*MemifSocketFilenameAddDelV2)(nil), "memif_socket_filename_add_del_v2_34223bdf")
 	api.RegisterMessage((*MemifSocketFilenameAddDelV2Reply)(nil), "memif_socket_filename_add_del_v2_reply_9f29bdb9")
 	api.RegisterMessage((*MemifSocketFilenameDetails)(nil), "memif_socket_filename_details_7ff326f7")
 	api.RegisterMessage((*MemifSocketFilenameDump)(nil), "memif_socket_filename_dump_51077d14")
-	api.RegisterMessage((*MemifSocketFilenameV2Details)(nil), "memif_socket_filename_v2_details_a21f3380")
-	api.RegisterMessage((*MemifSocketFilenameV2Dump)(nil), "memif_socket_filename_v2_dump_51077d14")
 }
 
 // Messages returns list of all messages in this module.
@@ -691,7 +615,5 @@ func AllMessages() []api.Message {
 		(*MemifSocketFilenameAddDelV2Reply)(nil),
 		(*MemifSocketFilenameDetails)(nil),
 		(*MemifSocketFilenameDump)(nil),
-		(*MemifSocketFilenameV2Details)(nil),
-		(*MemifSocketFilenameV2Dump)(nil),
 	}
 }

--- a/vpplink/binapi/vppapi/memif/memif_rpc.ba.go
+++ b/vpplink/binapi/vppapi/memif/memif_rpc.ba.go
@@ -19,7 +19,6 @@ type RPCService interface {
 	MemifSocketFilenameAddDel(ctx context.Context, in *MemifSocketFilenameAddDel) (*MemifSocketFilenameAddDelReply, error)
 	MemifSocketFilenameAddDelV2(ctx context.Context, in *MemifSocketFilenameAddDelV2) (*MemifSocketFilenameAddDelV2Reply, error)
 	MemifSocketFilenameDump(ctx context.Context, in *MemifSocketFilenameDump) (RPCService_MemifSocketFilenameDumpClient, error)
-	MemifSocketFilenameV2Dump(ctx context.Context, in *MemifSocketFilenameV2Dump) (RPCService_MemifSocketFilenameV2DumpClient, error)
 }
 
 type serviceClient struct {
@@ -140,49 +139,6 @@ func (c *serviceClient_MemifSocketFilenameDumpClient) Recv() (*MemifSocketFilena
 	}
 	switch m := msg.(type) {
 	case *MemifSocketFilenameDetails:
-		return m, nil
-	case *memclnt.ControlPingReply:
-		err = c.Stream.Close()
-		if err != nil {
-			return nil, err
-		}
-		return nil, io.EOF
-	default:
-		return nil, fmt.Errorf("unexpected message: %T %v", m, m)
-	}
-}
-
-func (c *serviceClient) MemifSocketFilenameV2Dump(ctx context.Context, in *MemifSocketFilenameV2Dump) (RPCService_MemifSocketFilenameV2DumpClient, error) {
-	stream, err := c.conn.NewStream(ctx)
-	if err != nil {
-		return nil, err
-	}
-	x := &serviceClient_MemifSocketFilenameV2DumpClient{stream}
-	if err := x.Stream.SendMsg(in); err != nil {
-		return nil, err
-	}
-	if err = x.Stream.SendMsg(&memclnt.ControlPing{}); err != nil {
-		return nil, err
-	}
-	return x, nil
-}
-
-type RPCService_MemifSocketFilenameV2DumpClient interface {
-	Recv() (*MemifSocketFilenameV2Details, error)
-	api.Stream
-}
-
-type serviceClient_MemifSocketFilenameV2DumpClient struct {
-	api.Stream
-}
-
-func (c *serviceClient_MemifSocketFilenameV2DumpClient) Recv() (*MemifSocketFilenameV2Details, error) {
-	msg, err := c.Stream.RecvMsg()
-	if err != nil {
-		return nil, err
-	}
-	switch m := msg.(type) {
-	case *MemifSocketFilenameV2Details:
 		return m, nil
 	case *memclnt.ControlPingReply:
 		err = c.Stream.Close()

--- a/vpplink/binapi/vppapi/tapv2/tapv2.ba.go
+++ b/vpplink/binapi/vppapi/tapv2/tapv2.ba.go
@@ -4,7 +4,7 @@
 //
 // Contents:
 //   1 enum
-//   6 messages
+//   8 messages
 //
 package tapv2
 
@@ -27,7 +27,7 @@ const _ = api.GoVppAPIPackageIsVersion2
 const (
 	APIFile    = "tapv2"
 	APIVersion = "4.0.0"
-	VersionCrc = 0x439a6221
+	VersionCrc = 0xc2f80dc7
 )
 
 // TapFlags defines enum 'tap_flags'.
@@ -216,38 +216,37 @@ func (m *SwInterfaceTapV2Dump) Unmarshal(b []byte) error {
 
 // TapCreateV2 defines message 'tap_create_v2'.
 type TapCreateV2 struct {
-	ID                   uint32                        `binapi:"u32,name=id,default=4294967295" json:"id,omitempty"`
-	UseRandomMac         bool                          `binapi:"bool,name=use_random_mac,default=true" json:"use_random_mac,omitempty"`
-	MacAddress           ethernet_types.MacAddress     `binapi:"mac_address,name=mac_address" json:"mac_address,omitempty"`
-	NumRxQueues          uint8                         `binapi:"u8,name=num_rx_queues,default=1" json:"num_rx_queues,omitempty"`
-	NumTxQueuesPerWorker uint8                         `binapi:"u8,name=num_tx_queues_per_worker,default=0" json:"num_tx_queues_per_worker,omitempty"`
-	TxRingSz             uint16                        `binapi:"u16,name=tx_ring_sz,default=256" json:"tx_ring_sz,omitempty"`
-	RxRingSz             uint16                        `binapi:"u16,name=rx_ring_sz,default=256" json:"rx_ring_sz,omitempty"`
-	HostMtuSet           bool                          `binapi:"bool,name=host_mtu_set" json:"host_mtu_set,omitempty"`
-	HostMtuSize          uint32                        `binapi:"u32,name=host_mtu_size" json:"host_mtu_size,omitempty"`
-	HostMacAddrSet       bool                          `binapi:"bool,name=host_mac_addr_set" json:"host_mac_addr_set,omitempty"`
-	HostMacAddr          ethernet_types.MacAddress     `binapi:"mac_address,name=host_mac_addr" json:"host_mac_addr,omitempty"`
-	HostIP4PrefixSet     bool                          `binapi:"bool,name=host_ip4_prefix_set" json:"host_ip4_prefix_set,omitempty"`
-	HostIP4Prefix        ip_types.IP4AddressWithPrefix `binapi:"ip4_address_with_prefix,name=host_ip4_prefix" json:"host_ip4_prefix,omitempty"`
-	HostIP6PrefixSet     bool                          `binapi:"bool,name=host_ip6_prefix_set" json:"host_ip6_prefix_set,omitempty"`
-	HostIP6Prefix        ip_types.IP6AddressWithPrefix `binapi:"ip6_address_with_prefix,name=host_ip6_prefix" json:"host_ip6_prefix,omitempty"`
-	HostIP4GwSet         bool                          `binapi:"bool,name=host_ip4_gw_set" json:"host_ip4_gw_set,omitempty"`
-	HostIP4Gw            ip_types.IP4Address           `binapi:"ip4_address,name=host_ip4_gw" json:"host_ip4_gw,omitempty"`
-	HostIP6GwSet         bool                          `binapi:"bool,name=host_ip6_gw_set" json:"host_ip6_gw_set,omitempty"`
-	HostIP6Gw            ip_types.IP6Address           `binapi:"ip6_address,name=host_ip6_gw" json:"host_ip6_gw,omitempty"`
-	TapFlags             TapFlags                      `binapi:"tap_flags,name=tap_flags" json:"tap_flags,omitempty"`
-	HostNamespaceSet     bool                          `binapi:"bool,name=host_namespace_set" json:"host_namespace_set,omitempty"`
-	HostNamespace        string                        `binapi:"string[64],name=host_namespace" json:"host_namespace,omitempty"`
-	HostIfNameSet        bool                          `binapi:"bool,name=host_if_name_set" json:"host_if_name_set,omitempty"`
-	HostIfName           string                        `binapi:"string[64],name=host_if_name" json:"host_if_name,omitempty"`
-	HostBridgeSet        bool                          `binapi:"bool,name=host_bridge_set" json:"host_bridge_set,omitempty"`
-	HostBridge           string                        `binapi:"string[64],name=host_bridge" json:"host_bridge,omitempty"`
-	Tag                  string                        `binapi:"string[],name=tag" json:"tag,omitempty"`
+	ID               uint32                        `binapi:"u32,name=id,default=4294967295" json:"id,omitempty"`
+	UseRandomMac     bool                          `binapi:"bool,name=use_random_mac,default=true" json:"use_random_mac,omitempty"`
+	MacAddress       ethernet_types.MacAddress     `binapi:"mac_address,name=mac_address" json:"mac_address,omitempty"`
+	NumRxQueues      uint8                         `binapi:"u8,name=num_rx_queues,default=1" json:"num_rx_queues,omitempty"`
+	TxRingSz         uint16                        `binapi:"u16,name=tx_ring_sz,default=256" json:"tx_ring_sz,omitempty"`
+	RxRingSz         uint16                        `binapi:"u16,name=rx_ring_sz,default=256" json:"rx_ring_sz,omitempty"`
+	HostMtuSet       bool                          `binapi:"bool,name=host_mtu_set" json:"host_mtu_set,omitempty"`
+	HostMtuSize      uint32                        `binapi:"u32,name=host_mtu_size" json:"host_mtu_size,omitempty"`
+	HostMacAddrSet   bool                          `binapi:"bool,name=host_mac_addr_set" json:"host_mac_addr_set,omitempty"`
+	HostMacAddr      ethernet_types.MacAddress     `binapi:"mac_address,name=host_mac_addr" json:"host_mac_addr,omitempty"`
+	HostIP4PrefixSet bool                          `binapi:"bool,name=host_ip4_prefix_set" json:"host_ip4_prefix_set,omitempty"`
+	HostIP4Prefix    ip_types.IP4AddressWithPrefix `binapi:"ip4_address_with_prefix,name=host_ip4_prefix" json:"host_ip4_prefix,omitempty"`
+	HostIP6PrefixSet bool                          `binapi:"bool,name=host_ip6_prefix_set" json:"host_ip6_prefix_set,omitempty"`
+	HostIP6Prefix    ip_types.IP6AddressWithPrefix `binapi:"ip6_address_with_prefix,name=host_ip6_prefix" json:"host_ip6_prefix,omitempty"`
+	HostIP4GwSet     bool                          `binapi:"bool,name=host_ip4_gw_set" json:"host_ip4_gw_set,omitempty"`
+	HostIP4Gw        ip_types.IP4Address           `binapi:"ip4_address,name=host_ip4_gw" json:"host_ip4_gw,omitempty"`
+	HostIP6GwSet     bool                          `binapi:"bool,name=host_ip6_gw_set" json:"host_ip6_gw_set,omitempty"`
+	HostIP6Gw        ip_types.IP6Address           `binapi:"ip6_address,name=host_ip6_gw" json:"host_ip6_gw,omitempty"`
+	TapFlags         TapFlags                      `binapi:"tap_flags,name=tap_flags" json:"tap_flags,omitempty"`
+	HostNamespaceSet bool                          `binapi:"bool,name=host_namespace_set" json:"host_namespace_set,omitempty"`
+	HostNamespace    string                        `binapi:"string[64],name=host_namespace" json:"host_namespace,omitempty"`
+	HostIfNameSet    bool                          `binapi:"bool,name=host_if_name_set" json:"host_if_name_set,omitempty"`
+	HostIfName       string                        `binapi:"string[64],name=host_if_name" json:"host_if_name,omitempty"`
+	HostBridgeSet    bool                          `binapi:"bool,name=host_bridge_set" json:"host_bridge_set,omitempty"`
+	HostBridge       string                        `binapi:"string[64],name=host_bridge" json:"host_bridge,omitempty"`
+	Tag              string                        `binapi:"string[],name=tag" json:"tag,omitempty"`
 }
 
 func (m *TapCreateV2) Reset()               { *m = TapCreateV2{} }
 func (*TapCreateV2) GetMessageName() string { return "tap_create_v2" }
-func (*TapCreateV2) GetCrcString() string   { return "8004afdc" }
+func (*TapCreateV2) GetCrcString() string   { return "2d0d6570" }
 func (*TapCreateV2) GetMessageType() api.MessageType {
 	return api.RequestMessage
 }
@@ -260,7 +259,6 @@ func (m *TapCreateV2) Size() (size int) {
 	size += 1              // m.UseRandomMac
 	size += 1 * 6          // m.MacAddress
 	size += 1              // m.NumRxQueues
-	size += 1              // m.NumTxQueuesPerWorker
 	size += 2              // m.TxRingSz
 	size += 2              // m.RxRingSz
 	size += 1              // m.HostMtuSet
@@ -296,7 +294,6 @@ func (m *TapCreateV2) Marshal(b []byte) ([]byte, error) {
 	buf.EncodeBool(m.UseRandomMac)
 	buf.EncodeBytes(m.MacAddress[:], 6)
 	buf.EncodeUint8(m.NumRxQueues)
-	buf.EncodeUint8(m.NumTxQueuesPerWorker)
 	buf.EncodeUint16(m.TxRingSz)
 	buf.EncodeUint16(m.RxRingSz)
 	buf.EncodeBool(m.HostMtuSet)
@@ -329,7 +326,6 @@ func (m *TapCreateV2) Unmarshal(b []byte) error {
 	m.UseRandomMac = buf.DecodeBool()
 	copy(m.MacAddress[:], buf.DecodeBytes(6))
 	m.NumRxQueues = buf.DecodeUint8()
-	m.NumTxQueuesPerWorker = buf.DecodeUint8()
 	m.TxRingSz = buf.DecodeUint16()
 	m.RxRingSz = buf.DecodeUint16()
 	m.HostMtuSet = buf.DecodeBool()
@@ -388,6 +384,186 @@ func (m *TapCreateV2Reply) Marshal(b []byte) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 func (m *TapCreateV2Reply) Unmarshal(b []byte) error {
+	buf := codec.NewBuffer(b)
+	m.Retval = buf.DecodeInt32()
+	m.SwIfIndex = interface_types.InterfaceIndex(buf.DecodeUint32())
+	return nil
+}
+
+// TapCreateV3 defines message 'tap_create_v3'.
+type TapCreateV3 struct {
+	ID               uint32                        `binapi:"u32,name=id,default=4294967295" json:"id,omitempty"`
+	UseRandomMac     bool                          `binapi:"bool,name=use_random_mac,default=true" json:"use_random_mac,omitempty"`
+	MacAddress       ethernet_types.MacAddress     `binapi:"mac_address,name=mac_address" json:"mac_address,omitempty"`
+	NumRxQueues      uint16                        `binapi:"u16,name=num_rx_queues,default=1" json:"num_rx_queues,omitempty"`
+	NumTxQueues      uint16                        `binapi:"u16,name=num_tx_queues" json:"num_tx_queues,omitempty"`
+	TxRingSz         uint16                        `binapi:"u16,name=tx_ring_sz,default=256" json:"tx_ring_sz,omitempty"`
+	RxRingSz         uint16                        `binapi:"u16,name=rx_ring_sz,default=256" json:"rx_ring_sz,omitempty"`
+	HostMtuSet       bool                          `binapi:"bool,name=host_mtu_set" json:"host_mtu_set,omitempty"`
+	HostMtuSize      uint32                        `binapi:"u32,name=host_mtu_size" json:"host_mtu_size,omitempty"`
+	HostMacAddrSet   bool                          `binapi:"bool,name=host_mac_addr_set" json:"host_mac_addr_set,omitempty"`
+	HostMacAddr      ethernet_types.MacAddress     `binapi:"mac_address,name=host_mac_addr" json:"host_mac_addr,omitempty"`
+	HostIP4PrefixSet bool                          `binapi:"bool,name=host_ip4_prefix_set" json:"host_ip4_prefix_set,omitempty"`
+	HostIP4Prefix    ip_types.IP4AddressWithPrefix `binapi:"ip4_address_with_prefix,name=host_ip4_prefix" json:"host_ip4_prefix,omitempty"`
+	HostIP6PrefixSet bool                          `binapi:"bool,name=host_ip6_prefix_set" json:"host_ip6_prefix_set,omitempty"`
+	HostIP6Prefix    ip_types.IP6AddressWithPrefix `binapi:"ip6_address_with_prefix,name=host_ip6_prefix" json:"host_ip6_prefix,omitempty"`
+	HostIP4GwSet     bool                          `binapi:"bool,name=host_ip4_gw_set" json:"host_ip4_gw_set,omitempty"`
+	HostIP4Gw        ip_types.IP4Address           `binapi:"ip4_address,name=host_ip4_gw" json:"host_ip4_gw,omitempty"`
+	HostIP6GwSet     bool                          `binapi:"bool,name=host_ip6_gw_set" json:"host_ip6_gw_set,omitempty"`
+	HostIP6Gw        ip_types.IP6Address           `binapi:"ip6_address,name=host_ip6_gw" json:"host_ip6_gw,omitempty"`
+	TapFlags         TapFlags                      `binapi:"tap_flags,name=tap_flags" json:"tap_flags,omitempty"`
+	HostNamespaceSet bool                          `binapi:"bool,name=host_namespace_set" json:"host_namespace_set,omitempty"`
+	HostNamespace    string                        `binapi:"string[64],name=host_namespace" json:"host_namespace,omitempty"`
+	HostIfNameSet    bool                          `binapi:"bool,name=host_if_name_set" json:"host_if_name_set,omitempty"`
+	HostIfName       string                        `binapi:"string[64],name=host_if_name" json:"host_if_name,omitempty"`
+	HostBridgeSet    bool                          `binapi:"bool,name=host_bridge_set" json:"host_bridge_set,omitempty"`
+	HostBridge       string                        `binapi:"string[64],name=host_bridge" json:"host_bridge,omitempty"`
+	Tag              string                        `binapi:"string[],name=tag" json:"tag,omitempty"`
+}
+
+func (m *TapCreateV3) Reset()               { *m = TapCreateV3{} }
+func (*TapCreateV3) GetMessageName() string { return "tap_create_v3" }
+func (*TapCreateV3) GetCrcString() string   { return "3f3fd1df" }
+func (*TapCreateV3) GetMessageType() api.MessageType {
+	return api.RequestMessage
+}
+
+func (m *TapCreateV3) Size() (size int) {
+	if m == nil {
+		return 0
+	}
+	size += 4              // m.ID
+	size += 1              // m.UseRandomMac
+	size += 1 * 6          // m.MacAddress
+	size += 2              // m.NumRxQueues
+	size += 2              // m.NumTxQueues
+	size += 2              // m.TxRingSz
+	size += 2              // m.RxRingSz
+	size += 1              // m.HostMtuSet
+	size += 4              // m.HostMtuSize
+	size += 1              // m.HostMacAddrSet
+	size += 1 * 6          // m.HostMacAddr
+	size += 1              // m.HostIP4PrefixSet
+	size += 1 * 4          // m.HostIP4Prefix.Address
+	size += 1              // m.HostIP4Prefix.Len
+	size += 1              // m.HostIP6PrefixSet
+	size += 1 * 16         // m.HostIP6Prefix.Address
+	size += 1              // m.HostIP6Prefix.Len
+	size += 1              // m.HostIP4GwSet
+	size += 1 * 4          // m.HostIP4Gw
+	size += 1              // m.HostIP6GwSet
+	size += 1 * 16         // m.HostIP6Gw
+	size += 4              // m.TapFlags
+	size += 1              // m.HostNamespaceSet
+	size += 64             // m.HostNamespace
+	size += 1              // m.HostIfNameSet
+	size += 64             // m.HostIfName
+	size += 1              // m.HostBridgeSet
+	size += 64             // m.HostBridge
+	size += 4 + len(m.Tag) // m.Tag
+	return size
+}
+func (m *TapCreateV3) Marshal(b []byte) ([]byte, error) {
+	if b == nil {
+		b = make([]byte, m.Size())
+	}
+	buf := codec.NewBuffer(b)
+	buf.EncodeUint32(m.ID)
+	buf.EncodeBool(m.UseRandomMac)
+	buf.EncodeBytes(m.MacAddress[:], 6)
+	buf.EncodeUint16(m.NumRxQueues)
+	buf.EncodeUint16(m.NumTxQueues)
+	buf.EncodeUint16(m.TxRingSz)
+	buf.EncodeUint16(m.RxRingSz)
+	buf.EncodeBool(m.HostMtuSet)
+	buf.EncodeUint32(m.HostMtuSize)
+	buf.EncodeBool(m.HostMacAddrSet)
+	buf.EncodeBytes(m.HostMacAddr[:], 6)
+	buf.EncodeBool(m.HostIP4PrefixSet)
+	buf.EncodeBytes(m.HostIP4Prefix.Address[:], 4)
+	buf.EncodeUint8(m.HostIP4Prefix.Len)
+	buf.EncodeBool(m.HostIP6PrefixSet)
+	buf.EncodeBytes(m.HostIP6Prefix.Address[:], 16)
+	buf.EncodeUint8(m.HostIP6Prefix.Len)
+	buf.EncodeBool(m.HostIP4GwSet)
+	buf.EncodeBytes(m.HostIP4Gw[:], 4)
+	buf.EncodeBool(m.HostIP6GwSet)
+	buf.EncodeBytes(m.HostIP6Gw[:], 16)
+	buf.EncodeUint32(uint32(m.TapFlags))
+	buf.EncodeBool(m.HostNamespaceSet)
+	buf.EncodeString(m.HostNamespace, 64)
+	buf.EncodeBool(m.HostIfNameSet)
+	buf.EncodeString(m.HostIfName, 64)
+	buf.EncodeBool(m.HostBridgeSet)
+	buf.EncodeString(m.HostBridge, 64)
+	buf.EncodeString(m.Tag, 0)
+	return buf.Bytes(), nil
+}
+func (m *TapCreateV3) Unmarshal(b []byte) error {
+	buf := codec.NewBuffer(b)
+	m.ID = buf.DecodeUint32()
+	m.UseRandomMac = buf.DecodeBool()
+	copy(m.MacAddress[:], buf.DecodeBytes(6))
+	m.NumRxQueues = buf.DecodeUint16()
+	m.NumTxQueues = buf.DecodeUint16()
+	m.TxRingSz = buf.DecodeUint16()
+	m.RxRingSz = buf.DecodeUint16()
+	m.HostMtuSet = buf.DecodeBool()
+	m.HostMtuSize = buf.DecodeUint32()
+	m.HostMacAddrSet = buf.DecodeBool()
+	copy(m.HostMacAddr[:], buf.DecodeBytes(6))
+	m.HostIP4PrefixSet = buf.DecodeBool()
+	copy(m.HostIP4Prefix.Address[:], buf.DecodeBytes(4))
+	m.HostIP4Prefix.Len = buf.DecodeUint8()
+	m.HostIP6PrefixSet = buf.DecodeBool()
+	copy(m.HostIP6Prefix.Address[:], buf.DecodeBytes(16))
+	m.HostIP6Prefix.Len = buf.DecodeUint8()
+	m.HostIP4GwSet = buf.DecodeBool()
+	copy(m.HostIP4Gw[:], buf.DecodeBytes(4))
+	m.HostIP6GwSet = buf.DecodeBool()
+	copy(m.HostIP6Gw[:], buf.DecodeBytes(16))
+	m.TapFlags = TapFlags(buf.DecodeUint32())
+	m.HostNamespaceSet = buf.DecodeBool()
+	m.HostNamespace = buf.DecodeString(64)
+	m.HostIfNameSet = buf.DecodeBool()
+	m.HostIfName = buf.DecodeString(64)
+	m.HostBridgeSet = buf.DecodeBool()
+	m.HostBridge = buf.DecodeString(64)
+	m.Tag = buf.DecodeString(0)
+	return nil
+}
+
+// TapCreateV3Reply defines message 'tap_create_v3_reply'.
+type TapCreateV3Reply struct {
+	Retval    int32                          `binapi:"i32,name=retval" json:"retval,omitempty"`
+	SwIfIndex interface_types.InterfaceIndex `binapi:"interface_index,name=sw_if_index" json:"sw_if_index,omitempty"`
+}
+
+func (m *TapCreateV3Reply) Reset()               { *m = TapCreateV3Reply{} }
+func (*TapCreateV3Reply) GetMessageName() string { return "tap_create_v3_reply" }
+func (*TapCreateV3Reply) GetCrcString() string   { return "5383d31f" }
+func (*TapCreateV3Reply) GetMessageType() api.MessageType {
+	return api.ReplyMessage
+}
+
+func (m *TapCreateV3Reply) Size() (size int) {
+	if m == nil {
+		return 0
+	}
+	size += 4 // m.Retval
+	size += 4 // m.SwIfIndex
+	return size
+}
+func (m *TapCreateV3Reply) Marshal(b []byte) ([]byte, error) {
+	if b == nil {
+		b = make([]byte, m.Size())
+	}
+	buf := codec.NewBuffer(b)
+	buf.EncodeInt32(m.Retval)
+	buf.EncodeUint32(uint32(m.SwIfIndex))
+	return buf.Bytes(), nil
+}
+func (m *TapCreateV3Reply) Unmarshal(b []byte) error {
 	buf := codec.NewBuffer(b)
 	m.Retval = buf.DecodeInt32()
 	m.SwIfIndex = interface_types.InterfaceIndex(buf.DecodeUint32())
@@ -464,8 +640,10 @@ func init() { file_tapv2_binapi_init() }
 func file_tapv2_binapi_init() {
 	api.RegisterMessage((*SwInterfaceTapV2Details)(nil), "sw_interface_tap_v2_details_1e2b2a47")
 	api.RegisterMessage((*SwInterfaceTapV2Dump)(nil), "sw_interface_tap_v2_dump_f9e6675e")
-	api.RegisterMessage((*TapCreateV2)(nil), "tap_create_v2_8004afdc")
+	api.RegisterMessage((*TapCreateV2)(nil), "tap_create_v2_2d0d6570")
 	api.RegisterMessage((*TapCreateV2Reply)(nil), "tap_create_v2_reply_5383d31f")
+	api.RegisterMessage((*TapCreateV3)(nil), "tap_create_v3_3f3fd1df")
+	api.RegisterMessage((*TapCreateV3Reply)(nil), "tap_create_v3_reply_5383d31f")
 	api.RegisterMessage((*TapDeleteV2)(nil), "tap_delete_v2_f9e6675e")
 	api.RegisterMessage((*TapDeleteV2Reply)(nil), "tap_delete_v2_reply_e8d4e804")
 }
@@ -477,6 +655,8 @@ func AllMessages() []api.Message {
 		(*SwInterfaceTapV2Dump)(nil),
 		(*TapCreateV2)(nil),
 		(*TapCreateV2Reply)(nil),
+		(*TapCreateV3)(nil),
+		(*TapCreateV3Reply)(nil),
 		(*TapDeleteV2)(nil),
 		(*TapDeleteV2Reply)(nil),
 	}

--- a/vpplink/binapi/vppapi/tapv2/tapv2_rpc.ba.go
+++ b/vpplink/binapi/vppapi/tapv2/tapv2_rpc.ba.go
@@ -15,6 +15,7 @@ import (
 type RPCService interface {
 	SwInterfaceTapV2Dump(ctx context.Context, in *SwInterfaceTapV2Dump) (RPCService_SwInterfaceTapV2DumpClient, error)
 	TapCreateV2(ctx context.Context, in *TapCreateV2) (*TapCreateV2Reply, error)
+	TapCreateV3(ctx context.Context, in *TapCreateV3) (*TapCreateV3Reply, error)
 	TapDeleteV2(ctx context.Context, in *TapDeleteV2) (*TapDeleteV2Reply, error)
 }
 
@@ -71,6 +72,15 @@ func (c *serviceClient_SwInterfaceTapV2DumpClient) Recv() (*SwInterfaceTapV2Deta
 
 func (c *serviceClient) TapCreateV2(ctx context.Context, in *TapCreateV2) (*TapCreateV2Reply, error) {
 	out := new(TapCreateV2Reply)
+	err := c.conn.Invoke(ctx, in, out)
+	if err != nil {
+		return nil, err
+	}
+	return out, api.RetvalToVPPApiError(out.Retval)
+}
+
+func (c *serviceClient) TapCreateV3(ctx context.Context, in *TapCreateV3) (*TapCreateV3Reply, error) {
+	out := new(TapCreateV3Reply)
 	err := c.conn.Invoke(ctx, in, out)
 	if err != nil {
 		return nil, err

--- a/vpplink/cnat.go
+++ b/vpplink/cnat.go
@@ -118,9 +118,9 @@ func (v *VppLink) CnatAddDelSnatPrefix(prefix *net.IPNet, isAdd bool) (err error
 	response := &cnat.CnatSnatPolicyAddDelExcludePfxReply{}
 	err = v.ch.SendRequest(request).ReceiveReply(response)
 	if err != nil {
-		return errors.Wrap(err, "Add/Del SNAT prefix failed")
+		return errors.Wrapf(err, "%s SNAT prefix failed", IsAddToStr(isAdd))
 	} else if response.Retval != 0 {
-		return fmt.Errorf("Add/Del SNAT prefix failed with retval: %d", response.Retval)
+		return fmt.Errorf("%s SNAT prefix failed with retval: %d", IsAddToStr(isAdd), response.Retval)
 	}
 	return nil
 }

--- a/vpplink/helpers.go
+++ b/vpplink/helpers.go
@@ -103,3 +103,11 @@ func BoolToU8(b bool) uint8 {
 		return 0
 	}
 }
+
+func IsAddToStr(isAdd bool) string {
+	if isAdd {
+		return "add"
+	} else {
+		return "delete"
+	}
+}

--- a/vpplink/interfaces.go
+++ b/vpplink/interfaces.go
@@ -123,17 +123,17 @@ func DefaultIntTo(value, defaultValue int) int {
 }
 
 func (v *VppLink) CreateTapV2(tap *types.TapV2) (swIfIndex uint32, err error) {
-	response := &tapv2.TapCreateV2Reply{}
-	request := &tapv2.TapCreateV2{
-		ID:                   ^uint32(0),
-		Tag:                  tap.Tag,
-		TapFlags:             tapv2.TapFlags(tap.Flags),
-		NumRxQueues:          uint8(DefaultIntTo(tap.NumRxQueues, 1)),
-		NumTxQueuesPerWorker: uint8(DefaultIntTo(tap.NumTxQueues, 1)),
-		TxRingSz:             uint16(DefaultIntTo(tap.TxQueueSize, DEFAULT_QUEUE_SIZE)),
-		RxRingSz:             uint16(DefaultIntTo(tap.RxQueueSize, DEFAULT_QUEUE_SIZE)),
-		HostMtuSize:          uint32(tap.HostMtu),
-		HostMtuSet:           bool(tap.HostMtu != 0),
+	response := &tapv2.TapCreateV3Reply{}
+	request := &tapv2.TapCreateV3{
+		ID:          ^uint32(0),
+		Tag:         tap.Tag,
+		TapFlags:    tapv2.TapFlags(tap.Flags),
+		NumRxQueues: uint16(DefaultIntTo(tap.NumRxQueues, 1)),
+		NumTxQueues: uint16(DefaultIntTo(tap.NumTxQueues, 1)),
+		TxRingSz:    uint16(DefaultIntTo(tap.TxQueueSize, DEFAULT_QUEUE_SIZE)),
+		RxRingSz:    uint16(DefaultIntTo(tap.RxQueueSize, DEFAULT_QUEUE_SIZE)),
+		HostMtuSize: uint32(tap.HostMtu),
+		HostMtuSet:  bool(tap.HostMtu != 0),
 	}
 	if tap.HardwareAddr != nil {
 		request.MacAddress = types.ToVppMacAddress(tap.HardwareAddr)

--- a/vpplink/memif.go
+++ b/vpplink/memif.go
@@ -24,14 +24,13 @@ import (
 	"github.com/projectcalico/vpp-dataplane/vpplink/types"
 )
 
-func (v *VppLink) addDelMemifSocketFileName(socketFileName string, namespace string, socketId uint32, isAdd bool) (uint32, error) {
+func (v *VppLink) addDelMemifSocketFileName(socketFileName string, socketId uint32, isAdd bool) (uint32, error) {
 	v.lock.Lock()
 	defer v.lock.Unlock()
 	response := &memif.MemifSocketFilenameAddDelV2Reply{}
 	request := &memif.MemifSocketFilenameAddDelV2{
 		IsAdd:          isAdd,
 		SocketFilename: socketFileName,
-		Namespace:      namespace,
 		SocketID:       socketId,
 	}
 	err := v.ch.SendRequest(request).ReceiveReply(response)
@@ -43,13 +42,13 @@ func (v *VppLink) addDelMemifSocketFileName(socketFileName string, namespace str
 	return response.SocketID, nil
 }
 
-func (v *VppLink) AddMemifSocketFileName(socketFileName string, namespace string) (uint32, error) {
-	socketId, err := v.addDelMemifSocketFileName(socketFileName, namespace, ^uint32(0), true /* isAdd */)
+func (v *VppLink) AddMemifSocketFileName(socketFileName string) (uint32, error) {
+	socketId, err := v.addDelMemifSocketFileName(socketFileName, ^uint32(0), true /* isAdd */)
 	return socketId, err
 }
 
 func (v *VppLink) DelMemifSocketFileName(socketId uint32) error {
-	_, err := v.addDelMemifSocketFileName("", "", socketId, false /* isAdd */)
+	_, err := v.addDelMemifSocketFileName("", socketId, false /* isAdd */)
 	return err
 }
 

--- a/vpplink/routes.go
+++ b/vpplink/routes.go
@@ -165,11 +165,11 @@ func (v *VppLink) addDelIPRoute(route *types.Route, isAdd bool) error {
 	response := &vppip.IPRouteAddDelReply{}
 	err := v.ch.SendRequest(request).ReceiveReply(response)
 	if err != nil {
-		return errors.Wrapf(err, "failed to add/delete (%d) route from VPP", isAdd)
+		return errors.Wrapf(err, "failed to %s route from VPP", IsAddToStr(isAdd))
 	} else if response.Retval != 0 {
-		return fmt.Errorf("failed to add/delete (%v) route from VPP (retval %d)", isAdd, response.Retval)
+		return fmt.Errorf("failed to %s route from VPP (retval %d)", IsAddToStr(isAdd), response.Retval)
 	}
-	v.log.Debugf("added/deleted (%d) route %+v", isAdd, route)
+	v.log.Debugf("%sed route %+v", IsAddToStr(isAdd), route)
 	return nil
 }
 

--- a/vpplink/session.go
+++ b/vpplink/session.go
@@ -89,9 +89,9 @@ func (v *VppLink) addDelSessionAppNamespace(namespace *types.SessionAppNamespace
 	}
 	err := v.ch.SendRequest(request).ReceiveReply(response)
 	if err != nil {
-		return errors.Wrapf(err, "Add/Del session namespace")
+		return errors.Wrapf(err, "error %sing session namespace", IsAddToStr(isAdd))
 	} else if response.Retval != 0 {
-		return fmt.Errorf("Add/Del session namespace with retval %d", response.Retval)
+		return fmt.Errorf("%s session namespace errored with retval %d", IsAddToStr(isAdd), response.Retval)
 	}
 	return nil
 }


### PR DESCRIPTION
This updates the API for creating memif sockets per changes required for upstream
- memif socket IDs are now allocated opportunistically walking the hash
- netns name is part of the socket name