### PR TITLE
vpp-manager: Make vpp own netns persistant

### DIFF
--- a/vpp-manager/config/config.go
+++ b/vpp-manager/config/config.go
@@ -36,6 +36,7 @@ const (
 	VppApiSocket           = "/var/run/vpp/vpp-api.sock"
 	CalicoVppPidFile       = "/var/run/vpp/calico_vpp.pid"
 	VppPath                = "/usr/bin/vpp"
+	VppNetnsName           = "calico-vpp-ns"
 	VppSigKillTimeout      = 2
 	DefaultEncapSize       = 60 // Used to lower the MTU of the routes to the cluster
 )

--- a/vpp-manager/uplink/af_packet.go
+++ b/vpp-manager/uplink/af_packet.go
@@ -48,6 +48,11 @@ func (d *AFPacketDriver) PreconfigureLinux() error {
 }
 
 func (d *AFPacketDriver) RestoreLinux() {
+	err := d.moveInterfaceFromNS(d.spec.InterfaceName)
+	if err != nil {
+		log.Warnf("Moving uplink back from NS failed", err)
+	}
+
 	if !d.conf.IsUp {
 		return
 	}
@@ -70,8 +75,8 @@ func (d *AFPacketDriver) RestoreLinux() {
 	d.restoreLinuxIfConf(link)
 }
 
-func (d *AFPacketDriver) CreateMainVppInterface(vpp *vpplink.VppLink, vppPid int) (err error) {
-	err = d.moveInterfaceToNS(d.spec.InterfaceName, vppPid)
+func (d *AFPacketDriver) CreateMainVppInterface(vpp *vpplink.VppLink) (err error) {
+	err = d.moveInterfaceToNS(d.spec.InterfaceName)
 	if err != nil {
 		return errors.Wrap(err, "Moving uplink in NS failed")
 	}

--- a/vpp-manager/uplink/af_xdp.go
+++ b/vpp-manager/uplink/af_xdp.go
@@ -93,6 +93,11 @@ func (d *AFXDPDriver) PreconfigureLinux() error {
 }
 
 func (d *AFXDPDriver) RestoreLinux() {
+	err := d.moveInterfaceFromNS(d.spec.InterfaceName)
+	if err != nil {
+		log.Warnf("Moving uplink back from NS failed %s", err)
+	}
+
 	if !d.conf.IsUp {
 		return
 	}
@@ -124,8 +129,8 @@ func (d *AFXDPDriver) RestoreLinux() {
 	d.restoreLinuxIfConf(link)
 }
 
-func (d *AFXDPDriver) CreateMainVppInterface(vpp *vpplink.VppLink, vppPid int) (err error) {
-	err = d.moveInterfaceToNS(d.spec.InterfaceName, vppPid)
+func (d *AFXDPDriver) CreateMainVppInterface(vpp *vpplink.VppLink) (err error) {
+	err = d.moveInterfaceToNS(d.spec.InterfaceName)
 	if err != nil {
 		return errors.Wrap(err, "Moving uplink in NS failed")
 	}

--- a/vpp-manager/uplink/avf.go
+++ b/vpp-manager/uplink/avf.go
@@ -115,6 +115,12 @@ func (d *AVFDriver) PreconfigureLinux() (err error) {
 }
 
 func (d *AVFDriver) RestoreLinux() {
+	if d.pfPCI != "" {
+		err := d.moveInterfaceFromNS(d.spec.InterfaceName)
+		if err != nil {
+			log.Warnf("Moving uplink back from NS failed %s", err)
+		}
+	}
 	if !d.conf.IsUp {
 		return
 	}
@@ -130,11 +136,11 @@ func (d *AVFDriver) RestoreLinux() {
 	d.restoreLinuxIfConf(link)
 }
 
-func (d *AVFDriver) CreateMainVppInterface(vpp *vpplink.VppLink, vppPid int) (err error) {
+func (d *AVFDriver) CreateMainVppInterface(vpp *vpplink.VppLink) (err error) {
 	if d.pfPCI != "" {
 		/* We were passed a PF, move it to vpp's NS so it doesn't
 		   conflict with vpptap0 */
-		err := d.moveInterfaceToNS(d.spec.InterfaceName, vppPid)
+		err := d.moveInterfaceToNS(d.spec.InterfaceName)
 		if err != nil {
 			return errors.Wrap(err, "Moving uplink in NS failed")
 		}

--- a/vpp-manager/uplink/default.go
+++ b/vpp-manager/uplink/default.go
@@ -76,9 +76,9 @@ func (d *DefaultDriver) RestoreLinux() {
 	d.restoreLinuxIfConf(link)
 }
 
-func (d *DefaultDriver) CreateMainVppInterface(vpp *vpplink.VppLink, vppPid int) (err error) {
+func (d *DefaultDriver) CreateMainVppInterface(vpp *vpplink.VppLink) (err error) {
 	// If interface is still in the host, move it to vpp netns to allow creation of the tap
-	err = d.moveInterfaceToNS(d.spec.InterfaceName, vppPid)
+	err = d.moveInterfaceToNS(d.spec.InterfaceName)
 	if err != nil {
 		log.Infof("Did NOT move interface %s to VPP netns: %v", d.spec.InterfaceName, err)
 	} else {

--- a/vpp-manager/uplink/dpdk.go
+++ b/vpp-manager/uplink/dpdk.go
@@ -146,7 +146,7 @@ func (d *DPDKDriver) RestoreLinux() {
 	d.restoreLinuxIfConf(link)
 }
 
-func (d *DPDKDriver) CreateMainVppInterface(vpp *vpplink.VppLink, vppPid int) (err error) {
+func (d *DPDKDriver) CreateMainVppInterface(vpp *vpplink.VppLink) (err error) {
 	// Nothing to do VPP autocreates
 	// refusing to run on secondary interfaces as we have no way to figure out the sw_if_index
 	if !d.spec.IsMain {

--- a/vpp-manager/uplink/rdma.go
+++ b/vpp-manager/uplink/rdma.go
@@ -49,7 +49,10 @@ func (d *RDMADriver) PreconfigureLinux() (err error) {
 }
 
 func (d *RDMADriver) RestoreLinux() {
-
+	err := d.moveInterfaceFromNS(d.spec.InterfaceName)
+	if err != nil {
+		log.Warnf("Moving uplink back from NS failed %s", err)
+	}
 	if !d.conf.IsUp {
 		return
 	}
@@ -65,7 +68,7 @@ func (d *RDMADriver) RestoreLinux() {
 	d.restoreLinuxIfConf(link)
 }
 
-func (d *RDMADriver) CreateMainVppInterface(vpp *vpplink.VppLink, vppPid int) (err error) {
+func (d *RDMADriver) CreateMainVppInterface(vpp *vpplink.VppLink) (err error) {
 	intf := types.RDMAInterface{
 		GenericVppInterface: d.getGenericVppInterface(),
 	}
@@ -75,7 +78,7 @@ func (d *RDMADriver) CreateMainVppInterface(vpp *vpplink.VppLink, vppPid int) (e
 		return errors.Wrapf(err, "Error creating RDMA interface")
 	}
 
-	err = d.moveInterfaceToNS(d.spec.InterfaceName, vppPid)
+	err = d.moveInterfaceToNS(d.spec.InterfaceName)
 	if err != nil {
 		return errors.Wrap(err, "Moving uplink in NS failed")
 	}

--- a/vpp-manager/uplink/virtio.go
+++ b/vpp-manager/uplink/virtio.go
@@ -92,6 +92,10 @@ func (d *VirtioDriver) RestoreLinux() {
 			log.Warnf("Error swapping back driver to %s for %s: %v", d.conf.Driver, d.conf.PciId, err)
 		}
 	}
+	err := d.moveInterfaceFromNS(d.spec.InterfaceName)
+	if err != nil {
+		log.Warnf("Moving uplink back from NS failed %s", err)
+	}
 	if !d.conf.IsUp {
 		return
 	}
@@ -107,7 +111,7 @@ func (d *VirtioDriver) RestoreLinux() {
 	d.restoreLinuxIfConf(link)
 }
 
-func (d *VirtioDriver) CreateMainVppInterface(vpp *vpplink.VppLink, vppPid int) (err error) {
+func (d *VirtioDriver) CreateMainVppInterface(vpp *vpplink.VppLink) (err error) {
 	intf := types.VirtioInterface{
 		GenericVppInterface: d.getGenericVppInterface(),
 		PciId:               d.conf.PciId,

--- a/vpp-manager/uplink/vmxnet3.go
+++ b/vpp-manager/uplink/vmxnet3.go
@@ -87,7 +87,7 @@ func (d *Vmxnet3Driver) RestoreLinux() {
 	d.restoreLinuxIfConf(link)
 }
 
-func (d *Vmxnet3Driver) CreateMainVppInterface(vpp *vpplink.VppLink, vppPid int) (err error) {
+func (d *Vmxnet3Driver) CreateMainVppInterface(vpp *vpplink.VppLink) (err error) {
 	intf := types.Vmxnet3Interface{
 		GenericVppInterface: d.getGenericVppInterface(),
 		EnableGso:           d.params.EnableGSO,


### PR DESCRIPTION
It appears process termination does delete veth interfaces put in its net namespace - 
which is not true for physical interfaces.
This makes the parking netns used for the uplink interfaces taken by VPP a persistant one, 
created with iproute2.


Signed-off-by: Nathan Skrzypczak <nathan.skrzypczak@gmail.com>