### PR TITLE
agent: fix policies init

### DIFF
--- a/calico-vpp-agent/policy/policy_server.go
+++ b/calico-vpp-agent/policy/policy_server.go
@@ -385,15 +385,19 @@ func (s *Server) ServePolicy(t *tomb.Tomb) error {
 
 	err = s.createAllowFromHostPolicy()
 	if err != nil {
-		s.log.Errorf("Error in createAllowFromHostPolicy %s", err)
+		return errors.Wrap(err, "Error in createAllowFromHostPolicy")
 	}
 	err = s.createEndpointToHostPolicy()
 	if err != nil {
-		s.log.Errorf("Error in createAllowFromHostPolicy %s", err)
+		return errors.Wrap(err, "Error in createAllowFromHostPolicy")
 	}
 	err = s.createAllowToHostPolicy()
 	if err != nil {
-		s.log.Errorf("Error in createAllowToHostPolicy %s", err)
+		return errors.Wrap(err, "Error in createAllowToHostPolicy")
+	}
+	err = s.createFailSafePolicies()
+	if err != nil {
+		return errors.Wrap(err, "Error in createFailSafePolicies")
 	}
 
 	for {


### PR DESCRIPTION
Return an error when the policy creation fails,
otherwise we risk a NPE on updates that depend
on the server properties they fill.

Also add the createFailSafePolicies that went
missing with #341

Signed-off-by: Nathan Skrzypczak <nathan.skrzypczak@gmail.com>