### PR TITLE
vpp-manager: fix the uplink driver load checking

### DIFF
--- a/vpp-manager/uplink/default.go
+++ b/vpp-manager/uplink/default.go
@@ -29,7 +29,7 @@ type DefaultDriver struct {
 }
 
 func (d *DefaultDriver) IsSupported(warn bool) bool {
-	if d.params.LoadedDrivers[config.DRIVER_VFIO_PCI] || d.params.LoadedDrivers[config.DRIVER_VFIO_PCI] {
+	if d.params.LoadedDrivers[config.DRIVER_VFIO_PCI] || d.params.LoadedDrivers[config.DRIVER_UIO_PCI_GENERIC] {
 		return true
 	}
 	if warn {


### PR DESCRIPTION
The uplink driver load checking missed the 'uio_pci_generic' driver.

Signed-off-by: Haiyue Wang <haiyue.wang@intel.com>