### PR TITLE
agent: better VRF tags

### DIFF
--- a/calico-vpp-agent/cni/pod_interface/common.go
+++ b/calico-vpp-agent/cni/pod_interface/common.go
@@ -115,7 +115,7 @@ func (i *PodInterfaceDriverData) DoPodInterfaceConfiguration(podSpec *storage.Lo
 	i.SpreadRxQueuesOnWorkers(swIfIndex)
 
 	for _, ipFamily := range vpplink.IpFamilies {
-		vrfId := podSpec.GetVrfId(ipFamily.IsIp6)
+		vrfId := podSpec.GetVrfId(ipFamily)
 		err = i.vpp.SetInterfaceVRF(swIfIndex, vrfId, ipFamily.IsIp6)
 		if err != nil {
 			return errors.Wrapf(err, "error setting vpp if[%d] in pod vrf", swIfIndex)

--- a/calico-vpp-agent/cni/pod_interface/loopback.go
+++ b/calico-vpp-agent/cni/pod_interface/loopback.go
@@ -46,7 +46,7 @@ func (i *LoopbackPodInterfaceDriver) CreateInterface(podSpec *storage.LocalPodSp
 	podSpec.LoopbackSwIfIndex = swIfIndex
 
 	for _, ipFamily := range vpplink.IpFamilies {
-		vrfId := podSpec.GetVrfId(ipFamily.IsIp6)
+		vrfId := podSpec.GetVrfId(ipFamily)
 		err = i.vpp.SetInterfaceVRF(swIfIndex, vrfId, ipFamily.IsIp6)
 		if err != nil {
 			return errors.Wrapf(err, "Error setting loopback %d in per pod vrf", swIfIndex)

--- a/vpplink/helpers.go
+++ b/vpplink/helpers.go
@@ -16,8 +16,9 @@
 package vpplink
 
 import (
-	"reflect"
+	"net"
 	"time"
+	"reflect"
 
 	"github.com/pkg/errors"
 
@@ -26,13 +27,26 @@ import (
 
 type IpFamily struct {
 	Str   string
+	ShortStr string
 	IsIp6 bool
 	IsIp4 bool
 }
 
 var (
-	IpFamilies = []IpFamily{{"ip4", false, true}, {"ip6", true, false}}
+	IpFamilyV4 = IpFamily{"ip4", "4", false, true}
+	IpFamilyV6 = IpFamily{"ip6", "6", true, false}
+	IpFamilies = []IpFamily{IpFamilyV4, IpFamilyV6}
 )
+
+func IpFamilyFromIPNet(ipNet *net.IPNet) IpFamily {
+	if ipNet == nil {
+		return IpFamilyV4
+	}
+	if ipNet.IP.To4() == nil {
+		return IpFamilyV6
+	}
+	return IpFamilyV4
+}
 
 type CleanupCall struct {
 	args []interface{}

--- a/vpplink/ip.go
+++ b/vpplink/ip.go
@@ -77,8 +77,8 @@ func (v *VppLink) AddVRF(index uint32, isIP6 bool, name string) error {
 	return v.addDelVRF(index, name, isIP6, true /*isAdd*/)
 }
 
-func (v *VppLink) DelVRF(index uint32, isIP6 bool, name string) error {
-	return v.addDelVRF(index, name, isIP6, false /*isAdd*/)
+func (v *VppLink) DelVRF(index uint32, isIP6 bool) error {
+	return v.addDelVRF(index, "", isIP6, false /*isAdd*/)
 }
 
 func (v *VppLink) AllocateVRF(isIP6 bool, name string) (uint32, error) {


### PR DESCRIPTION
This make the VRF tag be a hash (netns, ipversion),
followed by the ip version, and the netns basename truncated to 63 chars
Matching existing VRFs is then done based on this tag.

This allows to keep a user friendly display in the debug CLI
while preventing toe stepping on restarts (where existing VrfIds
get reallocated)

Signed-off-by: Nathan Skrzypczak <nathan.skrzypczak@gmail.com>