### PR TITLE
agent: clean conflicting IPs on pod add

### DIFF
--- a/calico-vpp-agent/cni/cni_server.go
+++ b/calico-vpp-agent/cni/cni_server.go
@@ -260,13 +260,14 @@ func (s *Server) rescanState() {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	for _, podSpec := range podSpecs {
-		/* copy the podSpec as a pointer to it will be sent over the event chan */
+		/* copy podSpec as a pointer to it will be sent over the event chan */
 		podSpecCopy := podSpec.Copy()
 		_, err := s.AddVppInterface(&podSpecCopy, false /* doHostSideConf */)
 		switch err.(type) {
 		case PodNSNotFoundErr:
 			s.log.Infof("Interface restore but netns missing %s", podSpecCopy.String())
 		case nil:
+			s.log.Infof("pod(re-add) podSpec=%s", podSpecCopy.String())
 			s.podInterfaceMap[podSpec.Key()] = podSpecCopy
 		default:
 			s.log.Errorf("Interface add failed %s : %v", podSpecCopy.String(), err)

--- a/calico-vpp-agent/cni/storage/storage.go
+++ b/calico-vpp-agent/cni/storage/storage.go
@@ -212,8 +212,13 @@ type LocalPodSpec struct {
 	MemifIsL3     bool
 	TunTapIsL3    bool
 
-	/* VPP internals. Persisting on the disk in the case of the
-	 * agent restarting. */
+	/**
+	 * Below are VPP internal ids, mutable fields in AddVppInterface
+	 * We persist them on the disk to avoid rescanning when the agent is restarting.
+	 *
+	 * We should be careful during state-reconciliation as they might not be
+	 * valid anymore. VRF tags should provide this guarantee
+	 */
 	MemifSocketId     uint32
 	TunTapSwIfIndex   uint32
 	MemifSwIfIndex    uint32
@@ -221,10 +226,12 @@ type LocalPodSpec struct {
 	PblIndexesLen     int `struc:"int16,sizeof=PblIndexes"`
 	PblIndexes        []uint32
 
-	V4VrfId uint32
-	V6VrfId uint32
-
-	/* Caching */
+	/**
+	 * These fields are only a runtime cache, but we also store them
+	 * on the disk for debugging purposes.
+	 */
+	V4VrfId   uint32
+	V6VrfId   uint32
 	NeedsSnat bool
 }
 


### PR DESCRIPTION
It can happen that having already configured an address
for a pod in VPP, we receive an add for a new pod with this
same address. The deletion notification for the old pod
comes only later, removing the main VRF route for the new
pod.

This patch ensures that when we adding the second pod we
first make sure to clean up existing pods with this address.

Signed-off-by: Nathan Skrzypczak <nathan.skrzypczak@gmail.com>