### PR TITLE
agent: better policy log & enum fix

### DIFF
--- a/calico-vpp-agent/cni/network_vpp.go
+++ b/calico-vpp-agent/cni/network_vpp.go
@@ -190,10 +190,14 @@ func (s *Server) DelVppInterface(podSpec *storage.LocalPodSpec) {
 	}
 
 	/* Interfaces */
-	s.log.Infof("Deleting Pod VCL")
-	s.vclDriver.DeleteInterface(podSpec)
-	s.log.Infof("Deleting Pod memif")
-	s.memifDriver.DeleteInterface(podSpec)
+	if podSpec.EnableVCL && config.VCLEnabled {
+		s.log.Infof("Deleting Pod VCL")
+		s.vclDriver.DeleteInterface(podSpec)
+	}
+	if podSpec.EnableMemif && config.MemifEnabled {
+		s.log.Infof("Deleting Pod memif")
+		s.memifDriver.DeleteInterface(podSpec)
+	}
 	s.log.Infof("Deleting Pod tuntap")
 	s.tuntapDriver.DeleteInterface(podSpec)
 

--- a/calico-vpp-agent/policy/messages.go
+++ b/calico-vpp-agent/policy/messages.go
@@ -35,7 +35,10 @@ func (s *Server) MessageReader(conn net.Conn) <-chan interface{} {
 				s.log.Errorf("Error receiving message from felix: %v", err)
 				break
 			}
-			ch <- msg
+			if msg != nil {
+				/* Only send supported messages */
+				ch <- msg
+			}
 		}
 		close(ch)
 	}()

--- a/calico-vpp-agent/policy/policy_server.go
+++ b/calico-vpp-agent/policy/policy_server.go
@@ -567,6 +567,7 @@ func (s *Server) handleIpsetUpdate(msg *proto.IPSetUpdate, pending bool) (err er
 		}
 	}
 	state.IPSets[msg.GetId()] = ips
+	log.Infof("Handled Ipset Update [pending:%t] id=%s %s", pending, msg.GetId(), ips)
 	return nil
 }
 
@@ -583,12 +584,13 @@ func (s *Server) handleIpsetDeltaUpdate(msg *proto.IPSetDeltaUpdate, pending boo
 	if err != nil {
 		return errors.Wrap(err, "cannot process ipset delta update")
 	}
+	log.Infof("Handled Ipset delta Update [pending:%t] id=%s %s", pending, msg.GetId(), ips)
 	return nil
 }
 
 func (s *Server) handleIpsetRemove(msg *proto.IPSetRemove, pending bool) (err error) {
 	state := s.currentState(pending)
-	_, ok := state.IPSets[msg.GetId()]
+	ips, ok := state.IPSets[msg.GetId()]
 	if !ok {
 		s.log.Debugf("Received ipset delete for ID %s that doesn't exists", msg.GetId())
 		return nil
@@ -599,6 +601,7 @@ func (s *Server) handleIpsetRemove(msg *proto.IPSetRemove, pending bool) (err er
 			return errors.Wrapf(err, "cannot delete ipset %s", msg.GetId())
 		}
 	}
+	log.Infof("Handled Ipset delta Update [pending:%t] id=%s %s", pending, msg.GetId(), ips)
 	delete(state.IPSets, msg.GetId())
 	return nil
 }
@@ -629,6 +632,7 @@ func (s *Server) handleActivePolicyUpdate(msg *proto.ActivePolicyUpdate, pending
 			return errors.Wrap(p.Create(s.vpp, state), "cannot create policy")
 		}
 	}
+	log.Infof("Handled policy Update [pending:%t] id=%s %s", pending, id, p)
 	return nil
 }
 
@@ -649,6 +653,7 @@ func (s *Server) handleActivePolicyRemove(msg *proto.ActivePolicyRemove, pending
 			return errors.Wrap(err, "error deleting policy")
 		}
 	}
+	log.Infof("Handled policy Remove [pending:%t] id=%s %s", pending, id, existing)
 	delete(state.Policies, id)
 	return nil
 }
@@ -676,6 +681,7 @@ func (s *Server) handleActiveProfileUpdate(msg *proto.ActiveProfileUpdate, pendi
 			return errors.Wrap(p.Create(s.vpp, state), "cannot create profile")
 		}
 	}
+	log.Infof("Handled Profile Update [pending:%t] id=%s %s -> %s", pending, id, existing, p)
 	return nil
 }
 
