### PR TITLE
vpp-manager: leverage node annot in config template

### DIFF
--- a/vpp-manager/config/config.go
+++ b/vpp-manager/config/config.go
@@ -86,6 +86,8 @@ type VppManagerParams struct {
 	KernelVersion      *KernelVersion
 	AvailableHugePages int
 	VfioUnsafeiommu    bool
+
+	NodeAnnotations map[string]string
 }
 
 type LinuxInterfaceState struct {
@@ -210,6 +212,9 @@ func TemplateScriptReplace(input string, params *VppManagerParams, conf []*Linux
 	template = strings.ReplaceAll(template, "__VPP_DATAPLANE_IF__", params.InterfacesSpecs[0].InterfaceName)
 	for i, ifc := range params.InterfacesSpecs {
 		template = strings.ReplaceAll(template, "__VPP_DATAPLANE_IF_"+fmt.Sprintf("%d", i)+"__", ifc.InterfaceName)
+	}
+	for key, value := range params.NodeAnnotations {
+		template = strings.ReplaceAll(template, fmt.Sprintf("__NODE_ANNOTATION:%s__", key), value)
 	}
 	return template
 }

--- a/vpp-manager/startup/startup.go
+++ b/vpp-manager/startup/startup.go
@@ -115,6 +115,8 @@ func GetVppManagerParams() (params *config.VppManagerParams) {
 		log.Panicf("Parse error %v", err)
 	}
 	getSystemCapabilities(params)
+	annotations := utils.FetchNodeAnnotations(params.NodeName)
+	params.NodeAnnotations = annotations
 	return params
 }
 


### PR DESCRIPTION
Allow to leverage node annotaions in vpp's config file
templating. This can be used to have as vpp.conf
````
cpu {
  main-core __NODE_ANNOTATION:cni.projectcalico.org/vpp.main-core__
}
````
The value coming from:
````
kubectl annotate node <somenode> cni.projectcalico.org/vpp.main-core=123
````
Signed-off-by: Nathan Skrzypczak <nathan.skrzypczak@gmail.com>