### PR TITLE
agent: refactor services

### DIFF
--- a/calico-vpp-agent/cni/network_vpp_hostports.go
+++ b/calico-vpp-agent/cni/network_vpp_hostports.go
@@ -47,7 +47,7 @@ func (s *Server) AddHostPort(podSpec *storage.LocalPodSpec, stack *vpplink.Clean
 			if err != nil {
 				return err
 			} else {
-				stack.Push(s.vpp.CnatTranslateDel, entry.ID)
+				stack.Push(s.vpp.CnatTranslateDel, id)
 			}
 			podSpec.HostPorts[idx].EntryID = id
 		}

--- a/calico-vpp-agent/common/common.go
+++ b/calico-vpp-agent/common/common.go
@@ -503,3 +503,28 @@ func FetchNDataThreads(vpp *vpplink.VppLink, log *logrus.Entry) int {
 	}
 	return nDataThreads
 }
+
+func CompareIPList(newIPList, oldIPList []net.IP) (added []net.IP, deleted []net.IP, changed bool) {
+	oldIPListMap := make(map[string]bool)
+	newIPListMap := make(map[string]bool)
+	for _, elem := range oldIPList {
+		oldIPListMap[elem.String()] = true
+	}
+	for _, elem := range newIPList {
+		newIPListMap[elem.String()] = true
+	}
+	for _, elem := range oldIPList {
+		_, found := newIPListMap[elem.String()]
+		if !found {
+			deleted = append(deleted, elem)
+		}
+	}
+	for _, elem := range newIPList {
+		_, found := oldIPListMap[elem.String()]
+		if !found {
+			added = append(added, elem)
+		}
+	}
+	changed = len(added)+len(deleted) > 0
+	return
+}