@@ -693,6 +699,7 @@ func (s *Server) handleActiveProfileRemove(msg *proto.ActiveProfileRemove, pendi
 			return errors.Wrap(err, "error deleting profile")
 		}
 	}
+	log.Infof("Handled Profile Remove [pending:%t] id=%s %s", pending, id, existing)
 	delete(state.Profiles, id)
 	return nil
 }
@@ -764,6 +771,7 @@ func (s *Server) handleHostEndpointUpdate(msg *proto.HostEndpointUpdate, pending
 				"cannot create host endpoint")
 		}
 	}
+	log.Infof("Handled Host Endpoint Update [pending:%t] id=%s %s", pending, *id, hep)
 	return nil
 }
 
@@ -782,6 +790,7 @@ func (s *Server) handleHostEndpointRemove(msg *proto.HostEndpointRemove, pending
 			return errors.Wrap(err, "error deleting host endpoint")
 		}
 	}
+	log.Infof("Handled Host Endpoint Remove [pending:%t] id=%s %s", pending, *id, existing)
 	delete(state.HostEndpoints, *id)
 	return nil
 }
@@ -815,6 +824,7 @@ func (s *Server) handleWorkloadEndpointUpdate(msg *proto.WorkloadEndpointUpdate,
 			return errors.Wrap(wep.Create(s.vpp, intf, state), "cannot create workload endpoint")
 		}
 	}
+	log.Infof("Handled Workload Endpoint Update [pending:%t] id=%s %s -> %s", pending, *id, existing, wep)
 	return nil
 }
 
@@ -835,47 +845,48 @@ func (s *Server) handleWorkloadEndpointRemove(msg *proto.WorkloadEndpointRemove,
 			return errors.Wrap(err, "error deleting workload endpoint")
 		}
 	}
+	log.Infof("Handled Workload Endpoint Remove [pending:%t] id=%s %s", pending, *id, existing)
 	delete(state.WorkloadEndpoints, *id)
 	return nil
 }
 
 func (s *Server) handleHostMetadataUpdate(msg *proto.HostMetadataUpdate, pending bool) (err error) {
-	s.log.Infof("Ignoring HostMetadataUpdate")
+	s.log.Debugf("Ignoring HostMetadataUpdate")
 	return nil
 }
 
 func (s *Server) handleHostMetadataRemove(msg *proto.HostMetadataRemove, pending bool) (err error) {
-	s.log.Infof("Ignoring HostMetadataRemove")
+	s.log.Debugf("Ignoring HostMetadataRemove")
 	return nil
 }
 
 func (s *Server) handleIpamPoolUpdate(msg *proto.IPAMPoolUpdate, pending bool) (err error) {
-	s.log.Infof("Ignoring IpamPoolUpdate")
+	s.log.Debugf("Ignoring IpamPoolUpdate")
 	return nil
 }
 
 func (s *Server) handleIpamPoolRemove(msg *proto.IPAMPoolRemove, pending bool) (err error) {
-	s.log.Infof("Ignoring IpamPoolRemove")
+	s.log.Debugf("Ignoring IpamPoolRemove")
 	return nil
 }
 
 func (s *Server) handleServiceAccountUpdate(msg *proto.ServiceAccountUpdate, pending bool) (err error) {
-	s.log.Infof("Ignoring ServiceAccountUpdate")
+	s.log.Debugf("Ignoring ServiceAccountUpdate")
 	return nil
 }
 
 func (s *Server) handleServiceAccountRemove(msg *proto.ServiceAccountRemove, pending bool) (err error) {
-	s.log.Infof("Ignoring ServiceAccountRemove")
+	s.log.Debugf("Ignoring ServiceAccountRemove")
 	return nil
 }
 
 func (s *Server) handleNamespaceUpdate(msg *proto.NamespaceUpdate, pending bool) (err error) {
-	s.log.Infof("Ignoring NamespaceUpdate")
+	s.log.Debugf("Ignoring NamespaceUpdate")
 	return nil
 }
 
 func (s *Server) handleNamespaceRemove(msg *proto.NamespaceRemove, pending bool) (err error) {
-	s.log.Infof("Ignoring NamespaceRemove")
+	s.log.Debugf("Ignoring NamespaceRemove")
 	return nil
 }
 

--- a/calico-vpp-agent/watchers/peers_watcher.go
+++ b/calico-vpp-agent/watchers/peers_watcher.go
@@ -149,8 +149,6 @@ func (w *PeerWatcher) WatchBGPPeers(t *tomb.Tomb) error {
 		}
 		// node and peer updates should be infrequent enough
 		// just reevaluate all peerings everytime there is an update
