### PR TITLE
Make agent fate share on VPP fault

### DIFF
--- a/calico-vpp-agent/connectivity/connectivity.go
+++ b/calico-vpp-agent/connectivity/connectivity.go
@@ -47,8 +47,6 @@ type ConnectivityProviderData struct {
 type ConnectivityProvider interface {
 	AddConnectivity(cn *common.NodeConnectivity) error
 	DelConnectivity(cn *common.NodeConnectivity) error
-	/* Called when VPP signals us that it has restarted */
-	OnVppRestart()
 	/* Check current state in VPP and update local cache */
 	RescanState()
 	/* is it enabled in the config ? */

--- a/calico-vpp-agent/connectivity/flat.go
+++ b/calico-vpp-agent/connectivity/flat.go
@@ -36,10 +36,6 @@ func getRoutePaths(addr net.IP) []types.RoutePath {
 	}}
 }
 
-func (p *FlatL3Provider) OnVppRestart() {
-	/* Nothing to do */
-}
-
 func (p *FlatL3Provider) RescanState() {
 	/* Nothing to do */
 }

--- a/calico-vpp-agent/connectivity/ipip.go
+++ b/calico-vpp-agent/connectivity/ipip.go
@@ -36,11 +36,6 @@ func NewIPIPProvider(d *ConnectivityProviderData) *IpipProvider {
 	return &IpipProvider{d, make(map[string]*types.IPIPTunnel), make(map[uint32]map[string]bool)}
 }
 
-func (p *IpipProvider) OnVppRestart() {
-	p.ipipIfs = make(map[string]*types.IPIPTunnel)
-	p.ipipRoutes = make(map[uint32]map[string]bool)
-}
-
 func (p *IpipProvider) Enabled() bool {
 	return true
 }

--- a/calico-vpp-agent/connectivity/srv6.go
+++ b/calico-vpp-agent/connectivity/srv6.go
@@ -46,10 +46,6 @@ func NewSRv6Provider(d *ConnectivityProviderData) *SRv6Provider {
 	return p
 }
 
-func (p *SRv6Provider) OnVppRestart() {
-	p.log.Infof("SRv6Provider OnVppRestart")
-}
-
 func (p *SRv6Provider) GetSwifindexes() []uint32 {
 	return []uint32{}
 }

--- a/calico-vpp-agent/connectivity/vxlan.go
+++ b/calico-vpp-agent/connectivity/vxlan.go
@@ -98,12 +98,6 @@ func (p *VXLanProvider) RescanState() {
 	}
 }
 