--- a/calico-vpp-agent/services/service_handler.go
+++ b/calico-vpp-agent/services/service_handler.go
@@ -18,7 +18,6 @@ package services
 import (
 	"net"
 
-	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 
 	"github.com/projectcalico/vpp-dataplane/calico-vpp-agent/common"
@@ -76,7 +75,7 @@ func getCnatVipDstPort(servicePort *v1.ServicePort, isNodePort bool) uint16 {
 	return uint16(servicePort.Port)
 }
 
-func buildCnatEntryForServicePort(servicePort *v1.ServicePort, service *v1.Service, ep *v1.Endpoints, serviceIP net.IP, isNodePort bool) *CnatTranslateEntryVPPState {
+func buildCnatEntryForServicePort(servicePort *v1.ServicePort, service *v1.Service, ep *v1.Endpoints, serviceIP net.IP, isNodePort bool) *types.CnatTranslateEntry {
 	backends := make([]types.CnatEndpointTuple, 0)
 	isLocalOnly := IsLocalOnly(service)
 	if isNodePort {
@@ -118,38 +117,40 @@ func buildCnatEntryForServicePort(servicePort *v1.ServicePort, service *v1.Servi
 		}
 	}
 
-	return &CnatTranslateEntryVPPState{
-		Entry: types.CnatTranslateEntry{
-			Proto: getServicePortProto(servicePort.Protocol),
-			Endpoint: types.CnatEndpoint{
-				Port: getCnatVipDstPort(servicePort, isNodePort),
-				IP:   serviceIP,
-			},
-			Backends: backends,
-			IsRealIP: isNodePort,
-			LbType:   getCnatLBType(),
-			ID:       vpplink.InvalidID,
+	return &types.CnatTranslateEntry{
+		Proto: getServicePortProto(servicePort.Protocol),
+		Endpoint: types.CnatEndpoint{
+			Port: getCnatVipDstPort(servicePort, isNodePort),
+			IP:   serviceIP,
 		},
-		OwnerServiceID: ServiceID(service),
+		Backends: backends,
+		IsRealIP: isNodePort,
+		LbType:   getCnatLBType(),
 	}
 }
 
-func (s *Server) GetCnatEntries(service *v1.Service, ep *v1.Endpoints) (entries []CnatTranslateEntryVPPState, specificRoutes []net.IP) {
+func (s *Server) GetLocalService(service *v1.Service, ep *v1.Endpoints) (localService *LocalService) {
+	localService = &LocalService{
+		Entries:        make([]types.CnatTranslateEntry, 0),
+		SpecificRoutes: make([]net.IP, 0),
+		ServiceID:      serviceID(&service.ObjectMeta), /* ip.ObjectMeta should yield the same id */
+	}
+
 	clusterIP := net.ParseIP(service.Spec.ClusterIP)
 	nodeIP := s.getNodeIP(vpplink.IsIP6(clusterIP))
 	for _, servicePort := range service.Spec.Ports {
 		if !clusterIP.IsUnspecified() {
 			entry := buildCnatEntryForServicePort(&servicePort, service, ep, clusterIP, false /* isNodePort */)
-			entries = append(entries, *entry)
+			localService.Entries = append(localService.Entries, *entry)
 		}
 
 		for _, eip := range service.Spec.ExternalIPs {
 			extIP := net.ParseIP(eip)
 			if !extIP.IsUnspecified() {
 				entry := buildCnatEntryForServicePort(&servicePort, service, ep, extIP, false /* isNodePort */)
-				entries = append(entries, *entry)
-				if IsLocalOnly(service) && len(entry.Entry.Backends) > 0 {
-					specificRoutes = append(specificRoutes, extIP)
+				localService.Entries = append(localService.Entries, *entry)
+				if IsLocalOnly(service) && len(entry.Backends) > 0 {
+					localService.SpecificRoutes = append(localService.SpecificRoutes, extIP)
 				}
 			}
 		}
@@ -158,9 +159,9 @@ func (s *Server) GetCnatEntries(service *v1.Service, ep *v1.Endpoints) (entries 
 			ingressIP := net.ParseIP(ingress.IP)
 			if !ingressIP.IsUnspecified() {
 				entry := buildCnatEntryForServicePort(&servicePort, service, ep, ingressIP, false /* isNodePort */)
-				entries = append(entries, *entry)
-				if IsLocalOnly(service) && len(entry.Entry.Backends) > 0 {
-					specificRoutes = append(specificRoutes, ingressIP)
+				localService.Entries = append(localService.Entries, *entry)
+				if IsLocalOnly(service) && len(entry.Backends) > 0 {
+					localService.SpecificRoutes = append(localService.SpecificRoutes, ingressIP)
 				}
 			}
 		}
@@ -168,51 +169,11 @@ func (s *Server) GetCnatEntries(service *v1.Service, ep *v1.Endpoints) (entries 
 		if service.Spec.Type == v1.ServiceTypeNodePort {
 			if !nodeIP.IsUnspecified() {
 				entry := buildCnatEntryForServicePort(&servicePort, service, ep, nodeIP, true /* isNodePort */)
-				entries = append(entries, *entry)
+				localService.Entries = append(localService.Entries, *entry)
 			}
 		}
 	}
-	return entries, specificRoutes
-}
-
-func (s *Server) deleteCnatEntry(entry *CnatTranslateEntryVPPState) (err error) {
-	s.log.Infof("svc(del) key=%s %s vpp-id=%d", entry.Key(), entry.String(), entry.Entry.ID)
-	previousEntry, previousFound := s.stateMap[entry.Key()]
-	if !previousFound {
-		s.log.Infof("Cnat entry not found")
-		return nil
-	}
-	if previousEntry.OwnerServiceID != entry.OwnerServiceID {
-		s.log.Infof("Cnat entry found but changed owner since")
-		return nil
-	}
-
-	err = s.vpp.CnatTranslateDel(previousEntry.Entry.ID)
-	if err != nil {
-		return err
-	}
-	delete(s.stateMap, entry.Key())
-
-	return nil
-}
-
-func (s *Server) updateCnatEntry(entry *CnatTranslateEntryVPPState) (err error) {
-	previousEntry, previousFound := s.stateMap[entry.Key()]
-	if previousFound && entry.Entry.Equal(&previousEntry.Entry) {
-		s.log.Infof("svc(same) %s", entry.String())
-		/* OwnerServiceID might have changed */
-		previousEntry.OwnerServiceID = entry.OwnerServiceID
-		s.stateMap[entry.Key()] = previousEntry
-	} else {
-		entryID, err := s.vpp.CnatTranslateAdd(&entry.Entry)
-		if err != nil {
-			return errors.Wrapf(err, "NAT:Error adding translation %s", entry.String())
-		}
-		entry.Entry.ID = entryID
-		s.log.Infof("svc(add) key=%s %s vpp-id=%d", entry.Key(), entry.String(), entryID)
-		s.stateMap[entry.Key()] = *entry
-	}
-	return nil
+	return
 }
 
 func (s *Server) isAddressExternalServiceIP(IPAddress net.IP) bool {
@@ -225,54 +186,89 @@ func (s *Server) isAddressExternalServiceIP(IPAddress net.IP) bool {
 	return false
 }
 
-func (s *Server) advertiseSpecificRoute(IPAddress net.IP, withdraw bool) {
-	if s.isAddressExternalServiceIP(IPAddress) {
-		if withdraw {
+func (s *Server) advertiseSpecificRoute(added []net.IP, deleted []net.IP) {
+	for _, specificRoute := range deleted {
+		if s.isAddressExternalServiceIP(specificRoute) {
 			common.SendEvent(common.CalicoVppEvent{
 				Type: common.LocalPodAddressDeleted,
-				Old:  common.ToMaxLenCIDR(IPAddress),
+				Old:  common.ToMaxLenCIDR(specificRoute),
 			})
-			s.log.Infof("Withdrawing advertisement for service specific route Addresses %+v", IPAddress)
-		} else {
+			s.log.Infof("Withdrawing advertisement for service specific route Addresses %+v", specificRoute)
+		}
+	}
+	for _, specificRoute := range added {
+		if s.isAddressExternalServiceIP(specificRoute) {
 			common.SendEvent(common.CalicoVppEvent{
 				Type: common.LocalPodAddressAdded,
-				New:  common.ToMaxLenCIDR(IPAddress),
+				New:  common.ToMaxLenCIDR(specificRoute),
 			})
-			s.log.Infof("Announcing service specific route Addresses %+v", IPAddress)
+			s.log.Infof("Announcing service specific route Addresses %+v", specificRoute)
 		}
 	}
 }
 
-func (s *Server) addServicePort(service *v1.Service, ep *v1.Endpoints) (err error) {
-	s.log.Debugf("Service update: svc:%s entry:%+v", ServiceID(service), ep.Subsets)
-
-	entries, specificRoutes := s.GetCnatEntries(service, ep)
-	for _, specificRoute := range specificRoutes {
-		s.advertiseSpecificRoute(specificRoute, false /* isWithdraw */)
-	}
+func (s *Server) deleteServiceEntries(entries []types.CnatTranslateEntry, oldService *LocalService) {
 	for _, entry := range entries {
-		err := s.updateCnatEntry(&entry)
-		if err != nil {
-			return err
+		oldServiceState, found := s.serviceStateMap[entry.Key()]
+		if !found {
+			s.log.Infof("svc(del) key=%s Cnat entry not found", entry.Key())
+			continue
 		}
-	}
+		s.log.Infof("svc(del) key=%s %s vpp-id=%d", entry.Key(), entry.String(), oldServiceState.VppID)
+		if oldServiceState.OwnerServiceID != oldService.ServiceID {
+			s.log.Infof("Cnat entry found but changed owner since")
+			continue
+		}
 
-	return nil
+		err := s.vpp.CnatTranslateDel(oldServiceState.VppID)
+		if err != nil {
+			s.log.Errorf("Cnat entry delete errored %s", err)
+			continue
+		}
+		delete(s.serviceStateMap, entry.Key())
+	}
 }
 
-func (s *Server) delServicePort(service *v1.Service, ep *v1.Endpoints) (err error) {
-	s.log.Debugf("Service del: svc:%s entry:%+v", ServiceID(service), ep.Subsets)
+func (s *Server) deleteServiceByName(serviceID string) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
 
-	entries, specificRoutes := s.GetCnatEntries(service, ep)
-	for _, specificRoute := range specificRoutes {
-		s.advertiseSpecificRoute(specificRoute, true /* isWithdraw */)
-	}
-	for _, entry := range entries {
-		err := s.deleteCnatEntry(&entry)
+	for key, oldServiceState := range s.serviceStateMap {
+		if oldServiceState.OwnerServiceID != serviceID {
+			continue
+		}
+		err := s.vpp.CnatTranslateDel(oldServiceState.VppID)
 		if err != nil {
-			return err
+			s.log.Errorf("Cnat entry delete errored %s", err)
+			continue
+		}
+		delete(s.serviceStateMap, key)
+	}
+
+}
+
+func (s *Server) sameServiceEntries(entries []types.CnatTranslateEntry, service *LocalService) {
+	for _, entry := range entries {
+		if serviceState, found := s.serviceStateMap[entry.Key()]; found {
+			serviceState.OwnerServiceID = service.ServiceID
+			s.serviceStateMap[entry.Key()] = serviceState
+		} else {
+			s.log.Warnf("Cnat entry not found key=%s", entry.Key())
 		}
 	}
+}
 
-	return nil
+func (s *Server) addServiceEntries(entries []types.CnatTranslateEntry, service *LocalService) {
+	for _, entry := range entries {
+		entryID, err := s.vpp.CnatTranslateAdd(&entry)
+		if err != nil {
+			s.log.Errorf("svc(add) Error adding translation %s %s", entry.String(), err)
+			continue
+		}
+		s.log.Infof("svc(add) key=%s %s vpp-id=%d", entry.Key(), entry.String(), entryID)
+		s.serviceStateMap[entry.Key()] = ServiceState{
+			OwnerServiceID: service.ServiceID,
+			VppID:          entryID,
+		}
+	}
 }


### PR DESCRIPTION
Resolve services to cnatEntries as soon as possible
to make computing the difference in case of an update
easier.

This also contains a fix : when a delete was preceded
by an update setting the list of backends to [] we were
not actually deleting the cnat entry.

Signed-off-by: Nathan Skrzypczak <nathan.skrzypczak@gmail.com>