-		w.log.Infof("Watching for peer Updates")
-
 		select {
 		case <-t.Dying():
 			w.log.Infof("Peers Watcher asked to stop")
@@ -185,12 +183,12 @@ func (w *PeerWatcher) WatchBGPPeers(t *tomb.Tomb) error {
 				if new != nil {
 					w.nodeStatesByName[new.Name] = *new
 				}
-				w.log.Infof("Nodes updated, reevaluating peerings old %s new %s", old, new)
+				w.log.Debugf("Nodes updated, reevaluating peerings old %s new %s", old, new)
 			default:
 				goto restart
 			}
 		}
-		w.log.Infof("Got peer Update")
+
 	restart:
 		w.log.Info("restarting peers watcher...")
 		w.cleanExistingWatcher()

--- a/vpplink/binapi/vpp_clone_current.sh
+++ b/vpplink/binapi/vpp_clone_current.sh
@@ -97,7 +97,7 @@ git_cherry_pick refs/changes/72/35072/4 # 35072: cnat: maglev fixes & improvemen
 # --------------- Dedicated plugins ---------------
 git_cherry_pick refs/changes/64/33264/7 # 33264: pbl: Port based balancer | https://gerrit.fd.io/r/c/vpp/+/33264
 git_cherry_pick refs/changes/88/31588/1 # 31588: cnat: [WIP] no k8s maglev from pods | https://gerrit.fd.io/r/c/vpp/+/31588
-git_cherry_pick refs/changes/83/28083/20 # 28083: acl: acl-plugin custom policies |  https://gerrit.fd.io/r/c/vpp/+/28083
-git_cherry_pick refs/changes/13/28513/24 # 25813: capo: Calico Policies plugin | https://gerrit.fd.io/r/c/vpp/+/28513
+git_cherry_pick refs/changes/83/28083/21 # 28083: acl: acl-plugin custom policies |  https://gerrit.fd.io/r/c/vpp/+/28083
+git_cherry_pick refs/changes/13/28513/25 # 25813: capo: Calico Policies plugin | https://gerrit.fd.io/r/c/vpp/+/28513
 # --------------- Dedicated plugins ---------------
 

--- a/vpplink/binapi/vppapi/capo/capo.ba.go
+++ b/vpplink/binapi/vppapi/capo/capo.ba.go
@@ -28,7 +28,7 @@ const _ = api.GoVppAPIPackageIsVersion2
 const (
 	APIFile    = "capo"
 	APIVersion = "0.1.0"
-	VersionCrc = 0x3dbafffc
+	VersionCrc = 0xf7ab3600
 )
 
 // CapoEntryType defines enum 'capo_entry_type'.
