### PR TITLE
agent: fix CNI pointer on state-recon

### DIFF
--- a/calico-vpp-agent/cni/cni_server.go
+++ b/calico-vpp-agent/cni/cni_server.go
@@ -260,14 +260,16 @@ func (s *Server) rescanState() error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	for _, podSpec := range podSpecs {
-		_, err2 := s.AddVppInterface(&podSpec, false /* doHostSideConf */)
+		/* copy the podSpec as a pointer to it will be sent over the event chan */
+		podSpecCopy := podSpec.Copy()
+		_, err2 := s.AddVppInterface(&podSpecCopy, false /* doHostSideConf */)
 		if err2 != nil {
 			// TODO: some errors are probably not critical, for instance if the interface
 			// can't be created because the netns disappeared (may happen when the host reboots)
-			s.log.Errorf("Interface add failed %s : %v", podSpec.String(), err2)
+			s.log.Errorf("Interface add failed %s : %v", podSpecCopy.String(), err2)
 			err = err2
 		} else {
-			s.podInterfaceMap[podSpec.Key()] = podSpec
+			s.podInterfaceMap[podSpec.Key()] = podSpecCopy
 		}
 	}
 	return err

--- a/calico-vpp-agent/cni/storage/storage.go
+++ b/calico-vpp-agent/cni/storage/storage.go
@@ -228,6 +228,19 @@ type LocalPodSpec struct {
 	NeedsSnat bool
 }
 
+func (ps *LocalPodSpec) Copy() LocalPodSpec {
+	newPs := *ps
+
+	newPs.Routes = append(make([]LocalIPNet, 0), ps.Routes...)
+	newPs.ContainerIps = append(make([]LocalIP, 0), ps.ContainerIps...)
+	newPs.HostPorts = append(make([]HostPortBinding, 0), ps.HostPorts...)
+	newPs.IfPortConfigs = append(make([]LocalIfPortConfigs, 0), ps.IfPortConfigs...)
+	newPs.PblIndexes = append(make([]uint32, 0), ps.PblIndexes...)
+
+	return newPs
+
+}
+
 // XXX: Increment CniServerStateFileVersion when changing this struct
 type HostPortBinding struct {
 	HostPort      uint16


### PR DESCRIPTION
We were passing a pointer on the loop iterator
in the AddVppInterface function, which ended up
down the event chan. This corrupted the swIfIndices
passed to the policy server on state reconciliation

Signed-off-by: Nathan Skrzypczak <nathan.skrzypczak@gmail.com>