### PR TITLE
agent: recreate felixConfig for missing fields

### DIFF
--- a/calico-vpp-agent/policy/policy_server.go
+++ b/calico-vpp-agent/policy/policy_server.go
@@ -598,12 +598,14 @@ func (s *Server) handleConfigUpdate(msg *proto.ConfigUpdate) (err error) {
 	s.log.Infof("Got config from felix: %+v", msg)
 	s.state = StateSyncing
 
-	oldFelixConfig := s.felixConfig.Copy()
+	oldFelixConfig := s.felixConfig
 	removeFelixConfigFileField(msg.Config)
-	changed, err := s.felixConfig.UpdateFrom(msg.Config, felixConfig.InternalOverride)
+	s.felixConfig = felixConfig.New()
+	_, err = s.felixConfig.UpdateFrom(msg.Config, felixConfig.InternalOverride)
 	if err != nil {
 		return err
 	}
+	changed := !reflect.DeepEqual(oldFelixConfig.RawValues(), s.felixConfig.RawValues())
 
 	// Note: This function will be called each time the Felix config changes.
 	// If we start handling config settings that require agent restart,


### PR DESCRIPTION
It can apparently happen that some fields are missing
when receiving the felixConfig via the socket.
Recreating the felixConfig object from scratch
each time resets the values to their default when
the fields are not present

Signed-off-by: Nathan Skrzypczak <nathan.skrzypczak@gmail.com>