@@ -131,24 +131,24 @@ func (x CapoRuleAction) String() string {
 type CapoRuleFilterType uint8
 
 const (
-	CAPO_RULE_FILTER_NONE_TYPE CapoRuleFilterType = 1
-	CAPO_RULE_FILTER_ICMP_TYPE CapoRuleFilterType = 2
-	CAPO_RULE_FILTER_ICMP_CODE CapoRuleFilterType = 3
-	CAPO_RULE_FILTER_L4_PROTO  CapoRuleFilterType = 4
+	CAPO_RULE_FILTER_NONE_TYPE CapoRuleFilterType = 0
+	CAPO_RULE_FILTER_ICMP_TYPE CapoRuleFilterType = 1
+	CAPO_RULE_FILTER_ICMP_CODE CapoRuleFilterType = 2
+	CAPO_RULE_FILTER_L4_PROTO  CapoRuleFilterType = 3
 )
 
 var (
 	CapoRuleFilterType_name = map[uint8]string{
-		1: "CAPO_RULE_FILTER_NONE_TYPE",
-		2: "CAPO_RULE_FILTER_ICMP_TYPE",
-		3: "CAPO_RULE_FILTER_ICMP_CODE",
-		4: "CAPO_RULE_FILTER_L4_PROTO",
+		0: "CAPO_RULE_FILTER_NONE_TYPE",
+		1: "CAPO_RULE_FILTER_ICMP_TYPE",
+		2: "CAPO_RULE_FILTER_ICMP_CODE",
+		3: "CAPO_RULE_FILTER_L4_PROTO",
 	}
 	CapoRuleFilterType_value = map[string]uint8{
-		"CAPO_RULE_FILTER_NONE_TYPE": 1,
-		"CAPO_RULE_FILTER_ICMP_TYPE": 2,
-		"CAPO_RULE_FILTER_ICMP_CODE": 3,
-		"CAPO_RULE_FILTER_L4_PROTO":  4,
+		"CAPO_RULE_FILTER_NONE_TYPE": 0,
+		"CAPO_RULE_FILTER_ICMP_TYPE": 1,
+		"CAPO_RULE_FILTER_ICMP_CODE": 2,
+		"CAPO_RULE_FILTER_L4_PROTO":  3,
 	}
 )
 
@@ -1066,7 +1066,7 @@ type CapoRuleCreate struct {
 
 func (m *CapoRuleCreate) Reset()               { *m = CapoRuleCreate{} }
 func (*CapoRuleCreate) GetMessageName() string { return "capo_rule_create" }
-func (*CapoRuleCreate) GetCrcString() string   { return "0e23e3f8" }
+func (*CapoRuleCreate) GetCrcString() string   { return "0a2d5fd6" }
 func (*CapoRuleCreate) GetMessageType() api.MessageType {
 	return api.RequestMessage
 }
@@ -1256,7 +1256,7 @@ type CapoRuleUpdate struct {
 
 func (m *CapoRuleUpdate) Reset()               { *m = CapoRuleUpdate{} }
 func (*CapoRuleUpdate) GetMessageName() string { return "capo_rule_update" }
-func (*CapoRuleUpdate) GetCrcString() string   { return "a45de2cc" }
+func (*CapoRuleUpdate) GetCrcString() string   { return "a0535ee2" }
 func (*CapoRuleUpdate) GetMessageType() api.MessageType {
 	return api.RequestMessage
 }
@@ -1388,11 +1388,11 @@ func file_capo_binapi_init() {
 	api.RegisterMessage((*CapoPolicyDeleteReply)(nil), "capo_policy_delete_reply_e8d4e804")
 	api.RegisterMessage((*CapoPolicyUpdate)(nil), "capo_policy_update_e2097dd0")
 	api.RegisterMessage((*CapoPolicyUpdateReply)(nil), "capo_policy_update_reply_e8d4e804")
-	api.RegisterMessage((*CapoRuleCreate)(nil), "capo_rule_create_0e23e3f8")
+	api.RegisterMessage((*CapoRuleCreate)(nil), "capo_rule_create_0a2d5fd6")
 	api.RegisterMessage((*CapoRuleCreateReply)(nil), "capo_rule_create_reply_b48f8052")
 	api.RegisterMessage((*CapoRuleDelete)(nil), "capo_rule_delete_d19bb6be")
 	api.RegisterMessage((*CapoRuleDeleteReply)(nil), "capo_rule_delete_reply_e8d4e804")
-	api.RegisterMessage((*CapoRuleUpdate)(nil), "capo_rule_update_a45de2cc")
+	api.RegisterMessage((*CapoRuleUpdate)(nil), "capo_rule_update_a0535ee2")
 	api.RegisterMessage((*CapoRuleUpdateReply)(nil), "capo_rule_update_reply_e8d4e804")
 }
 

--- a/vpplink/binapi/vppapi/generate.log
+++ b/vpplink/binapi/vppapi/generate.log
@@ -1,9 +1,9 @@
-VPP Version                 : 22.02-rc0~478-g43255c666
+VPP Version                 : 22.02-rc0~478-g14bd8b4c4
 Binapi-generator version    : govpp v0.4.0-dev
 VPP Base commit             : ed999e3b8 bonding: memory leak on parsing bad CLI command
 ------------------ Cherry picked commits --------------------
-gerrit:28513/24 capo: Calico Policies plugin
-gerrit:28083/20 acl: acl-plugin custom policies
+gerrit:28513/25 capo: Calico Policies plugin
+gerrit:28083/21 acl: acl-plugin custom policies
 gerrit:31588/1 cnat: [WIP] no k8s maglev from pods
 gerrit:33264/7 pbl: Port based balancer
 gerrit:35072/4 cnat: maglev fixes & improvements


### PR DESCRIPTION
This makes the policy log slightly better (less logs for unhandled messages, more for policy changes)
and integrates [0] which makes VPP debug CLIs in capo a bit better, and most importantly 
initialize the enum in the api to 0, as this was not correctly reflected in the generated bindings

[0] https://gerrit.fd.io/r/c/vpp/+/28513/24..25

Signed-off-by: Nathan Skrzypczak <nathan.skrzypczak@gmail.com>