### PR TITLE
Makefile: add a reminder to update {{page.vppbranch}} var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,3 +155,6 @@ release: check-TAG check-CALICO_TAG
 	git tag $(TAG)
 	git push --set-upstream origin release/$(TAG)
 	git push origin $(TAG)
+	@echo
+	@echo "***IMPORTANT***IMPORTANT***IMPORTANT***IMPORTANT***"
+	@echo "Please update \"vppbranch\" in https://github.com/projectcalico/calico/blob/${CALICO_TAG}/calico/_config.yml to ${TAG} otherwise the install docs get broken."


### PR DESCRIPTION
The calico user docs make use of {{page.vppbranch}} var which must point to the
release of calico/vpp corresponding to the calico release. This var in turn is
defined as "vppbranch" var in

[https://github.com/projectcalico/calico/blob/<release>/calico/_config.yml](https://github.com/projectcalico/calico/blob/%3Crelease%3E/calico/_config.yml)

In general,

  1. vppbranch=master for the master branch of calico
  2. vppbranch=master after a calico release and until a corresponding
     calico/vpp release
  3. vppbranch=<RELEASE TAG> for a calico release with a corresponding
     calico/vpp release

If "vppbranch" is left dangling after a calico/vpp release then it can
cause the user docs to be broken. An example being the 0.18.0 release
which left "vppbranch" pointing at "master" and as a result the calico
v3.21 user docs referred to the new operator install method when it
should have referred to the older manifest based install method.

So, it is important that "vppbranch" is set correctly after a release. Adding a
reminder in the make release command to prevent such occurences.