-func (p *VXLanProvider) OnVppRestart() {
-	p.vxlanIfs = make(map[string]types.VXLanTunnel)
-	p.configureVXLANNodes()
-	p.vxlanRoutes = make(map[uint32]map[string]bool)
-}
-
 func (p *VXLanProvider) getVXLANVNI() uint32 {
 	felixConfig := p.GetFelixConfig()
 	if felixConfig.VXLANVNI == 0 {

--- a/calico-vpp-agent/connectivity/wireguard.go
+++ b/calico-vpp-agent/connectivity/wireguard.go
@@ -59,12 +59,6 @@ func (p *WireguardProvider) getWireguardPort() uint16 {
 	return uint16(felixConfig.WireguardListeningPort)
 }
 
-func (p *WireguardProvider) OnVppRestart() {
-	p.wireguardPeers = make(map[string]types.WireguardPeer)
-	p.wireguardV4Tunnel = nil
-	p.wireguardV6Tunnel = nil
-}
-
 func (p *WireguardProvider) getNodePublicKey(cn *common.NodeConnectivity) ([]byte, error) {
 	node := p.GetNodeByIp(cn.NextHop)
 	if node.Status.WireguardPublicKey == "" {

--- a/calico-vpp-agent/prometheus/prometheus.go
+++ b/calico-vpp-agent/prometheus/prometheus.go
@@ -190,10 +190,6 @@ func getTimeSeries(worker int, pod storage.LocalPodSpec, value float64) *metrics
 	}
 }
 
-func (s *Server) OnVppRestart() {
-	/* todo : we should recreate the stats client */
-}
-
 func NewPrometheusServer(vpp *vpplink.VppLink, l *logrus.Entry) *Server {
 	server := &Server{
 		log:                      l,

--- a/calico-vpp-agent/routing/bgp_watcher.go
+++ b/calico-vpp-agent/routing/bgp_watcher.go
@@ -212,7 +212,6 @@ func (w *Server) WatchBGPPath(t *tomb.Tomb) error {
 				}
 				if f == &common.BgpFamilySRv6IPv6 {
 					w.log.Debugf("Path SRv6")
-					common.WaitIfVppIsRestarting()
 					if err := w.injectSRv6Policy(path); err != nil {
 						w.log.Errorf("cannot inject SRv6: %v", err)
 					}

--- a/calico-vpp-agent/routing/routing_server.go
+++ b/calico-vpp-agent/routing/routing_server.go
@@ -39,7 +39,6 @@ const (
 )
 
 type Server struct {
-	*common.CalicoVppServerData
 	log *logrus.Entry
 	vpp *vpplink.VppLink
 
@@ -106,8 +105,6 @@ func (s *Server) ServeRouting(t *tomb.Tomb) (err error) {
 	}
 
 	for t.Alive() {
-		common.WaitIfVppIsRestarting()
-
 		globalConfig, err := s.getGoBGPGlobalConfig()
 		if err != nil {
 			return fmt.Errorf("cannot get global configuration: %v", err)
@@ -253,13 +250,5 @@ func (s *Server) RestoreLocalAddresses() {
 		if err != nil {
 			s.log.Errorf("Local address %s restore failed : %+v", addr.String(), err)
 		}
-	}
-}
-
-func (s *Server) OnVppRestart() {
-	s.log.Infof("Restarting ROUTING")
-	err := s.configureLocalNodeSnat()
-	if err != nil {
-		s.log.Errorf("error reconfiguring loical node snat: %v", err)
 	}
 }

--- a/calico-vpp-agent/services/service_server.go
+++ b/calico-vpp-agent/services/service_server.go
@@ -55,7 +55,6 @@ func (es *CnatTranslateEntryVPPState) String() string {
 }
 
 type Server struct {
-	*common.CalicoVppServerData
 	log              *logrus.Entry
 	vpp              *vpplink.VppLink
 	endpointStore    cache.Store
@@ -63,7 +62,7 @@ type Server struct {
 	serviceInformer  cache.Controller
 	endpointInformer cache.Controller
 
-	lock sync.Mutex /* protects handleServiceEndpointEvent(s)/OnVppRestartServe */
+	lock sync.Mutex /* protects handleServiceEndpointEvent(s)/Serve */
 
 	BGPConf     *calicov3.BGPConfigurationSpec
 	nodeBGPSpec *oldv3.NodeBGPSpec
@@ -189,31 +188,6 @@ func (s *Server) configureSnat() (err error) {
 	return nil
 }
 
-func (s *Server) OnVppRestart() {
-	/* SNAT-outgoing config */
-	err := s.configureSnat()
-	if err != nil {
-		s.log.Errorf("Failed to reconfigure SNAT: %v", err)
-	}
-
-	/* Services NAT config */
-	if config.EnableServices {
-		s.lock.Lock()
-		defer s.lock.Unlock()
-		newState := make(map[string]CnatTranslateEntryVPPState)
-		for key, entry := range s.stateMap {
-			entryID, err := s.vpp.CnatTranslateAdd(&entry.Entry)
-			if err != nil {
-				s.log.Errorf("Error re-injecting cnat entry %s : %v", entry, err)
-			} else {
-				entry.Entry.ID = entryID
-				newState[key] = entry
-			}
-		}
-		s.stateMap = newState
-	}
-}
-
 func (s *Server) findMatchingService(ep *v1.Endpoints) *v1.Service {
 	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(ep)
 	if err != nil {
@@ -282,8 +256,6 @@ func (s *Server) handleServiceEndpointEvent(service *v1.Service, oldService *v1.
 	if !config.EnableServices {
 		return
 	}
-
-	common.WaitIfVppIsRestarting()
 
 	s.lock.Lock()
 	defer s.lock.Unlock()

--- a/calico-vpp-agent/watchers/bgp_configuration_watcher.go
+++ b/calico-vpp-agent/watchers/bgp_configuration_watcher.go
@@ -126,10 +126,6 @@ func (w *BGPConfigurationWatcher) getDefaultBGPConfig() (*calicov3.BGPConfigurat
 	}
 }
 
-func (w *BGPConfigurationWatcher) OnVppRestart() {
-	/* We don't do anything */
-}
-
 func (w *BGPConfigurationWatcher) WatchBGPConfiguration(t *tomb.Tomb) error {
 	for t.Alive() {
 		select {

--- a/calico-vpp-agent/watchers/ipam.go
+++ b/calico-vpp-agent/watchers/ipam.go
@@ -61,7 +61,6 @@ type IpamCache interface {
 	GetPrefixIPPool(*net.IPNet) *calicov3.IPPool
 	SyncIPAM(t *tomb.Tomb) error
 	WaitReady()
-	OnVppRestart()
 	IPNetNeedsSNAT(prefix *net.IPNet) bool
 }
 
@@ -310,15 +309,6 @@ func (c *ipamCache) ipamUpdateHandler(pool *calicov3.IPPool, prevPool *calicov3.
 		})
 	}
 	return nil
-}
-
-func (c *ipamCache) OnVppRestart() {
-	for _, pool := range c.ippoolmap {
-		err := c.ipamUpdateHandler(&pool, nil)
-		if err != nil {
-			c.log.Errorf("ipam restart error: %s", err)
-		}
-	}
 }
 
 func (c *ipamCache) WaitReady() {

--- a/calico-vpp-agent/watchers/kernel_watcher.go
+++ b/calico-vpp-agent/watchers/kernel_watcher.go
@@ -95,10 +95,6 @@ func (w *KernelWatcher) WatchKernelRoute(t *tomb.Tomb) error {
 	}
 }
 
-func (w *KernelWatcher) OnVppRestart() {
-	/* Do nothing */
-}
-
 func (w *KernelWatcher) loadKernelRoute() error {
 	filter := &netlink.Route{
 		Table: syscall.RT_TABLE_MAIN,

--- a/calico-vpp-agent/watchers/nodes_watcher.go
+++ b/calico-vpp-agent/watchers/nodes_watcher.go
@@ -254,12 +254,6 @@ func (w *NodeWatcher) handleNodeUpdate(node *common.NodeState, eventType watch.E
 	return false, err /* don't restart */
 }
 
-func (w *NodeWatcher) OnVppRestart() {
-	for _, node := range w.nodeStatesByName {
-		w.configureRemoteNodeSnat(&node, true /* isAdd */)
-	}
-}
-
 func (w *NodeWatcher) configureRemoteNodeSnat(node *common.NodeState, isAdd bool) {
 	if node.Spec.BGP.IPv4Address != "" {
 		addr, _, err := net.ParseCIDR(node.Spec.BGP.IPv4Address)

--- a/calico-vpp-agent/watchers/peers_watcher.go
+++ b/calico-vpp-agent/watchers/peers_watcher.go
@@ -52,10 +52,6 @@ type bgpPeer struct {
 	SweepFlag bool
 }
 
-func (w *PeerWatcher) OnVppRestart() {
-	/* We don't do anything */
-}
-
 // selectsNode determines whether or not the selector mySelector
 // matches the labels on the given node.
 func selectsNode(mySelector string, n *oldv3.Node) (bool, error) {

--- a/calico-vpp-agent/watchers/prefix_watcher.go
+++ b/calico-vpp-agent/watchers/prefix_watcher.go
@@ -161,10 +161,6 @@ func (w *PrefixWatcher) updateBGPPaths(paths []*bgpapi.Path) error {
 	return nil
 }
 
-func (w *PrefixWatcher) OnVppRestart() {
-	/* We don't do anything */
-}
-
 // _updatePrefixSet updates 'aggregated' and 'host' prefix-sets
 // we add the exact prefix to 'aggregated' set, and add corresponding longer
 // prefixes to 'host' set.

--- a/calico-vpp-agent/watchers/srv6_localsid_watcher.go
+++ b/calico-vpp-agent/watchers/srv6_localsid_watcher.go
@@ -106,10 +106,6 @@ func (p *LocalSIDWatcher) getSidFromPool(ipnet string) (newSidAddr ip_types.IP6A
 	return newSidAddr, nil
 }
 
-func (w *LocalSIDWatcher) OnVppRestart() {
-	/* We don't do anything */
-}
-
 func (w *LocalSIDWatcher) SetOurBGPSpec(nodeBGPSpec *oldv3.NodeBGPSpec) {
 	w.nodeBGPSpec = nodeBGPSpec
 }

--- a/vpplink/interfaces.go
+++ b/vpplink/interfaces.go
@@ -591,15 +591,15 @@ func (v *VppLink) DisableGSOFeature(swIfIndex uint32) error {
 	return v.enableDisableGso(swIfIndex, false)
 }
 
-func (v *VppLink) SetInterfaceTxPlacement(swIfIndex uint32, queue int, arraySize int, worker uint32) error {
+func (v *VppLink) SetInterfaceTxPlacement(swIfIndex uint32, queue int, worker int) error {
 	v.lock.Lock()
 	defer v.lock.Unlock()
 
 	request := &interfaces.SwInterfaceSetTxPlacement{
 		SwIfIndex: interface_types.InterfaceIndex(swIfIndex),
 		QueueID:   uint32(queue),
-		ArraySize: uint32(arraySize),
-		Threads:   []uint32{worker},
+		ArraySize: uint32(1),
+		Threads:   []uint32{uint32(worker)},
 	}
 	response := &interfaces.SwInterfaceSetTxPlacementReply{}
 	err := v.ch.SendRequest(request).ReceiveReply(response)


### PR DESCRIPTION
This PR changes the behavior of the agent on VPP's fault (SIGUSR1) to exit, and wait to be restarted by the k8s scheduler. This simplifies the state-reconciliation logic, most importantly preventing re-programming of VPP to trigger another segfault and end up in semi-programmed state.