### PR TITLE
Bump VPP to latest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ load-images:
 CALICO_INSTALLATION ?= installation-default
 .PHONY: test-install-calico
 test-install-calico:
-	kubectl apply -f https://projectcalico.docs.tigera.io/v3.23/manifests/tigera-operator.yaml
+	kubectl replace --force -f https://raw.githubusercontent.com/projectcalico/calico/v3.24.1/manifests/tigera-operator.yaml
 	kubectl apply -f yaml/calico/$(CALICO_INSTALLATION).yaml
 
 # Allows to simply run calico-vpp from release images in a test cluster
@@ -146,6 +146,7 @@ cherry-vpp:
 	@echo "branch    : $(shell cd ${VPP_DIR} && git branch --show-current)"
 	@echo "Are you sure? [y/N] " && read ans && [ $${ans:-N} = y ]
 	@bash ./vpplink/binapi/vpp_clone_current.sh ${VPP_DIR}
+	@make goapi
 
 .PHONY: cherry-wipe
 cherry-wipe:

--- a/vpp-manager/images/ubuntu-build/Dockerfile
+++ b/vpp-manager/images/ubuntu-build/Dockerfile
@@ -11,22 +11,19 @@ RUN apt-get update \
 	libconfuse-dev git-review exuberant-ctags cscope pkg-config \
 	lcov chrpath autoconf libnuma-dev \
 	python3-all python3-setuptools check \
-	libffi-dev python3-ply libmbedtls-dev \
+	libffi-dev python3-ply \
 	cmake ninja-build uuid-dev python3-jsonschema python3-yaml \
 	python3-venv \
-	python3-dev \
-	libnl-3-dev libnl-route-3-dev \
-	enchant \
+	python3-dev python3-pip \
+	libnl-3-dev libnl-route-3-dev libmnl-dev \
 	python3-virtualenv \
 	libssl-dev \
 	libelf-dev \
-	clang-11 clang-format-11 clang-format-10 \
-	enchant-2 \
-	libffi7 \
-	libmnl0 \
-	libiperf0 \
 	iperf3 \
-	libmnl-dev
+	nasm \
+	clang clang-format-11 \
+	enchant-2 \
+	libffi7
 
 WORKDIR /
 

--- a/vpplink/af_packet.go
+++ b/vpplink/af_packet.go
@@ -26,13 +26,18 @@ import (
 func (v *VppLink) CreateAfPacket(intf *types.AfPacketInterface) (swIfIndex uint32, err error) {
 	v.lock.Lock()
 	defer v.lock.Unlock()
-	response := &af_packet.AfPacketCreateV2Reply{}
-	request := &af_packet.AfPacketCreateV2{
+	response := &af_packet.AfPacketCreateV3Reply{}
+	request := &af_packet.AfPacketCreateV3{
+		Mode:             af_packet.AF_PACKET_API_MODE_ETHERNET,
 		UseRandomHwAddr:  true,
 		HostIfName:       intf.HostInterfaceName,
 		RxFramesPerBlock: uint32(intf.RxQueueSize),
 		TxFramesPerBlock: uint32(intf.TxQueueSize),
 		RxFrameSize:      uint32(1024 * 8 * 8),
+		TxFrameSize:      uint32(1024 * 8 * 8),
+		NumRxQueues:      uint16(intf.NumRxQueues),
+		NumTxQueues:      uint16(intf.NumTxQueues),
+		Flags:            af_packet.AF_PACKET_API_FLAG_VERSION_2 | af_packet.AF_PACKET_API_FLAG_CKSUM_GSO | af_packet.AF_PACKET_API_FLAG_QDISC_BYPASS,
 	}
 	if intf.HardwareAddr != nil {
 		request.UseRandomHwAddr = false

--- a/vpplink/binapi/vpp_clone_current.sh
+++ b/vpplink/binapi/vpp_clone_current.sh
@@ -84,27 +84,17 @@ function git_clone_cd_and_reset ()
 
 # --------------- Things to cherry pick ---------------
 
-git_clone_cd_and_reset "$1" 38659d8f2c588500f4e844195e0c59ab1cf6107f
+git_clone_cd_and_reset "$1" 8b90d89b05322ceaaf57e0eda403c4f92546f7b3
 
-
-git_cherry_pick refs/changes/45/36945/1 # 36945: wireguard: fix ipv6 handshake packet | https://gerrit.fd.io/r/c/vpp/+/36945
-git_cherry_pick refs/changes/18/37018/1 # 37018: wireguard: fix ipv6 payload_length computation | https://gerrit.fd.io/r/c/vpp/+/37018
-git_cherry_pick refs/changes/13/34713/3 # 34713: vppinfra: improve & test abstract socket | https://gerrit.fd.io/r/c/vpp/+/34713
-git_cherry_pick refs/changes/71/32271/15 # 32271: memif: add support for ns abstract sockets | https://gerrit.fd.io/r/c/vpp/+/32271
-git_cherry_pick refs/changes/34/34734/2 # 34734: memif: autogenerate socket_ids | https://gerrit.fd.io/r/c/vpp/+/34734
+git_cherry_pick refs/changes/13/34713/4 # 34713: vppinfra: improve & test abstract socket | https://gerrit.fd.io/r/c/vpp/+/34713
+git_cherry_pick refs/changes/71/32271/16 # 32271: memif: add support for ns abstract sockets | https://gerrit.fd.io/r/c/vpp/+/32271
+git_cherry_pick refs/changes/34/34734/3 # 34734: memif: autogenerate socket_ids | https://gerrit.fd.io/r/c/vpp/+/34734
 git_cherry_pick refs/changes/26/34726/1 # 34726: interface: add buffer stats api | https://gerrit.fd.io/r/c/vpp/+/34726
-git_cherry_pick refs/changes/38/35438/1 # 35438: af_packet: fix tx stall by retrying failed sendto | https://gerrit.fd.io/r/c/vpp/+/35438
 git_cherry_pick refs/changes/05/35805/2 # 35805: dpdk: add intf tag to dev{} subinput | https://gerrit.fd.io/r/c/vpp/+/35805
-git_cherry_pick refs/changes/78/35678/2 # 35678: dpdk: copy the enable_rxq_int flag from driver to conf | https://gerrit.fd.io/r/c/vpp/+/35678
-
-git_cherry_pick refs/changes/65/37365/2 # 37365: gso: set the header offsets in gro hdr fixup | https://gerrit.fd.io/r/c/vpp/+/37365
-git_cherry_pick refs/changes/64/37364/1 # 37364: gso: fix the checksum for odd number of data bytes | https://gerrit.fd.io/r/c/vpp/+/37364
 
 # --------------- Dedicated plugins ---------------
 git_cherry_pick refs/changes/64/33264/7 # 33264: pbl: Port based balancer | https://gerrit.fd.io/r/c/vpp/+/33264
-git_cherry_pick refs/changes/88/31588/1 # 31588: cnat: [WIP] no k8s maglev from pods | https://gerrit.fd.io/r/c/vpp/+/31588
+git_cherry_pick refs/changes/88/31588/4 # 31588: cnat: [WIP] no k8s maglev from pods | https://gerrit.fd.io/r/c/vpp/+/31588
 git_cherry_pick refs/changes/83/28083/21 # 28083: acl: acl-plugin custom policies |  https://gerrit.fd.io/r/c/vpp/+/28083
 git_cherry_pick refs/changes/13/28513/28 # 25813: capo: Calico Policies plugin | https://gerrit.fd.io/r/c/vpp/+/28513
-git_cherry_pick refs/changes/31/37131/11 # 37131: urpf: add mode for specific fib index lookup | https://gerrit.fd.io/r/c/vpp/+/37131/
-git_cherry_pick refs/changes/59/37259/2 # 37259: cnat: Add sctp support | https://gerrit.fd.io/r/c/vpp/+/37259
 # --------------- Dedicated plugins ---------------

--- a/vpplink/binapi/vppapi/af_packet/af_packet.ba.go
+++ b/vpplink/binapi/vppapi/af_packet/af_packet.ba.go
@@ -4,10 +4,13 @@
 //
 // Contents:
 //
-//	10 messages
+//	 2 enums
+//	12 messages
 package af_packet
 
 import (
+	"strconv"
+
 	ethernet_types "github.com/projectcalico/vpp-dataplane/vpplink/binapi/vppapi/ethernet_types"
 	interface_types "github.com/projectcalico/vpp-dataplane/vpplink/binapi/vppapi/interface_types"
 	api "go.fd.io/govpp/api"
@@ -23,8 +26,84 @@ const _ = api.GoVppAPIPackageIsVersion2
 const (
 	APIFile    = "af_packet"
 	APIVersion = "2.0.0"
-	VersionCrc = 0x589bd50e
+	VersionCrc = 0x5b12de21
 )
+
+// AfPacketFlags defines enum 'af_packet_flags'.
+type AfPacketFlags uint32
+
+const (
+	AF_PACKET_API_FLAG_QDISC_BYPASS AfPacketFlags = 1
+	AF_PACKET_API_FLAG_CKSUM_GSO    AfPacketFlags = 2
+	AF_PACKET_API_FLAG_VERSION_2    AfPacketFlags = 8
+)
+
+var (
+	AfPacketFlags_name = map[uint32]string{
+		1: "AF_PACKET_API_FLAG_QDISC_BYPASS",
+		2: "AF_PACKET_API_FLAG_CKSUM_GSO",
+		8: "AF_PACKET_API_FLAG_VERSION_2",
+	}
+	AfPacketFlags_value = map[string]uint32{
+		"AF_PACKET_API_FLAG_QDISC_BYPASS": 1,
+		"AF_PACKET_API_FLAG_CKSUM_GSO":    2,
+		"AF_PACKET_API_FLAG_VERSION_2":    8,
+	}
+)
+
+func (x AfPacketFlags) String() string {
+	s, ok := AfPacketFlags_name[uint32(x)]
+	if ok {
+		return s
+	}
+	str := func(n uint32) string {
+		s, ok := AfPacketFlags_name[uint32(n)]
+		if ok {
+			return s
+		}
+		return "AfPacketFlags(" + strconv.Itoa(int(n)) + ")"
+	}
+	for i := uint32(0); i <= 32; i++ {
+		val := uint32(x)
+		if val&(1<<i) != 0 {
+			if s != "" {
+				s += "|"
+			}
+			s += str(1 << i)
+		}
+	}
+	if s == "" {
+		return str(uint32(x))
+	}
+	return s
+}
+
+// AfPacketMode defines enum 'af_packet_mode'.
+type AfPacketMode uint32
+
+const (
+	AF_PACKET_API_MODE_ETHERNET AfPacketMode = 1
+	AF_PACKET_API_MODE_IP       AfPacketMode = 2
+)
+
+var (
+	AfPacketMode_name = map[uint32]string{
+		1: "AF_PACKET_API_MODE_ETHERNET",
+		2: "AF_PACKET_API_MODE_IP",
+	}
+	AfPacketMode_value = map[string]uint32{
+		"AF_PACKET_API_MODE_ETHERNET": 1,
+		"AF_PACKET_API_MODE_IP":       2,
+	}
+)
+
+func (x AfPacketMode) String() string {
+	s, ok := AfPacketMode_name[uint32(x)]
+	if ok {
+		return s
+	}
+	return "AfPacketMode(" + strconv.Itoa(int(x)) + ")"
+}
 
 // AfPacketCreate defines message 'af_packet_create'.
 type AfPacketCreate struct {
@@ -200,6 +279,116 @@ func (m *AfPacketCreateV2Reply) Marshal(b []byte) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 func (m *AfPacketCreateV2Reply) Unmarshal(b []byte) error {
+	buf := codec.NewBuffer(b)
+	m.Retval = buf.DecodeInt32()
+	m.SwIfIndex = interface_types.InterfaceIndex(buf.DecodeUint32())
+	return nil
+}
+
+// AfPacketCreateV3 defines message 'af_packet_create_v3'.
+type AfPacketCreateV3 struct {
+	Mode             AfPacketMode              `binapi:"af_packet_mode,name=mode" json:"mode,omitempty"`
+	HwAddr           ethernet_types.MacAddress `binapi:"mac_address,name=hw_addr" json:"hw_addr,omitempty"`
+	UseRandomHwAddr  bool                      `binapi:"bool,name=use_random_hw_addr" json:"use_random_hw_addr,omitempty"`
+	HostIfName       string                    `binapi:"string[64],name=host_if_name" json:"host_if_name,omitempty"`
+	RxFrameSize      uint32                    `binapi:"u32,name=rx_frame_size" json:"rx_frame_size,omitempty"`
+	TxFrameSize      uint32                    `binapi:"u32,name=tx_frame_size" json:"tx_frame_size,omitempty"`
+	RxFramesPerBlock uint32                    `binapi:"u32,name=rx_frames_per_block" json:"rx_frames_per_block,omitempty"`
+	TxFramesPerBlock uint32                    `binapi:"u32,name=tx_frames_per_block" json:"tx_frames_per_block,omitempty"`
+	Flags            AfPacketFlags             `binapi:"af_packet_flags,name=flags" json:"flags,omitempty"`
+	NumRxQueues      uint16                    `binapi:"u16,name=num_rx_queues,default=1" json:"num_rx_queues,omitempty"`
+	NumTxQueues      uint16                    `binapi:"u16,name=num_tx_queues,default=1" json:"num_tx_queues,omitempty"`
+}
+
+func (m *AfPacketCreateV3) Reset()               { *m = AfPacketCreateV3{} }
+func (*AfPacketCreateV3) GetMessageName() string { return "af_packet_create_v3" }
+func (*AfPacketCreateV3) GetCrcString() string   { return "b3a809d4" }
+func (*AfPacketCreateV3) GetMessageType() api.MessageType {
+	return api.RequestMessage
+}
+
+func (m *AfPacketCreateV3) Size() (size int) {
+	if m == nil {
+		return 0
+	}
+	size += 4     // m.Mode
+	size += 1 * 6 // m.HwAddr
+	size += 1     // m.UseRandomHwAddr
+	size += 64    // m.HostIfName
+	size += 4     // m.RxFrameSize
+	size += 4     // m.TxFrameSize
+	size += 4     // m.RxFramesPerBlock
+	size += 4     // m.TxFramesPerBlock
+	size += 4     // m.Flags
+	size += 2     // m.NumRxQueues
+	size += 2     // m.NumTxQueues
+	return size
+}
+func (m *AfPacketCreateV3) Marshal(b []byte) ([]byte, error) {
+	if b == nil {
+		b = make([]byte, m.Size())
+	}
+	buf := codec.NewBuffer(b)
+	buf.EncodeUint32(uint32(m.Mode))
+	buf.EncodeBytes(m.HwAddr[:], 6)
+	buf.EncodeBool(m.UseRandomHwAddr)
+	buf.EncodeString(m.HostIfName, 64)
+	buf.EncodeUint32(m.RxFrameSize)
+	buf.EncodeUint32(m.TxFrameSize)
+	buf.EncodeUint32(m.RxFramesPerBlock)
+	buf.EncodeUint32(m.TxFramesPerBlock)
+	buf.EncodeUint32(uint32(m.Flags))
+	buf.EncodeUint16(m.NumRxQueues)
+	buf.EncodeUint16(m.NumTxQueues)
+	return buf.Bytes(), nil
+}
+func (m *AfPacketCreateV3) Unmarshal(b []byte) error {
+	buf := codec.NewBuffer(b)
+	m.Mode = AfPacketMode(buf.DecodeUint32())
+	copy(m.HwAddr[:], buf.DecodeBytes(6))
+	m.UseRandomHwAddr = buf.DecodeBool()
+	m.HostIfName = buf.DecodeString(64)
+	m.RxFrameSize = buf.DecodeUint32()
+	m.TxFrameSize = buf.DecodeUint32()
+	m.RxFramesPerBlock = buf.DecodeUint32()
+	m.TxFramesPerBlock = buf.DecodeUint32()
+	m.Flags = AfPacketFlags(buf.DecodeUint32())
+	m.NumRxQueues = buf.DecodeUint16()
+	m.NumTxQueues = buf.DecodeUint16()
+	return nil
+}
+
+// AfPacketCreateV3Reply defines message 'af_packet_create_v3_reply'.
+type AfPacketCreateV3Reply struct {
+	Retval    int32                          `binapi:"i32,name=retval" json:"retval,omitempty"`
+	SwIfIndex interface_types.InterfaceIndex `binapi:"interface_index,name=sw_if_index" json:"sw_if_index,omitempty"`
+}
+
+func (m *AfPacketCreateV3Reply) Reset()               { *m = AfPacketCreateV3Reply{} }
+func (*AfPacketCreateV3Reply) GetMessageName() string { return "af_packet_create_v3_reply" }
+func (*AfPacketCreateV3Reply) GetCrcString() string   { return "5383d31f" }
+func (*AfPacketCreateV3Reply) GetMessageType() api.MessageType {
+	return api.ReplyMessage
+}
+
+func (m *AfPacketCreateV3Reply) Size() (size int) {
+	if m == nil {
+		return 0
+	}
+	size += 4 // m.Retval
+	size += 4 // m.SwIfIndex
+	return size
+}
+func (m *AfPacketCreateV3Reply) Marshal(b []byte) ([]byte, error) {
+	if b == nil {
+		b = make([]byte, m.Size())
+	}
+	buf := codec.NewBuffer(b)
+	buf.EncodeInt32(m.Retval)
+	buf.EncodeUint32(uint32(m.SwIfIndex))
+	return buf.Bytes(), nil
+}
+func (m *AfPacketCreateV3Reply) Unmarshal(b []byte) error {
 	buf := codec.NewBuffer(b)
 	m.Retval = buf.DecodeInt32()
 	m.SwIfIndex = interface_types.InterfaceIndex(buf.DecodeUint32())
@@ -414,6 +603,8 @@ func file_af_packet_binapi_init() {
 	api.RegisterMessage((*AfPacketCreateReply)(nil), "af_packet_create_reply_5383d31f")
 	api.RegisterMessage((*AfPacketCreateV2)(nil), "af_packet_create_v2_4aff0436")
 	api.RegisterMessage((*AfPacketCreateV2Reply)(nil), "af_packet_create_v2_reply_5383d31f")
+	api.RegisterMessage((*AfPacketCreateV3)(nil), "af_packet_create_v3_b3a809d4")
+	api.RegisterMessage((*AfPacketCreateV3Reply)(nil), "af_packet_create_v3_reply_5383d31f")
 	api.RegisterMessage((*AfPacketDelete)(nil), "af_packet_delete_863fa648")
 	api.RegisterMessage((*AfPacketDeleteReply)(nil), "af_packet_delete_reply_e8d4e804")
 	api.RegisterMessage((*AfPacketDetails)(nil), "af_packet_details_58c7c042")
@@ -429,6 +620,8 @@ func AllMessages() []api.Message {
 		(*AfPacketCreateReply)(nil),
 		(*AfPacketCreateV2)(nil),
 		(*AfPacketCreateV2Reply)(nil),
+		(*AfPacketCreateV3)(nil),
+		(*AfPacketCreateV3Reply)(nil),
 		(*AfPacketDelete)(nil),
 		(*AfPacketDeleteReply)(nil),
 		(*AfPacketDetails)(nil),

--- a/vpplink/binapi/vppapi/af_packet/af_packet_rpc.ba.go
+++ b/vpplink/binapi/vppapi/af_packet/af_packet_rpc.ba.go
@@ -15,6 +15,7 @@ import (
 type RPCService interface {
 	AfPacketCreate(ctx context.Context, in *AfPacketCreate) (*AfPacketCreateReply, error)
 	AfPacketCreateV2(ctx context.Context, in *AfPacketCreateV2) (*AfPacketCreateV2Reply, error)
+	AfPacketCreateV3(ctx context.Context, in *AfPacketCreateV3) (*AfPacketCreateV3Reply, error)
 	AfPacketDelete(ctx context.Context, in *AfPacketDelete) (*AfPacketDeleteReply, error)
 	AfPacketDump(ctx context.Context, in *AfPacketDump) (RPCService_AfPacketDumpClient, error)
 	AfPacketSetL4CksumOffload(ctx context.Context, in *AfPacketSetL4CksumOffload) (*AfPacketSetL4CksumOffloadReply, error)
@@ -39,6 +40,15 @@ func (c *serviceClient) AfPacketCreate(ctx context.Context, in *AfPacketCreate) 
 
 func (c *serviceClient) AfPacketCreateV2(ctx context.Context, in *AfPacketCreateV2) (*AfPacketCreateV2Reply, error) {
 	out := new(AfPacketCreateV2Reply)
+	err := c.conn.Invoke(ctx, in, out)
+	if err != nil {
+		return nil, err
+	}
+	return out, api.RetvalToVPPApiError(out.Retval)
+}
+
+func (c *serviceClient) AfPacketCreateV3(ctx context.Context, in *AfPacketCreateV3) (*AfPacketCreateV3Reply, error) {
+	out := new(AfPacketCreateV3Reply)
 	err := c.conn.Invoke(ctx, in, out)
 	if err != nil {
 		return nil, err

--- a/vpplink/binapi/vppapi/generate.log
+++ b/vpplink/binapi/vppapi/generate.log
@@ -1,22 +1,14 @@
-VPP Version                 : 22.06-rc0~257-g47d5ee707
+VPP Version                 : 23.02-rc0~81-g1abb2ae46
 Binapi-generator version    : govpp v0.6.0-dev
-VPP Base commit             : 38659d8f2 sr: fix srv6 definition of behavior associated to a LocalSID
+VPP Base commit             : 8b90d89b0 devices: add support for af-packet v2
 ------------------ Cherry picked commits --------------------
-gerrit:37259/2 cnat: Add sctp support
-gerrit:37131/11 urpf: add mode for specific fib index lookup
 gerrit:28513/28 capo: Calico Policies plugin
 gerrit:28083/21 acl: acl-plugin custom policies
-gerrit:31588/1 cnat: [WIP] no k8s maglev from pods
+gerrit:31588/4 cnat: [WIP] no k8s maglev from pods
 gerrit:33264/7 pbl: Port based balancer
-gerrit:37364/1 gso: fix the checksum for odd number of data bytes
-gerrit:37365/2 gso: set the header offsets in gro hdr fixup
-gerrit:35678/2 dpdk: copy the enable_rxq_int flag from driver to conf
 gerrit:35805/2 dpdk: add intf tag to dev{} subinput
-gerrit:35438/1 af_packet: fix tx stall by retrying failed sendto
 gerrit:34726/1 interface: add buffer stats api
-gerrit:34734/2 memif: autogenerate socket_ids
-gerrit:32271/15 memif: add support for ns abstract sockets
-gerrit:34713/3 vppinfra: improve & test abstract socket
-gerrit:37018/1 wireguard: fix ipv6 payload_length computation
-gerrit:36945/1 wireguard: fix ipv6 handshake packet
+gerrit:34734/3 memif: autogenerate socket_ids
+gerrit:32271/16 memif: add support for ns abstract sockets
+gerrit:34713/4 vppinfra: improve & test abstract socket
 -------------------------------------------------------------

--- a/vpplink/binapi/vppapi/ipsec/ipsec.ba.go
+++ b/vpplink/binapi/vppapi/ipsec/ipsec.ba.go
@@ -4,14 +4,11 @@
 //
 // Contents:
 //
-//	 1 enum
-//	 3 structs
-//	46 messages
+//	 2 structs
+//	48 messages
 package ipsec
 
 import (
-	"strconv"
-
 	interface_types "github.com/projectcalico/vpp-dataplane/vpplink/binapi/vppapi/interface_types"
 	ip_types "github.com/projectcalico/vpp-dataplane/vpplink/binapi/vppapi/ip_types"
 	ipsec_types "github.com/projectcalico/vpp-dataplane/vpplink/binapi/vppapi/ipsec_types"
@@ -29,65 +26,14 @@ const _ = api.GoVppAPIPackageIsVersion2
 const (
 	APIFile    = "ipsec"
 	APIVersion = "5.0.2"
-	VersionCrc = 0x6b08e91e
+	VersionCrc = 0xd8d93805
 )
-
-// IpsecSpdAction defines enum 'ipsec_spd_action'.
-type IpsecSpdAction uint32
-
-const (
-	IPSEC_API_SPD_ACTION_BYPASS  IpsecSpdAction = 0
-	IPSEC_API_SPD_ACTION_DISCARD IpsecSpdAction = 1
-	IPSEC_API_SPD_ACTION_RESOLVE IpsecSpdAction = 2
-	IPSEC_API_SPD_ACTION_PROTECT IpsecSpdAction = 3
-)
-
-var (
-	IpsecSpdAction_name = map[uint32]string{
-		0: "IPSEC_API_SPD_ACTION_BYPASS",
-		1: "IPSEC_API_SPD_ACTION_DISCARD",
-		2: "IPSEC_API_SPD_ACTION_RESOLVE",
-		3: "IPSEC_API_SPD_ACTION_PROTECT",
-	}
-	IpsecSpdAction_value = map[string]uint32{
-		"IPSEC_API_SPD_ACTION_BYPASS":  0,
-		"IPSEC_API_SPD_ACTION_DISCARD": 1,
-		"IPSEC_API_SPD_ACTION_RESOLVE": 2,
-		"IPSEC_API_SPD_ACTION_PROTECT": 3,
-	}
-)
-
-func (x IpsecSpdAction) String() string {
-	s, ok := IpsecSpdAction_name[uint32(x)]
-	if ok {
-		return s
-	}
-	return "IpsecSpdAction(" + strconv.Itoa(int(x)) + ")"
-}
 
 // IpsecItf defines type 'ipsec_itf'.
 type IpsecItf struct {
 	UserInstance uint32                         `binapi:"u32,name=user_instance,default=4294967295" json:"user_instance,omitempty"`
 	Mode         tunnel_types.TunnelMode        `binapi:"tunnel_mode,name=mode" json:"mode,omitempty"`
 	SwIfIndex    interface_types.InterfaceIndex `binapi:"interface_index,name=sw_if_index" json:"sw_if_index,omitempty"`
-}
-
-// IpsecSpdEntry defines type 'ipsec_spd_entry'.
-type IpsecSpdEntry struct {
-	SpdID              uint32           `binapi:"u32,name=spd_id" json:"spd_id,omitempty"`
-	Priority           int32            `binapi:"i32,name=priority" json:"priority,omitempty"`
-	IsOutbound         bool             `binapi:"bool,name=is_outbound" json:"is_outbound,omitempty"`
-	SaID               uint32           `binapi:"u32,name=sa_id" json:"sa_id,omitempty"`
-	Policy             IpsecSpdAction   `binapi:"ipsec_spd_action,name=policy" json:"policy,omitempty"`
-	Protocol           uint8            `binapi:"u8,name=protocol" json:"protocol,omitempty"`
-	RemoteAddressStart ip_types.Address `binapi:"address,name=remote_address_start" json:"remote_address_start,omitempty"`
-	RemoteAddressStop  ip_types.Address `binapi:"address,name=remote_address_stop" json:"remote_address_stop,omitempty"`
-	LocalAddressStart  ip_types.Address `binapi:"address,name=local_address_start" json:"local_address_start,omitempty"`
-	LocalAddressStop   ip_types.Address `binapi:"address,name=local_address_stop" json:"local_address_stop,omitempty"`
-	RemotePortStart    uint16           `binapi:"u16,name=remote_port_start" json:"remote_port_start,omitempty"`
-	RemotePortStop     uint16           `binapi:"u16,name=remote_port_stop" json:"remote_port_stop,omitempty"`
-	LocalPortStart     uint16           `binapi:"u16,name=local_port_start" json:"local_port_start,omitempty"`
-	LocalPortStop      uint16           `binapi:"u16,name=local_port_stop" json:"local_port_stop,omitempty"`
 }
 
 // IpsecTunnelProtect defines type 'ipsec_tunnel_protect'.
@@ -1743,7 +1689,7 @@ func (m *IpsecSpdAddDelReply) Unmarshal(b []byte) error {
 
 // IpsecSpdDetails defines message 'ipsec_spd_details'.
 type IpsecSpdDetails struct {
-	Entry IpsecSpdEntry `binapi:"ipsec_spd_entry,name=entry" json:"entry,omitempty"`
+	Entry ipsec_types.IpsecSpdEntry `binapi:"ipsec_spd_entry,name=entry" json:"entry,omitempty"`
 }
 
 func (m *IpsecSpdDetails) Reset()               { *m = IpsecSpdDetails{} }
@@ -1808,7 +1754,7 @@ func (m *IpsecSpdDetails) Unmarshal(b []byte) error {
 	m.Entry.Priority = buf.DecodeInt32()
 	m.Entry.IsOutbound = buf.DecodeBool()
 	m.Entry.SaID = buf.DecodeUint32()
-	m.Entry.Policy = IpsecSpdAction(buf.DecodeUint32())
+	m.Entry.Policy = ipsec_types.IpsecSpdAction(buf.DecodeUint32())
 	m.Entry.Protocol = buf.DecodeUint8()
 	m.Entry.RemoteAddressStart.Af = ip_types.AddressFamily(buf.DecodeUint8())
 	copy(m.Entry.RemoteAddressStart.Un.XXX_UnionData[:], buf.DecodeBytes(16))
@@ -1863,9 +1809,10 @@ func (m *IpsecSpdDump) Unmarshal(b []byte) error {
 }
 
 // IpsecSpdEntryAddDel defines message 'ipsec_spd_entry_add_del'.
+// Deprecated: the message will be removed in the future versions
 type IpsecSpdEntryAddDel struct {
-	IsAdd bool          `binapi:"bool,name=is_add" json:"is_add,omitempty"`
-	Entry IpsecSpdEntry `binapi:"ipsec_spd_entry,name=entry" json:"entry,omitempty"`
+	IsAdd bool                      `binapi:"bool,name=is_add" json:"is_add,omitempty"`
+	Entry ipsec_types.IpsecSpdEntry `binapi:"ipsec_spd_entry,name=entry" json:"entry,omitempty"`
 }
 
 func (m *IpsecSpdEntryAddDel) Reset()               { *m = IpsecSpdEntryAddDel{} }
@@ -1933,7 +1880,7 @@ func (m *IpsecSpdEntryAddDel) Unmarshal(b []byte) error {
 	m.Entry.Priority = buf.DecodeInt32()
 	m.Entry.IsOutbound = buf.DecodeBool()
 	m.Entry.SaID = buf.DecodeUint32()
-	m.Entry.Policy = IpsecSpdAction(buf.DecodeUint32())
+	m.Entry.Policy = ipsec_types.IpsecSpdAction(buf.DecodeUint32())
 	m.Entry.Protocol = buf.DecodeUint8()
 	m.Entry.RemoteAddressStart.Af = ip_types.AddressFamily(buf.DecodeUint8())
 	copy(m.Entry.RemoteAddressStart.Un.XXX_UnionData[:], buf.DecodeBytes(16))
@@ -1981,6 +1928,131 @@ func (m *IpsecSpdEntryAddDelReply) Marshal(b []byte) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 func (m *IpsecSpdEntryAddDelReply) Unmarshal(b []byte) error {
+	buf := codec.NewBuffer(b)
+	m.Retval = buf.DecodeInt32()
+	m.StatIndex = buf.DecodeUint32()
+	return nil
+}
+
+// IpsecSpdEntryAddDelV2 defines message 'ipsec_spd_entry_add_del_v2'.
+type IpsecSpdEntryAddDelV2 struct {
+	IsAdd bool                        `binapi:"bool,name=is_add" json:"is_add,omitempty"`
+	Entry ipsec_types.IpsecSpdEntryV2 `binapi:"ipsec_spd_entry_v2,name=entry" json:"entry,omitempty"`
+}
+
+func (m *IpsecSpdEntryAddDelV2) Reset()               { *m = IpsecSpdEntryAddDelV2{} }
+func (*IpsecSpdEntryAddDelV2) GetMessageName() string { return "ipsec_spd_entry_add_del_v2" }
+func (*IpsecSpdEntryAddDelV2) GetCrcString() string   { return "7bfe69fc" }
+func (*IpsecSpdEntryAddDelV2) GetMessageType() api.MessageType {
+	return api.RequestMessage
+}
+
+func (m *IpsecSpdEntryAddDelV2) Size() (size int) {
+	if m == nil {
+		return 0
+	}
+	size += 1      // m.IsAdd
+	size += 4      // m.Entry.SpdID
+	size += 4      // m.Entry.Priority
+	size += 1      // m.Entry.IsOutbound
+	size += 4      // m.Entry.SaID
+	size += 4      // m.Entry.Policy
+	size += 1      // m.Entry.Protocol
+	size += 1      // m.Entry.RemoteAddressStart.Af
+	size += 1 * 16 // m.Entry.RemoteAddressStart.Un
+	size += 1      // m.Entry.RemoteAddressStop.Af
+	size += 1 * 16 // m.Entry.RemoteAddressStop.Un
+	size += 1      // m.Entry.LocalAddressStart.Af
+	size += 1 * 16 // m.Entry.LocalAddressStart.Un
+	size += 1      // m.Entry.LocalAddressStop.Af
+	size += 1 * 16 // m.Entry.LocalAddressStop.Un
+	size += 2      // m.Entry.RemotePortStart
+	size += 2      // m.Entry.RemotePortStop
+	size += 2      // m.Entry.LocalPortStart
+	size += 2      // m.Entry.LocalPortStop
+	return size
+}
+func (m *IpsecSpdEntryAddDelV2) Marshal(b []byte) ([]byte, error) {
+	if b == nil {
+		b = make([]byte, m.Size())
+	}
+	buf := codec.NewBuffer(b)
+	buf.EncodeBool(m.IsAdd)
+	buf.EncodeUint32(m.Entry.SpdID)
+	buf.EncodeInt32(m.Entry.Priority)
+	buf.EncodeBool(m.Entry.IsOutbound)
+	buf.EncodeUint32(m.Entry.SaID)
+	buf.EncodeUint32(uint32(m.Entry.Policy))
+	buf.EncodeUint8(m.Entry.Protocol)
+	buf.EncodeUint8(uint8(m.Entry.RemoteAddressStart.Af))
+	buf.EncodeBytes(m.Entry.RemoteAddressStart.Un.XXX_UnionData[:], 16)
+	buf.EncodeUint8(uint8(m.Entry.RemoteAddressStop.Af))
+	buf.EncodeBytes(m.Entry.RemoteAddressStop.Un.XXX_UnionData[:], 16)
+	buf.EncodeUint8(uint8(m.Entry.LocalAddressStart.Af))
+	buf.EncodeBytes(m.Entry.LocalAddressStart.Un.XXX_UnionData[:], 16)
+	buf.EncodeUint8(uint8(m.Entry.LocalAddressStop.Af))
+	buf.EncodeBytes(m.Entry.LocalAddressStop.Un.XXX_UnionData[:], 16)
+	buf.EncodeUint16(m.Entry.RemotePortStart)
+	buf.EncodeUint16(m.Entry.RemotePortStop)
+	buf.EncodeUint16(m.Entry.LocalPortStart)
+	buf.EncodeUint16(m.Entry.LocalPortStop)
+	return buf.Bytes(), nil
+}
+func (m *IpsecSpdEntryAddDelV2) Unmarshal(b []byte) error {
+	buf := codec.NewBuffer(b)
+	m.IsAdd = buf.DecodeBool()
+	m.Entry.SpdID = buf.DecodeUint32()
+	m.Entry.Priority = buf.DecodeInt32()
+	m.Entry.IsOutbound = buf.DecodeBool()
+	m.Entry.SaID = buf.DecodeUint32()
+	m.Entry.Policy = ipsec_types.IpsecSpdAction(buf.DecodeUint32())
+	m.Entry.Protocol = buf.DecodeUint8()
+	m.Entry.RemoteAddressStart.Af = ip_types.AddressFamily(buf.DecodeUint8())
+	copy(m.Entry.RemoteAddressStart.Un.XXX_UnionData[:], buf.DecodeBytes(16))
+	m.Entry.RemoteAddressStop.Af = ip_types.AddressFamily(buf.DecodeUint8())
+	copy(m.Entry.RemoteAddressStop.Un.XXX_UnionData[:], buf.DecodeBytes(16))
+	m.Entry.LocalAddressStart.Af = ip_types.AddressFamily(buf.DecodeUint8())
+	copy(m.Entry.LocalAddressStart.Un.XXX_UnionData[:], buf.DecodeBytes(16))
+	m.Entry.LocalAddressStop.Af = ip_types.AddressFamily(buf.DecodeUint8())
+	copy(m.Entry.LocalAddressStop.Un.XXX_UnionData[:], buf.DecodeBytes(16))
+	m.Entry.RemotePortStart = buf.DecodeUint16()
+	m.Entry.RemotePortStop = buf.DecodeUint16()
+	m.Entry.LocalPortStart = buf.DecodeUint16()
+	m.Entry.LocalPortStop = buf.DecodeUint16()
+	return nil
+}
+
+// IpsecSpdEntryAddDelV2Reply defines message 'ipsec_spd_entry_add_del_v2_reply'.
+type IpsecSpdEntryAddDelV2Reply struct {
+	Retval    int32  `binapi:"i32,name=retval" json:"retval,omitempty"`
+	StatIndex uint32 `binapi:"u32,name=stat_index" json:"stat_index,omitempty"`
+}
+
+func (m *IpsecSpdEntryAddDelV2Reply) Reset()               { *m = IpsecSpdEntryAddDelV2Reply{} }
+func (*IpsecSpdEntryAddDelV2Reply) GetMessageName() string { return "ipsec_spd_entry_add_del_v2_reply" }
+func (*IpsecSpdEntryAddDelV2Reply) GetCrcString() string   { return "9ffac24b" }
+func (*IpsecSpdEntryAddDelV2Reply) GetMessageType() api.MessageType {
+	return api.ReplyMessage
+}
+
+func (m *IpsecSpdEntryAddDelV2Reply) Size() (size int) {
+	if m == nil {
+		return 0
+	}
+	size += 4 // m.Retval
+	size += 4 // m.StatIndex
+	return size
+}
+func (m *IpsecSpdEntryAddDelV2Reply) Marshal(b []byte) ([]byte, error) {
+	if b == nil {
+		b = make([]byte, m.Size())
+	}
+	buf := codec.NewBuffer(b)
+	buf.EncodeInt32(m.Retval)
+	buf.EncodeUint32(m.StatIndex)
+	return buf.Bytes(), nil
+}
+func (m *IpsecSpdEntryAddDelV2Reply) Unmarshal(b []byte) error {
 	buf := codec.NewBuffer(b)
 	m.Retval = buf.DecodeInt32()
 	m.StatIndex = buf.DecodeUint32()
@@ -2418,6 +2490,8 @@ func file_ipsec_binapi_init() {
 	api.RegisterMessage((*IpsecSpdDump)(nil), "ipsec_spd_dump_afefbf7d")
 	api.RegisterMessage((*IpsecSpdEntryAddDel)(nil), "ipsec_spd_entry_add_del_338b7411")
 	api.RegisterMessage((*IpsecSpdEntryAddDelReply)(nil), "ipsec_spd_entry_add_del_reply_9ffac24b")
+	api.RegisterMessage((*IpsecSpdEntryAddDelV2)(nil), "ipsec_spd_entry_add_del_v2_7bfe69fc")
+	api.RegisterMessage((*IpsecSpdEntryAddDelV2Reply)(nil), "ipsec_spd_entry_add_del_v2_reply_9ffac24b")
 	api.RegisterMessage((*IpsecSpdInterfaceDetails)(nil), "ipsec_spd_interface_details_7a0bcf3e")
 	api.RegisterMessage((*IpsecSpdInterfaceDump)(nil), "ipsec_spd_interface_dump_8971de19")
 	api.RegisterMessage((*IpsecSpdsDetails)(nil), "ipsec_spds_details_a04bb254")
@@ -2469,6 +2543,8 @@ func AllMessages() []api.Message {
 		(*IpsecSpdDump)(nil),
 		(*IpsecSpdEntryAddDel)(nil),
 		(*IpsecSpdEntryAddDelReply)(nil),
+		(*IpsecSpdEntryAddDelV2)(nil),
+		(*IpsecSpdEntryAddDelV2Reply)(nil),
 		(*IpsecSpdInterfaceDetails)(nil),
 		(*IpsecSpdInterfaceDump)(nil),
 		(*IpsecSpdsDetails)(nil),

--- a/vpplink/binapi/vppapi/ipsec/ipsec_rpc.ba.go
+++ b/vpplink/binapi/vppapi/ipsec/ipsec_rpc.ba.go
@@ -31,6 +31,7 @@ type RPCService interface {
 	IpsecSpdAddDel(ctx context.Context, in *IpsecSpdAddDel) (*IpsecSpdAddDelReply, error)
 	IpsecSpdDump(ctx context.Context, in *IpsecSpdDump) (RPCService_IpsecSpdDumpClient, error)
 	IpsecSpdEntryAddDel(ctx context.Context, in *IpsecSpdEntryAddDel) (*IpsecSpdEntryAddDelReply, error)
+	IpsecSpdEntryAddDelV2(ctx context.Context, in *IpsecSpdEntryAddDelV2) (*IpsecSpdEntryAddDelV2Reply, error)
 	IpsecSpdInterfaceDump(ctx context.Context, in *IpsecSpdInterfaceDump) (RPCService_IpsecSpdInterfaceDumpClient, error)
 	IpsecSpdsDump(ctx context.Context, in *IpsecSpdsDump) (RPCService_IpsecSpdsDumpClient, error)
 	IpsecTunnelProtectDel(ctx context.Context, in *IpsecTunnelProtectDel) (*IpsecTunnelProtectDelReply, error)
@@ -405,6 +406,15 @@ func (c *serviceClient_IpsecSpdDumpClient) Recv() (*IpsecSpdDetails, error) {
 
 func (c *serviceClient) IpsecSpdEntryAddDel(ctx context.Context, in *IpsecSpdEntryAddDel) (*IpsecSpdEntryAddDelReply, error) {
 	out := new(IpsecSpdEntryAddDelReply)
+	err := c.conn.Invoke(ctx, in, out)
+	if err != nil {
+		return nil, err
+	}
+	return out, api.RetvalToVPPApiError(out.Retval)
+}
+
+func (c *serviceClient) IpsecSpdEntryAddDelV2(ctx context.Context, in *IpsecSpdEntryAddDelV2) (*IpsecSpdEntryAddDelV2Reply, error) {
+	out := new(IpsecSpdEntryAddDelV2Reply)
 	err := c.conn.Invoke(ctx, in, out)
 	if err != nil {
 		return nil, err

--- a/vpplink/binapi/vppapi/ipsec_types/ipsec_types.ba.go
+++ b/vpplink/binapi/vppapi/ipsec_types/ipsec_types.ba.go
@@ -4,8 +4,8 @@
 //
 // Contents:
 //
-//	4 enums
-//	4 structs
+//	5 enums
+//	6 structs
 package ipsec_types
 
 import (
@@ -26,25 +26,26 @@ const _ = api.GoVppAPIPackageIsVersion2
 const (
 	APIFile    = "ipsec_types"
 	APIVersion = "3.0.1"
-	VersionCrc = 0x48f74470
+	VersionCrc = 0x7892423b
 )
 
 // IpsecCryptoAlg defines enum 'ipsec_crypto_alg'.
 type IpsecCryptoAlg uint32
 
 const (
-	IPSEC_API_CRYPTO_ALG_NONE        IpsecCryptoAlg = 0
-	IPSEC_API_CRYPTO_ALG_AES_CBC_128 IpsecCryptoAlg = 1
-	IPSEC_API_CRYPTO_ALG_AES_CBC_192 IpsecCryptoAlg = 2
-	IPSEC_API_CRYPTO_ALG_AES_CBC_256 IpsecCryptoAlg = 3
-	IPSEC_API_CRYPTO_ALG_AES_CTR_128 IpsecCryptoAlg = 4
-	IPSEC_API_CRYPTO_ALG_AES_CTR_192 IpsecCryptoAlg = 5
-	IPSEC_API_CRYPTO_ALG_AES_CTR_256 IpsecCryptoAlg = 6
-	IPSEC_API_CRYPTO_ALG_AES_GCM_128 IpsecCryptoAlg = 7
-	IPSEC_API_CRYPTO_ALG_AES_GCM_192 IpsecCryptoAlg = 8
-	IPSEC_API_CRYPTO_ALG_AES_GCM_256 IpsecCryptoAlg = 9
-	IPSEC_API_CRYPTO_ALG_DES_CBC     IpsecCryptoAlg = 10
-	IPSEC_API_CRYPTO_ALG_3DES_CBC    IpsecCryptoAlg = 11
+	IPSEC_API_CRYPTO_ALG_NONE              IpsecCryptoAlg = 0
+	IPSEC_API_CRYPTO_ALG_AES_CBC_128       IpsecCryptoAlg = 1
+	IPSEC_API_CRYPTO_ALG_AES_CBC_192       IpsecCryptoAlg = 2
+	IPSEC_API_CRYPTO_ALG_AES_CBC_256       IpsecCryptoAlg = 3
+	IPSEC_API_CRYPTO_ALG_AES_CTR_128       IpsecCryptoAlg = 4
+	IPSEC_API_CRYPTO_ALG_AES_CTR_192       IpsecCryptoAlg = 5
+	IPSEC_API_CRYPTO_ALG_AES_CTR_256       IpsecCryptoAlg = 6
+	IPSEC_API_CRYPTO_ALG_AES_GCM_128       IpsecCryptoAlg = 7
+	IPSEC_API_CRYPTO_ALG_AES_GCM_192       IpsecCryptoAlg = 8
+	IPSEC_API_CRYPTO_ALG_AES_GCM_256       IpsecCryptoAlg = 9
+	IPSEC_API_CRYPTO_ALG_DES_CBC           IpsecCryptoAlg = 10
+	IPSEC_API_CRYPTO_ALG_3DES_CBC          IpsecCryptoAlg = 11
+	IPSEC_API_CRYPTO_ALG_CHACHA20_POLY1305 IpsecCryptoAlg = 12
 )
 
 var (
@@ -61,20 +62,22 @@ var (
 		9:  "IPSEC_API_CRYPTO_ALG_AES_GCM_256",
 		10: "IPSEC_API_CRYPTO_ALG_DES_CBC",
 		11: "IPSEC_API_CRYPTO_ALG_3DES_CBC",
+		12: "IPSEC_API_CRYPTO_ALG_CHACHA20_POLY1305",
 	}
 	IpsecCryptoAlg_value = map[string]uint32{
-		"IPSEC_API_CRYPTO_ALG_NONE":        0,
-		"IPSEC_API_CRYPTO_ALG_AES_CBC_128": 1,
-		"IPSEC_API_CRYPTO_ALG_AES_CBC_192": 2,
-		"IPSEC_API_CRYPTO_ALG_AES_CBC_256": 3,
-		"IPSEC_API_CRYPTO_ALG_AES_CTR_128": 4,
-		"IPSEC_API_CRYPTO_ALG_AES_CTR_192": 5,
-		"IPSEC_API_CRYPTO_ALG_AES_CTR_256": 6,
-		"IPSEC_API_CRYPTO_ALG_AES_GCM_128": 7,
-		"IPSEC_API_CRYPTO_ALG_AES_GCM_192": 8,
-		"IPSEC_API_CRYPTO_ALG_AES_GCM_256": 9,
-		"IPSEC_API_CRYPTO_ALG_DES_CBC":     10,
-		"IPSEC_API_CRYPTO_ALG_3DES_CBC":    11,
+		"IPSEC_API_CRYPTO_ALG_NONE":              0,
+		"IPSEC_API_CRYPTO_ALG_AES_CBC_128":       1,
+		"IPSEC_API_CRYPTO_ALG_AES_CBC_192":       2,
+		"IPSEC_API_CRYPTO_ALG_AES_CBC_256":       3,
+		"IPSEC_API_CRYPTO_ALG_AES_CTR_128":       4,
+		"IPSEC_API_CRYPTO_ALG_AES_CTR_192":       5,
+		"IPSEC_API_CRYPTO_ALG_AES_CTR_256":       6,
+		"IPSEC_API_CRYPTO_ALG_AES_GCM_128":       7,
+		"IPSEC_API_CRYPTO_ALG_AES_GCM_192":       8,
+		"IPSEC_API_CRYPTO_ALG_AES_GCM_256":       9,
+		"IPSEC_API_CRYPTO_ALG_DES_CBC":           10,
+		"IPSEC_API_CRYPTO_ALG_3DES_CBC":          11,
+		"IPSEC_API_CRYPTO_ALG_CHACHA20_POLY1305": 12,
 	}
 )
 
@@ -219,6 +222,39 @@ func (x IpsecSadFlags) String() string {
 	return s
 }
 
+// IpsecSpdAction defines enum 'ipsec_spd_action'.
+type IpsecSpdAction uint32
+
+const (
+	IPSEC_API_SPD_ACTION_BYPASS  IpsecSpdAction = 0
+	IPSEC_API_SPD_ACTION_DISCARD IpsecSpdAction = 1
+	IPSEC_API_SPD_ACTION_RESOLVE IpsecSpdAction = 2
+	IPSEC_API_SPD_ACTION_PROTECT IpsecSpdAction = 3
+)
+
+var (
+	IpsecSpdAction_name = map[uint32]string{
+		0: "IPSEC_API_SPD_ACTION_BYPASS",
+		1: "IPSEC_API_SPD_ACTION_DISCARD",
+		2: "IPSEC_API_SPD_ACTION_RESOLVE",
+		3: "IPSEC_API_SPD_ACTION_PROTECT",
+	}
+	IpsecSpdAction_value = map[string]uint32{
+		"IPSEC_API_SPD_ACTION_BYPASS":  0,
+		"IPSEC_API_SPD_ACTION_DISCARD": 1,
+		"IPSEC_API_SPD_ACTION_RESOLVE": 2,
+		"IPSEC_API_SPD_ACTION_PROTECT": 3,
+	}
+)
+
+func (x IpsecSpdAction) String() string {
+	s, ok := IpsecSpdAction_name[uint32(x)]
+	if ok {
+		return s
+	}
+	return "IpsecSpdAction(" + strconv.Itoa(int(x)) + ")"
+}
+
 // IpsecSadEntry defines type 'ipsec_sad_entry'.
 type IpsecSadEntry struct {
 	SadID              uint32           `binapi:"u32,name=sad_id" json:"sad_id,omitempty"`
@@ -271,6 +307,42 @@ type IpsecSadEntryV3 struct {
 	Salt               uint32              `binapi:"u32,name=salt" json:"salt,omitempty"`
 	UDPSrcPort         uint16              `binapi:"u16,name=udp_src_port,default=4500" json:"udp_src_port,omitempty"`
 	UDPDstPort         uint16              `binapi:"u16,name=udp_dst_port,default=4500" json:"udp_dst_port,omitempty"`
+}
+
+// IpsecSpdEntry defines type 'ipsec_spd_entry'.
+type IpsecSpdEntry struct {
+	SpdID              uint32           `binapi:"u32,name=spd_id" json:"spd_id,omitempty"`
+	Priority           int32            `binapi:"i32,name=priority" json:"priority,omitempty"`
+	IsOutbound         bool             `binapi:"bool,name=is_outbound" json:"is_outbound,omitempty"`
+	SaID               uint32           `binapi:"u32,name=sa_id" json:"sa_id,omitempty"`
+	Policy             IpsecSpdAction   `binapi:"ipsec_spd_action,name=policy" json:"policy,omitempty"`
+	Protocol           uint8            `binapi:"u8,name=protocol" json:"protocol,omitempty"`
+	RemoteAddressStart ip_types.Address `binapi:"address,name=remote_address_start" json:"remote_address_start,omitempty"`
+	RemoteAddressStop  ip_types.Address `binapi:"address,name=remote_address_stop" json:"remote_address_stop,omitempty"`
+	LocalAddressStart  ip_types.Address `binapi:"address,name=local_address_start" json:"local_address_start,omitempty"`
+	LocalAddressStop   ip_types.Address `binapi:"address,name=local_address_stop" json:"local_address_stop,omitempty"`
+	RemotePortStart    uint16           `binapi:"u16,name=remote_port_start" json:"remote_port_start,omitempty"`
+	RemotePortStop     uint16           `binapi:"u16,name=remote_port_stop" json:"remote_port_stop,omitempty"`
+	LocalPortStart     uint16           `binapi:"u16,name=local_port_start" json:"local_port_start,omitempty"`
+	LocalPortStop      uint16           `binapi:"u16,name=local_port_stop" json:"local_port_stop,omitempty"`
+}
+
+// IpsecSpdEntryV2 defines type 'ipsec_spd_entry_v2'.
+type IpsecSpdEntryV2 struct {
+	SpdID              uint32           `binapi:"u32,name=spd_id" json:"spd_id,omitempty"`
+	Priority           int32            `binapi:"i32,name=priority" json:"priority,omitempty"`
+	IsOutbound         bool             `binapi:"bool,name=is_outbound" json:"is_outbound,omitempty"`
+	SaID               uint32           `binapi:"u32,name=sa_id" json:"sa_id,omitempty"`
+	Policy             IpsecSpdAction   `binapi:"ipsec_spd_action,name=policy" json:"policy,omitempty"`
+	Protocol           uint8            `binapi:"u8,name=protocol" json:"protocol,omitempty"`
+	RemoteAddressStart ip_types.Address `binapi:"address,name=remote_address_start" json:"remote_address_start,omitempty"`
+	RemoteAddressStop  ip_types.Address `binapi:"address,name=remote_address_stop" json:"remote_address_stop,omitempty"`
+	LocalAddressStart  ip_types.Address `binapi:"address,name=local_address_start" json:"local_address_start,omitempty"`
+	LocalAddressStop   ip_types.Address `binapi:"address,name=local_address_stop" json:"local_address_stop,omitempty"`
+	RemotePortStart    uint16           `binapi:"u16,name=remote_port_start" json:"remote_port_start,omitempty"`
+	RemotePortStop     uint16           `binapi:"u16,name=remote_port_stop" json:"remote_port_stop,omitempty"`
+	LocalPortStart     uint16           `binapi:"u16,name=local_port_start" json:"local_port_start,omitempty"`
+	LocalPortStop      uint16           `binapi:"u16,name=local_port_stop" json:"local_port_stop,omitempty"`
 }
 
 // Key defines type 'key'.

--- a/vpplink/binapi/vppapi/memclnt/memclnt.ba.go
+++ b/vpplink/binapi/vppapi/memclnt/memclnt.ba.go
@@ -5,7 +5,7 @@
 // Contents:
 //
 //	 2 structs
-//	24 messages
+//	26 messages
 package memclnt
 
 import (
@@ -22,7 +22,7 @@ const _ = api.GoVppAPIPackageIsVersion2
 const (
 	APIFile    = "memclnt"
 	APIVersion = "2.1.0"
-	VersionCrc = 0x230bb938
+	VersionCrc = 0x21d36234
 )
 
 // MessageTableEntry defines type 'message_table_entry'.
@@ -361,6 +361,109 @@ func (m *MemclntCreateReply) Marshal(b []byte) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 func (m *MemclntCreateReply) Unmarshal(b []byte) error {
+	buf := codec.NewBuffer(b)
+	m.Response = buf.DecodeInt32()
+	m.Handle = buf.DecodeUint64()
+	m.Index = buf.DecodeUint32()
+	m.MessageTable = buf.DecodeUint64()
+	return nil
+}
+
+// MemclntCreateV2 defines message 'memclnt_create_v2'.
+type MemclntCreateV2 struct {
+	CtxQuota    int32    `binapi:"i32,name=ctx_quota" json:"ctx_quota,omitempty"`
+	InputQueue  uint64   `binapi:"u64,name=input_queue" json:"input_queue,omitempty"`
+	Name        string   `binapi:"string[64],name=name" json:"name,omitempty"`
+	APIVersions []uint32 `binapi:"u32[8],name=api_versions" json:"api_versions,omitempty"`
+	Keepalive   bool     `binapi:"bool,name=keepalive,default=true" json:"keepalive,omitempty"`
+}
+
+func (m *MemclntCreateV2) Reset()               { *m = MemclntCreateV2{} }
+func (*MemclntCreateV2) GetMessageName() string { return "memclnt_create_v2" }
+func (*MemclntCreateV2) GetCrcString() string   { return "c4bd4882" }
+func (*MemclntCreateV2) GetMessageType() api.MessageType {
+	return api.ReplyMessage
+}
+
+func (m *MemclntCreateV2) Size() (size int) {
+	if m == nil {
+		return 0
+	}
+	size += 4     // m.CtxQuota
+	size += 8     // m.InputQueue
+	size += 64    // m.Name
+	size += 4 * 8 // m.APIVersions
+	size += 1     // m.Keepalive
+	return size
+}
+func (m *MemclntCreateV2) Marshal(b []byte) ([]byte, error) {
+	if b == nil {
+		b = make([]byte, m.Size())
+	}
+	buf := codec.NewBuffer(b)
+	buf.EncodeInt32(m.CtxQuota)
+	buf.EncodeUint64(m.InputQueue)
+	buf.EncodeString(m.Name, 64)
+	for i := 0; i < 8; i++ {
+		var x uint32
+		if i < len(m.APIVersions) {
+			x = uint32(m.APIVersions[i])
+		}
+		buf.EncodeUint32(x)
+	}
+	buf.EncodeBool(m.Keepalive)
+	return buf.Bytes(), nil
+}
+func (m *MemclntCreateV2) Unmarshal(b []byte) error {
+	buf := codec.NewBuffer(b)
+	m.CtxQuota = buf.DecodeInt32()
+	m.InputQueue = buf.DecodeUint64()
+	m.Name = buf.DecodeString(64)
+	m.APIVersions = make([]uint32, 8)
+	for i := 0; i < len(m.APIVersions); i++ {
+		m.APIVersions[i] = buf.DecodeUint32()
+	}
+	m.Keepalive = buf.DecodeBool()
+	return nil
+}
+
+// MemclntCreateV2Reply defines message 'memclnt_create_v2_reply'.
+type MemclntCreateV2Reply struct {
+	Response     int32  `binapi:"i32,name=response" json:"response,omitempty"`
+	Handle       uint64 `binapi:"u64,name=handle" json:"handle,omitempty"`
+	Index        uint32 `binapi:"u32,name=index" json:"index,omitempty"`
+	MessageTable uint64 `binapi:"u64,name=message_table" json:"message_table,omitempty"`
+}
+
+func (m *MemclntCreateV2Reply) Reset()               { *m = MemclntCreateV2Reply{} }
+func (*MemclntCreateV2Reply) GetMessageName() string { return "memclnt_create_v2_reply" }
+func (*MemclntCreateV2Reply) GetCrcString() string   { return "42ec4560" }
+func (*MemclntCreateV2Reply) GetMessageType() api.MessageType {
+	return api.ReplyMessage
+}
+
+func (m *MemclntCreateV2Reply) Size() (size int) {
+	if m == nil {
+		return 0
+	}
+	size += 4 // m.Response
+	size += 8 // m.Handle
+	size += 4 // m.Index
+	size += 8 // m.MessageTable
+	return size
+}
+func (m *MemclntCreateV2Reply) Marshal(b []byte) ([]byte, error) {
+	if b == nil {
+		b = make([]byte, m.Size())
+	}
+	buf := codec.NewBuffer(b)
+	buf.EncodeInt32(m.Response)
+	buf.EncodeUint64(m.Handle)
+	buf.EncodeUint32(m.Index)
+	buf.EncodeUint64(m.MessageTable)
+	return buf.Bytes(), nil
+}
+func (m *MemclntCreateV2Reply) Unmarshal(b []byte) error {
 	buf := codec.NewBuffer(b)
 	m.Response = buf.DecodeInt32()
 	m.Handle = buf.DecodeUint64()
@@ -990,6 +1093,8 @@ func file_memclnt_binapi_init() {
 	api.RegisterMessage((*GetFirstMsgIDReply)(nil), "get_first_msg_id_reply_7d337472")
 	api.RegisterMessage((*MemclntCreate)(nil), "memclnt_create_9c5e1c2f")
 	api.RegisterMessage((*MemclntCreateReply)(nil), "memclnt_create_reply_42ec4560")
+	api.RegisterMessage((*MemclntCreateV2)(nil), "memclnt_create_v2_c4bd4882")
+	api.RegisterMessage((*MemclntCreateV2Reply)(nil), "memclnt_create_v2_reply_42ec4560")
 	api.RegisterMessage((*MemclntDelete)(nil), "memclnt_delete_7e1c04e3")
 	api.RegisterMessage((*MemclntDeleteReply)(nil), "memclnt_delete_reply_3d3b6312")
 	api.RegisterMessage((*MemclntKeepalive)(nil), "memclnt_keepalive_51077d14")
@@ -1019,6 +1124,8 @@ func AllMessages() []api.Message {
 		(*GetFirstMsgIDReply)(nil),
 		(*MemclntCreate)(nil),
 		(*MemclntCreateReply)(nil),
+		(*MemclntCreateV2)(nil),
+		(*MemclntCreateV2Reply)(nil),
 		(*MemclntDelete)(nil),
 		(*MemclntDeleteReply)(nil),
 		(*MemclntKeepalive)(nil),

--- a/vpplink/binapi/vppapi/memclnt/memclnt_rpc.ba.go
+++ b/vpplink/binapi/vppapi/memclnt/memclnt_rpc.ba.go
@@ -14,6 +14,7 @@ type RPCService interface {
 	ControlPing(ctx context.Context, in *ControlPing) (*ControlPingReply, error)
 	GetFirstMsgID(ctx context.Context, in *GetFirstMsgID) (*GetFirstMsgIDReply, error)
 	MemclntCreate(ctx context.Context, in *MemclntCreate) (*MemclntCreateReply, error)
+	MemclntCreateV2(ctx context.Context, in *MemclntCreateV2) (*MemclntCreateV2Reply, error)
 	MemclntDelete(ctx context.Context, in *MemclntDelete) (*MemclntDeleteReply, error)
 	MemclntKeepalive(ctx context.Context, in *MemclntKeepalive) (*MemclntKeepaliveReply, error)
 	MemclntReadTimeout(ctx context.Context, in *MemclntReadTimeout) error
@@ -63,6 +64,15 @@ func (c *serviceClient) GetFirstMsgID(ctx context.Context, in *GetFirstMsgID) (*
 
 func (c *serviceClient) MemclntCreate(ctx context.Context, in *MemclntCreate) (*MemclntCreateReply, error) {
 	out := new(MemclntCreateReply)
+	err := c.conn.Invoke(ctx, in, out)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *serviceClient) MemclntCreateV2(ctx context.Context, in *MemclntCreateV2) (*MemclntCreateV2Reply, error) {
+	out := new(MemclntCreateV2Reply)
 	err := c.conn.Invoke(ctx, in, out)
 	if err != nil {
 		return nil, err

--- a/vpplink/binapi/vppapi/nat44_ed/nat44_ed.ba.go
+++ b/vpplink/binapi/vppapi/nat44_ed/nat44_ed.ba.go
@@ -4,10 +4,9 @@
 //
 // Contents:
 //
-//	1 enum
-//	1 struct
-//
-// 104 messages
+//	 1 enum
+//	 1 struct
+//	92 messages
 package nat44_ed
 
 import (
@@ -28,8 +27,8 @@ const _ = api.GoVppAPIPackageIsVersion2
 
 const (
 	APIFile    = "nat44_ed"
-	APIVersion = "5.4.0"
-	VersionCrc = 0x5697d0ef
+	APIVersion = "5.5.0"
+	VersionCrc = 0x89b1d9d3
 )
 
 // Nat44ConfigFlags defines enum 'nat44_config_flags'.
@@ -581,7 +580,6 @@ func (m *Nat44AddDelStaticMappingReply) Unmarshal(b []byte) error {
 }
 
 // Nat44AddDelStaticMappingV2 defines message 'nat44_add_del_static_mapping_v2'.
-// InProgress: the message form may change in the future versions
 type Nat44AddDelStaticMappingV2 struct {
 	IsAdd             bool                           `binapi:"bool,name=is_add" json:"is_add,omitempty"`
 	MatchPool         bool                           `binapi:"bool,name=match_pool" json:"match_pool,omitempty"`
@@ -659,7 +657,6 @@ func (m *Nat44AddDelStaticMappingV2) Unmarshal(b []byte) error {
 }
 
 // Nat44AddDelStaticMappingV2Reply defines message 'nat44_add_del_static_mapping_v2_reply'.
-// InProgress: the message form may change in the future versions
 type Nat44AddDelStaticMappingV2Reply struct {
 	Retval int32 `binapi:"i32,name=retval" json:"retval,omitempty"`
 }
@@ -853,6 +850,7 @@ func (m *Nat44DelSessionReply) Unmarshal(b []byte) error {
 }
 
 // Nat44DelUser defines message 'nat44_del_user'.
+// Deprecated: the message will be removed in the future versions
 type Nat44DelUser struct {
 	IPAddress ip_types.IP4Address `binapi:"ip4_address,name=ip_address" json:"ip_address,omitempty"`
 	FibIndex  uint32              `binapi:"u32,name=fib_index" json:"fib_index,omitempty"`
@@ -890,6 +888,7 @@ func (m *Nat44DelUser) Unmarshal(b []byte) error {
 }
 
 // Nat44DelUserReply defines message 'nat44_del_user_reply'.
+// Deprecated: the message will be removed in the future versions
 type Nat44DelUserReply struct {
 	Retval int32 `binapi:"i32,name=retval" json:"retval,omitempty"`
 }
@@ -991,6 +990,150 @@ func (m *Nat44EdAddDelOutputInterfaceReply) Marshal(b []byte) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 func (m *Nat44EdAddDelOutputInterfaceReply) Unmarshal(b []byte) error {
+	buf := codec.NewBuffer(b)
+	m.Retval = buf.DecodeInt32()
+	return nil
+}
+
+// Nat44EdAddDelVrfRoute defines message 'nat44_ed_add_del_vrf_route'.
+type Nat44EdAddDelVrfRoute struct {
+	TableVrfID uint32 `binapi:"u32,name=table_vrf_id" json:"table_vrf_id,omitempty"`
+	VrfID      uint32 `binapi:"u32,name=vrf_id" json:"vrf_id,omitempty"`
+	IsAdd      bool   `binapi:"bool,name=is_add" json:"is_add,omitempty"`
+}
+
+func (m *Nat44EdAddDelVrfRoute) Reset()               { *m = Nat44EdAddDelVrfRoute{} }
+func (*Nat44EdAddDelVrfRoute) GetMessageName() string { return "nat44_ed_add_del_vrf_route" }
+func (*Nat44EdAddDelVrfRoute) GetCrcString() string   { return "59187407" }
+func (*Nat44EdAddDelVrfRoute) GetMessageType() api.MessageType {
+	return api.RequestMessage
+}
+
+func (m *Nat44EdAddDelVrfRoute) Size() (size int) {
+	if m == nil {
+		return 0
+	}
+	size += 4 // m.TableVrfID
+	size += 4 // m.VrfID
+	size += 1 // m.IsAdd
+	return size
+}
+func (m *Nat44EdAddDelVrfRoute) Marshal(b []byte) ([]byte, error) {
+	if b == nil {
+		b = make([]byte, m.Size())
+	}
+	buf := codec.NewBuffer(b)
+	buf.EncodeUint32(m.TableVrfID)
+	buf.EncodeUint32(m.VrfID)
+	buf.EncodeBool(m.IsAdd)
+	return buf.Bytes(), nil
+}
+func (m *Nat44EdAddDelVrfRoute) Unmarshal(b []byte) error {
+	buf := codec.NewBuffer(b)
+	m.TableVrfID = buf.DecodeUint32()
+	m.VrfID = buf.DecodeUint32()
+	m.IsAdd = buf.DecodeBool()
+	return nil
+}
+
+// Nat44EdAddDelVrfRouteReply defines message 'nat44_ed_add_del_vrf_route_reply'.
+type Nat44EdAddDelVrfRouteReply struct {
+	Retval int32 `binapi:"i32,name=retval" json:"retval,omitempty"`
+}
+
+func (m *Nat44EdAddDelVrfRouteReply) Reset()               { *m = Nat44EdAddDelVrfRouteReply{} }
+func (*Nat44EdAddDelVrfRouteReply) GetMessageName() string { return "nat44_ed_add_del_vrf_route_reply" }
+func (*Nat44EdAddDelVrfRouteReply) GetCrcString() string   { return "e8d4e804" }
+func (*Nat44EdAddDelVrfRouteReply) GetMessageType() api.MessageType {
+	return api.ReplyMessage
+}
+
+func (m *Nat44EdAddDelVrfRouteReply) Size() (size int) {
+	if m == nil {
+		return 0
+	}
+	size += 4 // m.Retval
+	return size
+}
+func (m *Nat44EdAddDelVrfRouteReply) Marshal(b []byte) ([]byte, error) {
+	if b == nil {
+		b = make([]byte, m.Size())
+	}
+	buf := codec.NewBuffer(b)
+	buf.EncodeInt32(m.Retval)
+	return buf.Bytes(), nil
+}
+func (m *Nat44EdAddDelVrfRouteReply) Unmarshal(b []byte) error {
+	buf := codec.NewBuffer(b)
+	m.Retval = buf.DecodeInt32()
+	return nil
+}
+
+// Nat44EdAddDelVrfTable defines message 'nat44_ed_add_del_vrf_table'.
+type Nat44EdAddDelVrfTable struct {
+	TableVrfID uint32 `binapi:"u32,name=table_vrf_id" json:"table_vrf_id,omitempty"`
+	IsAdd      bool   `binapi:"bool,name=is_add" json:"is_add,omitempty"`
+}
+
+func (m *Nat44EdAddDelVrfTable) Reset()               { *m = Nat44EdAddDelVrfTable{} }
+func (*Nat44EdAddDelVrfTable) GetMessageName() string { return "nat44_ed_add_del_vrf_table" }
+func (*Nat44EdAddDelVrfTable) GetCrcString() string   { return "08330904" }
+func (*Nat44EdAddDelVrfTable) GetMessageType() api.MessageType {
+	return api.RequestMessage
+}
+
+func (m *Nat44EdAddDelVrfTable) Size() (size int) {
+	if m == nil {
+		return 0
+	}
+	size += 4 // m.TableVrfID
+	size += 1 // m.IsAdd
+	return size
+}
+func (m *Nat44EdAddDelVrfTable) Marshal(b []byte) ([]byte, error) {
+	if b == nil {
+		b = make([]byte, m.Size())
+	}
+	buf := codec.NewBuffer(b)
+	buf.EncodeUint32(m.TableVrfID)
+	buf.EncodeBool(m.IsAdd)
+	return buf.Bytes(), nil
+}
+func (m *Nat44EdAddDelVrfTable) Unmarshal(b []byte) error {
+	buf := codec.NewBuffer(b)
+	m.TableVrfID = buf.DecodeUint32()
+	m.IsAdd = buf.DecodeBool()
+	return nil
+}
+
+// Nat44EdAddDelVrfTableReply defines message 'nat44_ed_add_del_vrf_table_reply'.
+type Nat44EdAddDelVrfTableReply struct {
+	Retval int32 `binapi:"i32,name=retval" json:"retval,omitempty"`
+}
+
+func (m *Nat44EdAddDelVrfTableReply) Reset()               { *m = Nat44EdAddDelVrfTableReply{} }
+func (*Nat44EdAddDelVrfTableReply) GetMessageName() string { return "nat44_ed_add_del_vrf_table_reply" }
+func (*Nat44EdAddDelVrfTableReply) GetCrcString() string   { return "e8d4e804" }
+func (*Nat44EdAddDelVrfTableReply) GetMessageType() api.MessageType {
+	return api.ReplyMessage
+}
+
+func (m *Nat44EdAddDelVrfTableReply) Size() (size int) {
+	if m == nil {
+		return 0
+	}
+	size += 4 // m.Retval
+	return size
+}
+func (m *Nat44EdAddDelVrfTableReply) Marshal(b []byte) ([]byte, error) {
+	if b == nil {
+		b = make([]byte, m.Size())
+	}
+	buf := codec.NewBuffer(b)
+	buf.EncodeInt32(m.Retval)
+	return buf.Bytes(), nil
+}
+func (m *Nat44EdAddDelVrfTableReply) Unmarshal(b []byte) error {
 	buf := codec.NewBuffer(b)
 	m.Retval = buf.DecodeInt32()
 	return nil
@@ -1104,7 +1247,6 @@ func (m *Nat44EdOutputInterfaceGetReply) Unmarshal(b []byte) error {
 }
 
 // Nat44EdPluginEnableDisable defines message 'nat44_ed_plugin_enable_disable'.
-// InProgress: the message form may change in the future versions
 type Nat44EdPluginEnableDisable struct {
 	InsideVrf     uint32           `binapi:"u32,name=inside_vrf" json:"inside_vrf,omitempty"`
 	OutsideVrf    uint32           `binapi:"u32,name=outside_vrf" json:"outside_vrf,omitempty"`
@@ -1158,7 +1300,6 @@ func (m *Nat44EdPluginEnableDisable) Unmarshal(b []byte) error {
 }
 
 // Nat44EdPluginEnableDisableReply defines message 'nat44_ed_plugin_enable_disable_reply'.
-// InProgress: the message form may change in the future versions
 type Nat44EdPluginEnableDisableReply struct {
 	Retval int32 `binapi:"i32,name=retval" json:"retval,omitempty"`
 }
@@ -1194,7 +1335,6 @@ func (m *Nat44EdPluginEnableDisableReply) Unmarshal(b []byte) error {
 }
 
 // Nat44EdSetFqOptions defines message 'nat44_ed_set_fq_options'.
-// InProgress: the message form may change in the future versions
 type Nat44EdSetFqOptions struct {
 	FrameQueueNelts uint32 `binapi:"u32,name=frame_queue_nelts" json:"frame_queue_nelts,omitempty"`
 }
@@ -1228,7 +1368,6 @@ func (m *Nat44EdSetFqOptions) Unmarshal(b []byte) error {
 }
 
 // Nat44EdSetFqOptionsReply defines message 'nat44_ed_set_fq_options_reply'.
-// InProgress: the message form may change in the future versions
 type Nat44EdSetFqOptionsReply struct {
 	Retval int32 `binapi:"i32,name=retval" json:"retval,omitempty"`
 }
@@ -1262,7 +1401,6 @@ func (m *Nat44EdSetFqOptionsReply) Unmarshal(b []byte) error {
 }
 
 // Nat44EdShowFqOptions defines message 'nat44_ed_show_fq_options'.
-// InProgress: the message form may change in the future versions
 type Nat44EdShowFqOptions struct{}
 
 func (m *Nat44EdShowFqOptions) Reset()               { *m = Nat44EdShowFqOptions{} }
@@ -1290,7 +1428,6 @@ func (m *Nat44EdShowFqOptions) Unmarshal(b []byte) error {
 }
 
 // Nat44EdShowFqOptionsReply defines message 'nat44_ed_show_fq_options_reply'.
-// InProgress: the message form may change in the future versions
 type Nat44EdShowFqOptionsReply struct {
 	Retval          int32  `binapi:"i32,name=retval" json:"retval,omitempty"`
 	FrameQueueNelts uint32 `binapi:"u32,name=frame_queue_nelts" json:"frame_queue_nelts,omitempty"`
@@ -1324,6 +1461,83 @@ func (m *Nat44EdShowFqOptionsReply) Unmarshal(b []byte) error {
 	buf := codec.NewBuffer(b)
 	m.Retval = buf.DecodeInt32()
 	m.FrameQueueNelts = buf.DecodeUint32()
+	return nil
+}
+
+// Nat44EdVrfTablesDetails defines message 'nat44_ed_vrf_tables_details'.
+type Nat44EdVrfTablesDetails struct {
+	TableVrfID uint32   `binapi:"u32,name=table_vrf_id" json:"table_vrf_id,omitempty"`
+	NVrfIds    uint32   `binapi:"u32,name=n_vrf_ids" json:"-"`
+	VrfIds     []uint32 `binapi:"u32[n_vrf_ids],name=vrf_ids" json:"vrf_ids,omitempty"`
+}
+
+func (m *Nat44EdVrfTablesDetails) Reset()               { *m = Nat44EdVrfTablesDetails{} }
+func (*Nat44EdVrfTablesDetails) GetMessageName() string { return "nat44_ed_vrf_tables_details" }
+func (*Nat44EdVrfTablesDetails) GetCrcString() string   { return "7b264e4f" }
+func (*Nat44EdVrfTablesDetails) GetMessageType() api.MessageType {
+	return api.ReplyMessage
+}
+
+func (m *Nat44EdVrfTablesDetails) Size() (size int) {
+	if m == nil {
+		return 0
+	}
+	size += 4                 // m.TableVrfID
+	size += 4                 // m.NVrfIds
+	size += 4 * len(m.VrfIds) // m.VrfIds
+	return size
+}
+func (m *Nat44EdVrfTablesDetails) Marshal(b []byte) ([]byte, error) {
+	if b == nil {
+		b = make([]byte, m.Size())
+	}
+	buf := codec.NewBuffer(b)
+	buf.EncodeUint32(m.TableVrfID)
+	buf.EncodeUint32(uint32(len(m.VrfIds)))
+	for i := 0; i < len(m.VrfIds); i++ {
+		var x uint32
+		if i < len(m.VrfIds) {
+			x = uint32(m.VrfIds[i])
+		}
+		buf.EncodeUint32(x)
+	}
+	return buf.Bytes(), nil
+}
+func (m *Nat44EdVrfTablesDetails) Unmarshal(b []byte) error {
+	buf := codec.NewBuffer(b)
+	m.TableVrfID = buf.DecodeUint32()
+	m.NVrfIds = buf.DecodeUint32()
+	m.VrfIds = make([]uint32, m.NVrfIds)
+	for i := 0; i < len(m.VrfIds); i++ {
+		m.VrfIds[i] = buf.DecodeUint32()
+	}
+	return nil
+}
+
+// Nat44EdVrfTablesDump defines message 'nat44_ed_vrf_tables_dump'.
+type Nat44EdVrfTablesDump struct{}
+
+func (m *Nat44EdVrfTablesDump) Reset()               { *m = Nat44EdVrfTablesDump{} }
+func (*Nat44EdVrfTablesDump) GetMessageName() string { return "nat44_ed_vrf_tables_dump" }
+func (*Nat44EdVrfTablesDump) GetCrcString() string   { return "51077d14" }
+func (*Nat44EdVrfTablesDump) GetMessageType() api.MessageType {
+	return api.RequestMessage
+}
+
+func (m *Nat44EdVrfTablesDump) Size() (size int) {
+	if m == nil {
+		return 0
+	}
+	return size
+}
+func (m *Nat44EdVrfTablesDump) Marshal(b []byte) ([]byte, error) {
+	if b == nil {
+		b = make([]byte, m.Size())
+	}
+	buf := codec.NewBuffer(b)
+	return buf.Bytes(), nil
+}
+func (m *Nat44EdVrfTablesDump) Unmarshal(b []byte) error {
 	return nil
 }
 
@@ -1396,70 +1610,6 @@ func (m *Nat44ForwardingEnableDisableReply) Marshal(b []byte) ([]byte, error) {
 func (m *Nat44ForwardingEnableDisableReply) Unmarshal(b []byte) error {
 	buf := codec.NewBuffer(b)
 	m.Retval = buf.DecodeInt32()
-	return nil
-}
-
-// Nat44ForwardingIsEnabled defines message 'nat44_forwarding_is_enabled'.
-// Deprecated: the message will be removed in the future versions
-type Nat44ForwardingIsEnabled struct{}
-
-func (m *Nat44ForwardingIsEnabled) Reset()               { *m = Nat44ForwardingIsEnabled{} }
-func (*Nat44ForwardingIsEnabled) GetMessageName() string { return "nat44_forwarding_is_enabled" }
-func (*Nat44ForwardingIsEnabled) GetCrcString() string   { return "51077d14" }
-func (*Nat44ForwardingIsEnabled) GetMessageType() api.MessageType {
-	return api.RequestMessage
-}
-
-func (m *Nat44ForwardingIsEnabled) Size() (size int) {
-	if m == nil {
-		return 0
-	}
-	return size
-}
-func (m *Nat44ForwardingIsEnabled) Marshal(b []byte) ([]byte, error) {
-	if b == nil {
-		b = make([]byte, m.Size())
-	}
-	buf := codec.NewBuffer(b)
-	return buf.Bytes(), nil
-}
-func (m *Nat44ForwardingIsEnabled) Unmarshal(b []byte) error {
-	return nil
-}
-
-// Nat44ForwardingIsEnabledReply defines message 'nat44_forwarding_is_enabled_reply'.
-// Deprecated: the message will be removed in the future versions
-type Nat44ForwardingIsEnabledReply struct {
-	Enabled bool `binapi:"bool,name=enabled" json:"enabled,omitempty"`
-}
-
-func (m *Nat44ForwardingIsEnabledReply) Reset() { *m = Nat44ForwardingIsEnabledReply{} }
-func (*Nat44ForwardingIsEnabledReply) GetMessageName() string {
-	return "nat44_forwarding_is_enabled_reply"
-}
-func (*Nat44ForwardingIsEnabledReply) GetCrcString() string { return "46924a06" }
-func (*Nat44ForwardingIsEnabledReply) GetMessageType() api.MessageType {
-	return api.ReplyMessage
-}
-
-func (m *Nat44ForwardingIsEnabledReply) Size() (size int) {
-	if m == nil {
-		return 0
-	}
-	size += 1 // m.Enabled
-	return size
-}
-func (m *Nat44ForwardingIsEnabledReply) Marshal(b []byte) ([]byte, error) {
-	if b == nil {
-		b = make([]byte, m.Size())
-	}
-	buf := codec.NewBuffer(b)
-	buf.EncodeBool(m.Enabled)
-	return buf.Bytes(), nil
-}
-func (m *Nat44ForwardingIsEnabledReply) Unmarshal(b []byte) error {
-	buf := codec.NewBuffer(b)
-	m.Enabled = buf.DecodeBool()
 	return nil
 }
 
@@ -1623,88 +1773,6 @@ func (m *Nat44InterfaceAddDelFeatureReply) Unmarshal(b []byte) error {
 	return nil
 }
 
-// Nat44InterfaceAddDelOutputFeature defines message 'nat44_interface_add_del_output_feature'.
-// Deprecated: the message will be removed in the future versions
-type Nat44InterfaceAddDelOutputFeature struct {
-	IsAdd     bool                           `binapi:"bool,name=is_add" json:"is_add,omitempty"`
-	Flags     nat_types.NatConfigFlags       `binapi:"nat_config_flags,name=flags" json:"flags,omitempty"`
-	SwIfIndex interface_types.InterfaceIndex `binapi:"interface_index,name=sw_if_index" json:"sw_if_index,omitempty"`
-}
-
-func (m *Nat44InterfaceAddDelOutputFeature) Reset() { *m = Nat44InterfaceAddDelOutputFeature{} }
-func (*Nat44InterfaceAddDelOutputFeature) GetMessageName() string {
-	return "nat44_interface_add_del_output_feature"
-}
-func (*Nat44InterfaceAddDelOutputFeature) GetCrcString() string { return "f3699b83" }
-func (*Nat44InterfaceAddDelOutputFeature) GetMessageType() api.MessageType {
-	return api.RequestMessage
-}
-
-func (m *Nat44InterfaceAddDelOutputFeature) Size() (size int) {
-	if m == nil {
-		return 0
-	}
-	size += 1 // m.IsAdd
-	size += 1 // m.Flags
-	size += 4 // m.SwIfIndex
-	return size
-}
-func (m *Nat44InterfaceAddDelOutputFeature) Marshal(b []byte) ([]byte, error) {
-	if b == nil {
-		b = make([]byte, m.Size())
-	}
-	buf := codec.NewBuffer(b)
-	buf.EncodeBool(m.IsAdd)
-	buf.EncodeUint8(uint8(m.Flags))
-	buf.EncodeUint32(uint32(m.SwIfIndex))
-	return buf.Bytes(), nil
-}
-func (m *Nat44InterfaceAddDelOutputFeature) Unmarshal(b []byte) error {
-	buf := codec.NewBuffer(b)
-	m.IsAdd = buf.DecodeBool()
-	m.Flags = nat_types.NatConfigFlags(buf.DecodeUint8())
-	m.SwIfIndex = interface_types.InterfaceIndex(buf.DecodeUint32())
-	return nil
-}
-
-// Nat44InterfaceAddDelOutputFeatureReply defines message 'nat44_interface_add_del_output_feature_reply'.
-// Deprecated: the message will be removed in the future versions
-type Nat44InterfaceAddDelOutputFeatureReply struct {
-	Retval int32 `binapi:"i32,name=retval" json:"retval,omitempty"`
-}
-
-func (m *Nat44InterfaceAddDelOutputFeatureReply) Reset() {
-	*m = Nat44InterfaceAddDelOutputFeatureReply{}
-}
-func (*Nat44InterfaceAddDelOutputFeatureReply) GetMessageName() string {
-	return "nat44_interface_add_del_output_feature_reply"
-}
-func (*Nat44InterfaceAddDelOutputFeatureReply) GetCrcString() string { return "e8d4e804" }
-func (*Nat44InterfaceAddDelOutputFeatureReply) GetMessageType() api.MessageType {
-	return api.ReplyMessage
-}
-
-func (m *Nat44InterfaceAddDelOutputFeatureReply) Size() (size int) {
-	if m == nil {
-		return 0
-	}
-	size += 4 // m.Retval
-	return size
-}
-func (m *Nat44InterfaceAddDelOutputFeatureReply) Marshal(b []byte) ([]byte, error) {
-	if b == nil {
-		b = make([]byte, m.Size())
-	}
-	buf := codec.NewBuffer(b)
-	buf.EncodeInt32(m.Retval)
-	return buf.Bytes(), nil
-}
-func (m *Nat44InterfaceAddDelOutputFeatureReply) Unmarshal(b []byte) error {
-	buf := codec.NewBuffer(b)
-	m.Retval = buf.DecodeInt32()
-	return nil
-}
-
 // Nat44InterfaceAddrDetails defines message 'nat44_interface_addr_details'.
 type Nat44InterfaceAddrDetails struct {
 	SwIfIndex interface_types.InterfaceIndex `binapi:"interface_index,name=sw_if_index" json:"sw_if_index,omitempty"`
@@ -1830,76 +1898,6 @@ func (m *Nat44InterfaceDump) Marshal(b []byte) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 func (m *Nat44InterfaceDump) Unmarshal(b []byte) error {
-	return nil
-}
-
-// Nat44InterfaceOutputFeatureDetails defines message 'nat44_interface_output_feature_details'.
-// Deprecated: the message will be removed in the future versions
-type Nat44InterfaceOutputFeatureDetails struct {
-	Flags     nat_types.NatConfigFlags       `binapi:"nat_config_flags,name=flags" json:"flags,omitempty"`
-	SwIfIndex interface_types.InterfaceIndex `binapi:"interface_index,name=sw_if_index" json:"sw_if_index,omitempty"`
-}
-
-func (m *Nat44InterfaceOutputFeatureDetails) Reset() { *m = Nat44InterfaceOutputFeatureDetails{} }
-func (*Nat44InterfaceOutputFeatureDetails) GetMessageName() string {
-	return "nat44_interface_output_feature_details"
-}
-func (*Nat44InterfaceOutputFeatureDetails) GetCrcString() string { return "5d286289" }
-func (*Nat44InterfaceOutputFeatureDetails) GetMessageType() api.MessageType {
-	return api.ReplyMessage
-}
-
-func (m *Nat44InterfaceOutputFeatureDetails) Size() (size int) {
-	if m == nil {
-		return 0
-	}
-	size += 1 // m.Flags
-	size += 4 // m.SwIfIndex
-	return size
-}
-func (m *Nat44InterfaceOutputFeatureDetails) Marshal(b []byte) ([]byte, error) {
-	if b == nil {
-		b = make([]byte, m.Size())
-	}
-	buf := codec.NewBuffer(b)
-	buf.EncodeUint8(uint8(m.Flags))
-	buf.EncodeUint32(uint32(m.SwIfIndex))
-	return buf.Bytes(), nil
-}
-func (m *Nat44InterfaceOutputFeatureDetails) Unmarshal(b []byte) error {
-	buf := codec.NewBuffer(b)
-	m.Flags = nat_types.NatConfigFlags(buf.DecodeUint8())
-	m.SwIfIndex = interface_types.InterfaceIndex(buf.DecodeUint32())
-	return nil
-}
-
-// Nat44InterfaceOutputFeatureDump defines message 'nat44_interface_output_feature_dump'.
-// Deprecated: the message will be removed in the future versions
-type Nat44InterfaceOutputFeatureDump struct{}
-
-func (m *Nat44InterfaceOutputFeatureDump) Reset() { *m = Nat44InterfaceOutputFeatureDump{} }
-func (*Nat44InterfaceOutputFeatureDump) GetMessageName() string {
-	return "nat44_interface_output_feature_dump"
-}
-func (*Nat44InterfaceOutputFeatureDump) GetCrcString() string { return "51077d14" }
-func (*Nat44InterfaceOutputFeatureDump) GetMessageType() api.MessageType {
-	return api.RequestMessage
-}
-
-func (m *Nat44InterfaceOutputFeatureDump) Size() (size int) {
-	if m == nil {
-		return 0
-	}
-	return size
-}
-func (m *Nat44InterfaceOutputFeatureDump) Marshal(b []byte) ([]byte, error) {
-	if b == nil {
-		b = make([]byte, m.Size())
-	}
-	buf := codec.NewBuffer(b)
-	return buf.Bytes(), nil
-}
-func (m *Nat44InterfaceOutputFeatureDump) Unmarshal(b []byte) error {
 	return nil
 }
 
@@ -2111,170 +2109,6 @@ func (m *Nat44LbStaticMappingDump) Unmarshal(b []byte) error {
 	return nil
 }
 
-// Nat44PluginEnableDisable defines message 'nat44_plugin_enable_disable'.
-// Deprecated: the message will be removed in the future versions
-type Nat44PluginEnableDisable struct {
-	InsideVrf     uint32           `binapi:"u32,name=inside_vrf" json:"inside_vrf,omitempty"`
-	OutsideVrf    uint32           `binapi:"u32,name=outside_vrf" json:"outside_vrf,omitempty"`
-	Users         uint32           `binapi:"u32,name=users" json:"users,omitempty"`
-	UserMemory    uint32           `binapi:"u32,name=user_memory" json:"user_memory,omitempty"`
-	Sessions      uint32           `binapi:"u32,name=sessions" json:"sessions,omitempty"`
-	SessionMemory uint32           `binapi:"u32,name=session_memory" json:"session_memory,omitempty"`
-	UserSessions  uint32           `binapi:"u32,name=user_sessions" json:"user_sessions,omitempty"`
-	Enable        bool             `binapi:"bool,name=enable" json:"enable,omitempty"`
-	Flags         Nat44ConfigFlags `binapi:"nat44_config_flags,name=flags" json:"flags,omitempty"`
-}
-
-func (m *Nat44PluginEnableDisable) Reset()               { *m = Nat44PluginEnableDisable{} }
-func (*Nat44PluginEnableDisable) GetMessageName() string { return "nat44_plugin_enable_disable" }
-func (*Nat44PluginEnableDisable) GetCrcString() string   { return "dea0d501" }
-func (*Nat44PluginEnableDisable) GetMessageType() api.MessageType {
-	return api.RequestMessage
-}
-
-func (m *Nat44PluginEnableDisable) Size() (size int) {
-	if m == nil {
-		return 0
-	}
-	size += 4 // m.InsideVrf
-	size += 4 // m.OutsideVrf
-	size += 4 // m.Users
-	size += 4 // m.UserMemory
-	size += 4 // m.Sessions
-	size += 4 // m.SessionMemory
-	size += 4 // m.UserSessions
-	size += 1 // m.Enable
-	size += 1 // m.Flags
-	return size
-}
-func (m *Nat44PluginEnableDisable) Marshal(b []byte) ([]byte, error) {
-	if b == nil {
-		b = make([]byte, m.Size())
-	}
-	buf := codec.NewBuffer(b)
-	buf.EncodeUint32(m.InsideVrf)
-	buf.EncodeUint32(m.OutsideVrf)
-	buf.EncodeUint32(m.Users)
-	buf.EncodeUint32(m.UserMemory)
-	buf.EncodeUint32(m.Sessions)
-	buf.EncodeUint32(m.SessionMemory)
-	buf.EncodeUint32(m.UserSessions)
-	buf.EncodeBool(m.Enable)
-	buf.EncodeUint8(uint8(m.Flags))
-	return buf.Bytes(), nil
-}
-func (m *Nat44PluginEnableDisable) Unmarshal(b []byte) error {
-	buf := codec.NewBuffer(b)
-	m.InsideVrf = buf.DecodeUint32()
-	m.OutsideVrf = buf.DecodeUint32()
-	m.Users = buf.DecodeUint32()
-	m.UserMemory = buf.DecodeUint32()
-	m.Sessions = buf.DecodeUint32()
-	m.SessionMemory = buf.DecodeUint32()
-	m.UserSessions = buf.DecodeUint32()
-	m.Enable = buf.DecodeBool()
-	m.Flags = Nat44ConfigFlags(buf.DecodeUint8())
-	return nil
-}
-
-// Nat44PluginEnableDisableReply defines message 'nat44_plugin_enable_disable_reply'.
-// Deprecated: the message will be removed in the future versions
-type Nat44PluginEnableDisableReply struct {
-	Retval int32 `binapi:"i32,name=retval" json:"retval,omitempty"`
-}
-
-func (m *Nat44PluginEnableDisableReply) Reset() { *m = Nat44PluginEnableDisableReply{} }
-func (*Nat44PluginEnableDisableReply) GetMessageName() string {
-	return "nat44_plugin_enable_disable_reply"
-}
-func (*Nat44PluginEnableDisableReply) GetCrcString() string { return "e8d4e804" }
-func (*Nat44PluginEnableDisableReply) GetMessageType() api.MessageType {
-	return api.ReplyMessage
-}
-
-func (m *Nat44PluginEnableDisableReply) Size() (size int) {
-	if m == nil {
-		return 0
-	}
-	size += 4 // m.Retval
-	return size
-}
-func (m *Nat44PluginEnableDisableReply) Marshal(b []byte) ([]byte, error) {
-	if b == nil {
-		b = make([]byte, m.Size())
-	}
-	buf := codec.NewBuffer(b)
-	buf.EncodeInt32(m.Retval)
-	return buf.Bytes(), nil
-}
-func (m *Nat44PluginEnableDisableReply) Unmarshal(b []byte) error {
-	buf := codec.NewBuffer(b)
-	m.Retval = buf.DecodeInt32()
-	return nil
-}
-
-// Nat44SessionCleanup defines message 'nat44_session_cleanup'.
-// Deprecated: the message will be removed in the future versions
-type Nat44SessionCleanup struct{}
-
-func (m *Nat44SessionCleanup) Reset()               { *m = Nat44SessionCleanup{} }
-func (*Nat44SessionCleanup) GetMessageName() string { return "nat44_session_cleanup" }
-func (*Nat44SessionCleanup) GetCrcString() string   { return "51077d14" }
-func (*Nat44SessionCleanup) GetMessageType() api.MessageType {
-	return api.RequestMessage
-}
-
-func (m *Nat44SessionCleanup) Size() (size int) {
-	if m == nil {
-		return 0
-	}
-	return size
-}
-func (m *Nat44SessionCleanup) Marshal(b []byte) ([]byte, error) {
-	if b == nil {
-		b = make([]byte, m.Size())
-	}
-	buf := codec.NewBuffer(b)
-	return buf.Bytes(), nil
-}
-func (m *Nat44SessionCleanup) Unmarshal(b []byte) error {
-	return nil
-}
-
-// Nat44SessionCleanupReply defines message 'nat44_session_cleanup_reply'.
-// Deprecated: the message will be removed in the future versions
-type Nat44SessionCleanupReply struct {
-	Retval int32 `binapi:"i32,name=retval" json:"retval,omitempty"`
-}
-
-func (m *Nat44SessionCleanupReply) Reset()               { *m = Nat44SessionCleanupReply{} }
-func (*Nat44SessionCleanupReply) GetMessageName() string { return "nat44_session_cleanup_reply" }
-func (*Nat44SessionCleanupReply) GetCrcString() string   { return "e8d4e804" }
-func (*Nat44SessionCleanupReply) GetMessageType() api.MessageType {
-	return api.ReplyMessage
-}
-
-func (m *Nat44SessionCleanupReply) Size() (size int) {
-	if m == nil {
-		return 0
-	}
-	size += 4 // m.Retval
-	return size
-}
-func (m *Nat44SessionCleanupReply) Marshal(b []byte) ([]byte, error) {
-	if b == nil {
-		b = make([]byte, m.Size())
-	}
-	buf := codec.NewBuffer(b)
-	buf.EncodeInt32(m.Retval)
-	return buf.Bytes(), nil
-}
-func (m *Nat44SessionCleanupReply) Unmarshal(b []byte) error {
-	buf := codec.NewBuffer(b)
-	m.Retval = buf.DecodeInt32()
-	return nil
-}
-
 // Nat44SetSessionLimit defines message 'nat44_set_session_limit'.
 type Nat44SetSessionLimit struct {
 	SessionLimit uint32 `binapi:"u32,name=session_limit" json:"session_limit,omitempty"`
@@ -2346,7 +2180,6 @@ func (m *Nat44SetSessionLimitReply) Unmarshal(b []byte) error {
 }
 
 // Nat44ShowRunningConfig defines message 'nat44_show_running_config'.
-// InProgress: the message form may change in the future versions
 type Nat44ShowRunningConfig struct{}
 
 func (m *Nat44ShowRunningConfig) Reset()               { *m = Nat44ShowRunningConfig{} }
@@ -2374,7 +2207,6 @@ func (m *Nat44ShowRunningConfig) Unmarshal(b []byte) error {
 }
 
 // Nat44ShowRunningConfigReply defines message 'nat44_show_running_config_reply'.
-// InProgress: the message form may change in the future versions
 type Nat44ShowRunningConfigReply struct {
 	Retval              int32                 `binapi:"i32,name=retval" json:"retval,omitempty"`
 	InsideVrf           uint32                `binapi:"u32,name=inside_vrf" json:"inside_vrf,omitempty"`
@@ -2747,7 +2579,6 @@ func (m *Nat44UserSessionDump) Unmarshal(b []byte) error {
 }
 
 // Nat44UserSessionV2Details defines message 'nat44_user_session_v2_details'.
-// InProgress: the message form may change in the future versions
 type Nat44UserSessionV2Details struct {
 	OutsideIPAddress  ip_types.IP4Address      `binapi:"ip4_address,name=outside_ip_address" json:"outside_ip_address,omitempty"`
 	OutsidePort       uint16                   `binapi:"u16,name=outside_port" json:"outside_port,omitempty"`
@@ -2833,7 +2664,6 @@ func (m *Nat44UserSessionV2Details) Unmarshal(b []byte) error {
 }
 
 // Nat44UserSessionV2Dump defines message 'nat44_user_session_v2_dump'.
-// InProgress: the message form may change in the future versions
 type Nat44UserSessionV2Dump struct {
 	IPAddress ip_types.IP4Address `binapi:"ip4_address,name=ip_address" json:"ip_address,omitempty"`
 	VrfID     uint32              `binapi:"u32,name=vrf_id" json:"vrf_id,omitempty"`
@@ -2870,77 +2700,134 @@ func (m *Nat44UserSessionV2Dump) Unmarshal(b []byte) error {
 	return nil
 }
 
-// NatControlPing defines message 'nat_control_ping'.
-// Deprecated: the message will be removed in the future versions
-type NatControlPing struct{}
-
-func (m *NatControlPing) Reset()               { *m = NatControlPing{} }
-func (*NatControlPing) GetMessageName() string { return "nat_control_ping" }
-func (*NatControlPing) GetCrcString() string   { return "51077d14" }
-func (*NatControlPing) GetMessageType() api.MessageType {
-	return api.RequestMessage
+// Nat44UserSessionV3Details defines message 'nat44_user_session_v3_details'.
+type Nat44UserSessionV3Details struct {
+	OutsideIPAddress   ip_types.IP4Address      `binapi:"ip4_address,name=outside_ip_address" json:"outside_ip_address,omitempty"`
+	OutsidePort        uint16                   `binapi:"u16,name=outside_port" json:"outside_port,omitempty"`
+	InsideIPAddress    ip_types.IP4Address      `binapi:"ip4_address,name=inside_ip_address" json:"inside_ip_address,omitempty"`
+	InsidePort         uint16                   `binapi:"u16,name=inside_port" json:"inside_port,omitempty"`
+	Protocol           uint16                   `binapi:"u16,name=protocol" json:"protocol,omitempty"`
+	Flags              nat_types.NatConfigFlags `binapi:"nat_config_flags,name=flags" json:"flags,omitempty"`
+	LastHeard          uint64                   `binapi:"u64,name=last_heard" json:"last_heard,omitempty"`
+	TimeSinceLastHeard uint64                   `binapi:"u64,name=time_since_last_heard" json:"time_since_last_heard,omitempty"`
+	TotalBytes         uint64                   `binapi:"u64,name=total_bytes" json:"total_bytes,omitempty"`
+	TotalPkts          uint32                   `binapi:"u32,name=total_pkts" json:"total_pkts,omitempty"`
+	ExtHostAddress     ip_types.IP4Address      `binapi:"ip4_address,name=ext_host_address" json:"ext_host_address,omitempty"`
+	ExtHostPort        uint16                   `binapi:"u16,name=ext_host_port" json:"ext_host_port,omitempty"`
+	ExtHostNatAddress  ip_types.IP4Address      `binapi:"ip4_address,name=ext_host_nat_address" json:"ext_host_nat_address,omitempty"`
+	ExtHostNatPort     uint16                   `binapi:"u16,name=ext_host_nat_port" json:"ext_host_nat_port,omitempty"`
+	IsTimedOut         bool                     `binapi:"bool,name=is_timed_out" json:"is_timed_out,omitempty"`
 }
 
-func (m *NatControlPing) Size() (size int) {
-	if m == nil {
-		return 0
-	}
-	return size
-}
-func (m *NatControlPing) Marshal(b []byte) ([]byte, error) {
-	if b == nil {
-		b = make([]byte, m.Size())
-	}
-	buf := codec.NewBuffer(b)
-	return buf.Bytes(), nil
-}
-func (m *NatControlPing) Unmarshal(b []byte) error {
-	return nil
-}
-
-// NatControlPingReply defines message 'nat_control_ping_reply'.
-// Deprecated: the message will be removed in the future versions
-type NatControlPingReply struct {
-	Retval      int32  `binapi:"i32,name=retval" json:"retval,omitempty"`
-	ClientIndex uint32 `binapi:"u32,name=client_index" json:"client_index,omitempty"`
-	VpePID      uint32 `binapi:"u32,name=vpe_pid" json:"vpe_pid,omitempty"`
-}
-
-func (m *NatControlPingReply) Reset()               { *m = NatControlPingReply{} }
-func (*NatControlPingReply) GetMessageName() string { return "nat_control_ping_reply" }
-func (*NatControlPingReply) GetCrcString() string   { return "f6b0b8ca" }
-func (*NatControlPingReply) GetMessageType() api.MessageType {
+func (m *Nat44UserSessionV3Details) Reset()               { *m = Nat44UserSessionV3Details{} }
+func (*Nat44UserSessionV3Details) GetMessageName() string { return "nat44_user_session_v3_details" }
+func (*Nat44UserSessionV3Details) GetCrcString() string   { return "edae926e" }
+func (*Nat44UserSessionV3Details) GetMessageType() api.MessageType {
 	return api.ReplyMessage
 }
 
-func (m *NatControlPingReply) Size() (size int) {
+func (m *Nat44UserSessionV3Details) Size() (size int) {
 	if m == nil {
 		return 0
 	}
-	size += 4 // m.Retval
-	size += 4 // m.ClientIndex
-	size += 4 // m.VpePID
+	size += 1 * 4 // m.OutsideIPAddress
+	size += 2     // m.OutsidePort
+	size += 1 * 4 // m.InsideIPAddress
+	size += 2     // m.InsidePort
+	size += 2     // m.Protocol
+	size += 1     // m.Flags
+	size += 8     // m.LastHeard
+	size += 8     // m.TimeSinceLastHeard
+	size += 8     // m.TotalBytes
+	size += 4     // m.TotalPkts
+	size += 1 * 4 // m.ExtHostAddress
+	size += 2     // m.ExtHostPort
+	size += 1 * 4 // m.ExtHostNatAddress
+	size += 2     // m.ExtHostNatPort
+	size += 1     // m.IsTimedOut
 	return size
 }
-func (m *NatControlPingReply) Marshal(b []byte) ([]byte, error) {
+func (m *Nat44UserSessionV3Details) Marshal(b []byte) ([]byte, error) {
 	if b == nil {
 		b = make([]byte, m.Size())
 	}
 	buf := codec.NewBuffer(b)
-	buf.EncodeInt32(m.Retval)
-	buf.EncodeUint32(m.ClientIndex)
-	buf.EncodeUint32(m.VpePID)
+	buf.EncodeBytes(m.OutsideIPAddress[:], 4)
+	buf.EncodeUint16(m.OutsidePort)
+	buf.EncodeBytes(m.InsideIPAddress[:], 4)
+	buf.EncodeUint16(m.InsidePort)
+	buf.EncodeUint16(m.Protocol)
+	buf.EncodeUint8(uint8(m.Flags))
+	buf.EncodeUint64(m.LastHeard)
+	buf.EncodeUint64(m.TimeSinceLastHeard)
+	buf.EncodeUint64(m.TotalBytes)
+	buf.EncodeUint32(m.TotalPkts)
+	buf.EncodeBytes(m.ExtHostAddress[:], 4)
+	buf.EncodeUint16(m.ExtHostPort)
+	buf.EncodeBytes(m.ExtHostNatAddress[:], 4)
+	buf.EncodeUint16(m.ExtHostNatPort)
+	buf.EncodeBool(m.IsTimedOut)
 	return buf.Bytes(), nil
 }
-func (m *NatControlPingReply) Unmarshal(b []byte) error {
+func (m *Nat44UserSessionV3Details) Unmarshal(b []byte) error {
 	buf := codec.NewBuffer(b)
-	m.Retval = buf.DecodeInt32()
-	m.ClientIndex = buf.DecodeUint32()
-	m.VpePID = buf.DecodeUint32()
+	copy(m.OutsideIPAddress[:], buf.DecodeBytes(4))
+	m.OutsidePort = buf.DecodeUint16()
+	copy(m.InsideIPAddress[:], buf.DecodeBytes(4))
+	m.InsidePort = buf.DecodeUint16()
+	m.Protocol = buf.DecodeUint16()
+	m.Flags = nat_types.NatConfigFlags(buf.DecodeUint8())
+	m.LastHeard = buf.DecodeUint64()
+	m.TimeSinceLastHeard = buf.DecodeUint64()
+	m.TotalBytes = buf.DecodeUint64()
+	m.TotalPkts = buf.DecodeUint32()
+	copy(m.ExtHostAddress[:], buf.DecodeBytes(4))
+	m.ExtHostPort = buf.DecodeUint16()
+	copy(m.ExtHostNatAddress[:], buf.DecodeBytes(4))
+	m.ExtHostNatPort = buf.DecodeUint16()
+	m.IsTimedOut = buf.DecodeBool()
+	return nil
+}
+
+// Nat44UserSessionV3Dump defines message 'nat44_user_session_v3_dump'.
+type Nat44UserSessionV3Dump struct {
+	IPAddress ip_types.IP4Address `binapi:"ip4_address,name=ip_address" json:"ip_address,omitempty"`
+	VrfID     uint32              `binapi:"u32,name=vrf_id" json:"vrf_id,omitempty"`
+}
+
+func (m *Nat44UserSessionV3Dump) Reset()               { *m = Nat44UserSessionV3Dump{} }
+func (*Nat44UserSessionV3Dump) GetMessageName() string { return "nat44_user_session_v3_dump" }
+func (*Nat44UserSessionV3Dump) GetCrcString() string   { return "e1899c98" }
+func (*Nat44UserSessionV3Dump) GetMessageType() api.MessageType {
+	return api.RequestMessage
+}
+
+func (m *Nat44UserSessionV3Dump) Size() (size int) {
+	if m == nil {
+		return 0
+	}
+	size += 1 * 4 // m.IPAddress
+	size += 4     // m.VrfID
+	return size
+}
+func (m *Nat44UserSessionV3Dump) Marshal(b []byte) ([]byte, error) {
+	if b == nil {
+		b = make([]byte, m.Size())
+	}
+	buf := codec.NewBuffer(b)
+	buf.EncodeBytes(m.IPAddress[:], 4)
+	buf.EncodeUint32(m.VrfID)
+	return buf.Bytes(), nil
+}
+func (m *Nat44UserSessionV3Dump) Unmarshal(b []byte) error {
+	buf := codec.NewBuffer(b)
+	copy(m.IPAddress[:], buf.DecodeBytes(4))
+	m.VrfID = buf.DecodeUint32()
 	return nil
 }
 
 // NatGetAddrAndPortAllocAlg defines message 'nat_get_addr_and_port_alloc_alg'.
+// Deprecated: the message will be removed in the future versions
 type NatGetAddrAndPortAllocAlg struct{}
 
 func (m *NatGetAddrAndPortAllocAlg) Reset()               { *m = NatGetAddrAndPortAllocAlg{} }
@@ -2968,6 +2855,7 @@ func (m *NatGetAddrAndPortAllocAlg) Unmarshal(b []byte) error {
 }
 
 // NatGetAddrAndPortAllocAlgReply defines message 'nat_get_addr_and_port_alloc_alg_reply'.
+// Deprecated: the message will be removed in the future versions
 type NatGetAddrAndPortAllocAlgReply struct {
 	Retval     int32  `binapi:"i32,name=retval" json:"retval,omitempty"`
 	Alg        uint8  `binapi:"u8,name=alg" json:"alg,omitempty"`
@@ -3094,85 +2982,8 @@ func (m *NatGetMssClampingReply) Unmarshal(b []byte) error {
 	return nil
 }
 
-// NatGetTimeouts defines message 'nat_get_timeouts'.
-// Deprecated: the message will be removed in the future versions
-type NatGetTimeouts struct{}
-
-func (m *NatGetTimeouts) Reset()               { *m = NatGetTimeouts{} }
-func (*NatGetTimeouts) GetMessageName() string { return "nat_get_timeouts" }
-func (*NatGetTimeouts) GetCrcString() string   { return "51077d14" }
-func (*NatGetTimeouts) GetMessageType() api.MessageType {
-	return api.RequestMessage
-}
-
-func (m *NatGetTimeouts) Size() (size int) {
-	if m == nil {
-		return 0
-	}
-	return size
-}
-func (m *NatGetTimeouts) Marshal(b []byte) ([]byte, error) {
-	if b == nil {
-		b = make([]byte, m.Size())
-	}
-	buf := codec.NewBuffer(b)
-	return buf.Bytes(), nil
-}
-func (m *NatGetTimeouts) Unmarshal(b []byte) error {
-	return nil
-}
-
-// NatGetTimeoutsReply defines message 'nat_get_timeouts_reply'.
-// Deprecated: the message will be removed in the future versions
-type NatGetTimeoutsReply struct {
-	Retval         int32  `binapi:"i32,name=retval" json:"retval,omitempty"`
-	UDP            uint32 `binapi:"u32,name=udp" json:"udp,omitempty"`
-	TCPEstablished uint32 `binapi:"u32,name=tcp_established" json:"tcp_established,omitempty"`
-	TCPTransitory  uint32 `binapi:"u32,name=tcp_transitory" json:"tcp_transitory,omitempty"`
-	ICMP           uint32 `binapi:"u32,name=icmp" json:"icmp,omitempty"`
-}
-
-func (m *NatGetTimeoutsReply) Reset()               { *m = NatGetTimeoutsReply{} }
-func (*NatGetTimeoutsReply) GetMessageName() string { return "nat_get_timeouts_reply" }
-func (*NatGetTimeoutsReply) GetCrcString() string   { return "3c4df4e1" }
-func (*NatGetTimeoutsReply) GetMessageType() api.MessageType {
-	return api.ReplyMessage
-}
-
-func (m *NatGetTimeoutsReply) Size() (size int) {
-	if m == nil {
-		return 0
-	}
-	size += 4 // m.Retval
-	size += 4 // m.UDP
-	size += 4 // m.TCPEstablished
-	size += 4 // m.TCPTransitory
-	size += 4 // m.ICMP
-	return size
-}
-func (m *NatGetTimeoutsReply) Marshal(b []byte) ([]byte, error) {
-	if b == nil {
-		b = make([]byte, m.Size())
-	}
-	buf := codec.NewBuffer(b)
-	buf.EncodeInt32(m.Retval)
-	buf.EncodeUint32(m.UDP)
-	buf.EncodeUint32(m.TCPEstablished)
-	buf.EncodeUint32(m.TCPTransitory)
-	buf.EncodeUint32(m.ICMP)
-	return buf.Bytes(), nil
-}
-func (m *NatGetTimeoutsReply) Unmarshal(b []byte) error {
-	buf := codec.NewBuffer(b)
-	m.Retval = buf.DecodeInt32()
-	m.UDP = buf.DecodeUint32()
-	m.TCPEstablished = buf.DecodeUint32()
-	m.TCPTransitory = buf.DecodeUint32()
-	m.ICMP = buf.DecodeUint32()
-	return nil
-}
-
 // NatHaFlush defines message 'nat_ha_flush'.
+// Deprecated: the message will be removed in the future versions
 type NatHaFlush struct{}
 
 func (m *NatHaFlush) Reset()               { *m = NatHaFlush{} }
@@ -3200,6 +3011,7 @@ func (m *NatHaFlush) Unmarshal(b []byte) error {
 }
 
 // NatHaFlushReply defines message 'nat_ha_flush_reply'.
+// Deprecated: the message will be removed in the future versions
 type NatHaFlushReply struct {
 	Retval int32 `binapi:"i32,name=retval" json:"retval,omitempty"`
 }
@@ -3233,6 +3045,7 @@ func (m *NatHaFlushReply) Unmarshal(b []byte) error {
 }
 
 // NatHaGetFailover defines message 'nat_ha_get_failover'.
+// Deprecated: the message will be removed in the future versions
 type NatHaGetFailover struct{}
 
 func (m *NatHaGetFailover) Reset()               { *m = NatHaGetFailover{} }
@@ -3260,6 +3073,7 @@ func (m *NatHaGetFailover) Unmarshal(b []byte) error {
 }
 
 // NatHaGetFailoverReply defines message 'nat_ha_get_failover_reply'.
+// Deprecated: the message will be removed in the future versions
 type NatHaGetFailoverReply struct {
 	Retval                 int32               `binapi:"i32,name=retval" json:"retval,omitempty"`
 	IPAddress              ip_types.IP4Address `binapi:"ip4_address,name=ip_address" json:"ip_address,omitempty"`
@@ -3305,6 +3119,7 @@ func (m *NatHaGetFailoverReply) Unmarshal(b []byte) error {
 }
 
 // NatHaGetListener defines message 'nat_ha_get_listener'.
+// Deprecated: the message will be removed in the future versions
 type NatHaGetListener struct{}
 
 func (m *NatHaGetListener) Reset()               { *m = NatHaGetListener{} }
@@ -3332,6 +3147,7 @@ func (m *NatHaGetListener) Unmarshal(b []byte) error {
 }
 
 // NatHaGetListenerReply defines message 'nat_ha_get_listener_reply'.
+// Deprecated: the message will be removed in the future versions
 type NatHaGetListenerReply struct {
 	Retval    int32               `binapi:"i32,name=retval" json:"retval,omitempty"`
 	IPAddress ip_types.IP4Address `binapi:"ip4_address,name=ip_address" json:"ip_address,omitempty"`
@@ -3377,6 +3193,7 @@ func (m *NatHaGetListenerReply) Unmarshal(b []byte) error {
 }
 
 // NatHaResync defines message 'nat_ha_resync'.
+// Deprecated: the message will be removed in the future versions
 type NatHaResync struct {
 	WantResyncEvent uint8  `binapi:"u8,name=want_resync_event" json:"want_resync_event,omitempty"`
 	PID             uint32 `binapi:"u32,name=pid" json:"pid,omitempty"`
@@ -3414,6 +3231,7 @@ func (m *NatHaResync) Unmarshal(b []byte) error {
 }
 
 // NatHaResyncCompletedEvent defines message 'nat_ha_resync_completed_event'.
+// Deprecated: the message will be removed in the future versions
 type NatHaResyncCompletedEvent struct {
 	PID         uint32 `binapi:"u32,name=pid" json:"pid,omitempty"`
 	MissedCount uint32 `binapi:"u32,name=missed_count" json:"missed_count,omitempty"`
@@ -3451,6 +3269,7 @@ func (m *NatHaResyncCompletedEvent) Unmarshal(b []byte) error {
 }
 
 // NatHaResyncReply defines message 'nat_ha_resync_reply'.
+// Deprecated: the message will be removed in the future versions
 type NatHaResyncReply struct {
 	Retval int32 `binapi:"i32,name=retval" json:"retval,omitempty"`
 }
@@ -3484,6 +3303,7 @@ func (m *NatHaResyncReply) Unmarshal(b []byte) error {
 }
 
 // NatHaSetFailover defines message 'nat_ha_set_failover'.
+// Deprecated: the message will be removed in the future versions
 type NatHaSetFailover struct {
 	IPAddress              ip_types.IP4Address `binapi:"ip4_address,name=ip_address" json:"ip_address,omitempty"`
 	Port                   uint16              `binapi:"u16,name=port" json:"port,omitempty"`
@@ -3525,6 +3345,7 @@ func (m *NatHaSetFailover) Unmarshal(b []byte) error {
 }
 
 // NatHaSetFailoverReply defines message 'nat_ha_set_failover_reply'.
+// Deprecated: the message will be removed in the future versions
 type NatHaSetFailoverReply struct {
 	Retval int32 `binapi:"i32,name=retval" json:"retval,omitempty"`
 }
@@ -3558,6 +3379,7 @@ func (m *NatHaSetFailoverReply) Unmarshal(b []byte) error {
 }
 
 // NatHaSetListener defines message 'nat_ha_set_listener'.
+// Deprecated: the message will be removed in the future versions
 type NatHaSetListener struct {
 	IPAddress ip_types.IP4Address `binapi:"ip4_address,name=ip_address" json:"ip_address,omitempty"`
 	Port      uint16              `binapi:"u16,name=port" json:"port,omitempty"`
@@ -3599,6 +3421,7 @@ func (m *NatHaSetListener) Unmarshal(b []byte) error {
 }
 
 // NatHaSetListenerReply defines message 'nat_ha_set_listener_reply'.
+// Deprecated: the message will be removed in the future versions
 type NatHaSetListenerReply struct {
 	Retval int32 `binapi:"i32,name=retval" json:"retval,omitempty"`
 }
@@ -3708,6 +3531,7 @@ func (m *NatIpfixEnableDisableReply) Unmarshal(b []byte) error {
 }
 
 // NatSetAddrAndPortAllocAlg defines message 'nat_set_addr_and_port_alloc_alg'.
+// Deprecated: the message will be removed in the future versions
 type NatSetAddrAndPortAllocAlg struct {
 	Alg        uint8  `binapi:"u8,name=alg" json:"alg,omitempty"`
 	PsidOffset uint8  `binapi:"u8,name=psid_offset" json:"psid_offset,omitempty"`
@@ -3761,6 +3585,7 @@ func (m *NatSetAddrAndPortAllocAlg) Unmarshal(b []byte) error {
 }
 
 // NatSetAddrAndPortAllocAlgReply defines message 'nat_set_addr_and_port_alloc_alg_reply'.
+// Deprecated: the message will be removed in the future versions
 type NatSetAddrAndPortAllocAlgReply struct {
 	Retval int32 `binapi:"i32,name=retval" json:"retval,omitempty"`
 }
@@ -3790,74 +3615,6 @@ func (m *NatSetAddrAndPortAllocAlgReply) Marshal(b []byte) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 func (m *NatSetAddrAndPortAllocAlgReply) Unmarshal(b []byte) error {
-	buf := codec.NewBuffer(b)
-	m.Retval = buf.DecodeInt32()
-	return nil
-}
-
-// NatSetLogLevel defines message 'nat_set_log_level'.
-// Deprecated: the message will be removed in the future versions
-type NatSetLogLevel struct {
-	LogLevel nat_types.NatLogLevel `binapi:"nat_log_level,name=log_level" json:"log_level,omitempty"`
-}
-
-func (m *NatSetLogLevel) Reset()               { *m = NatSetLogLevel{} }
-func (*NatSetLogLevel) GetMessageName() string { return "nat_set_log_level" }
-func (*NatSetLogLevel) GetCrcString() string   { return "70076bfe" }
-func (*NatSetLogLevel) GetMessageType() api.MessageType {
-	return api.RequestMessage
-}
-
-func (m *NatSetLogLevel) Size() (size int) {
-	if m == nil {
-		return 0
-	}
-	size += 1 // m.LogLevel
-	return size
-}
-func (m *NatSetLogLevel) Marshal(b []byte) ([]byte, error) {
-	if b == nil {
-		b = make([]byte, m.Size())
-	}
-	buf := codec.NewBuffer(b)
-	buf.EncodeUint8(uint8(m.LogLevel))
-	return buf.Bytes(), nil
-}
-func (m *NatSetLogLevel) Unmarshal(b []byte) error {
-	buf := codec.NewBuffer(b)
-	m.LogLevel = nat_types.NatLogLevel(buf.DecodeUint8())
-	return nil
-}
-
-// NatSetLogLevelReply defines message 'nat_set_log_level_reply'.
-// Deprecated: the message will be removed in the future versions
-type NatSetLogLevelReply struct {
-	Retval int32 `binapi:"i32,name=retval" json:"retval,omitempty"`
-}
-
-func (m *NatSetLogLevelReply) Reset()               { *m = NatSetLogLevelReply{} }
-func (*NatSetLogLevelReply) GetMessageName() string { return "nat_set_log_level_reply" }
-func (*NatSetLogLevelReply) GetCrcString() string   { return "e8d4e804" }
-func (*NatSetLogLevelReply) GetMessageType() api.MessageType {
-	return api.ReplyMessage
-}
-
-func (m *NatSetLogLevelReply) Size() (size int) {
-	if m == nil {
-		return 0
-	}
-	size += 4 // m.Retval
-	return size
-}
-func (m *NatSetLogLevelReply) Marshal(b []byte) ([]byte, error) {
-	if b == nil {
-		b = make([]byte, m.Size())
-	}
-	buf := codec.NewBuffer(b)
-	buf.EncodeInt32(m.Retval)
-	return buf.Bytes(), nil
-}
-func (m *NatSetLogLevelReply) Unmarshal(b []byte) error {
 	buf := codec.NewBuffer(b)
 	m.Retval = buf.DecodeInt32()
 	return nil
@@ -4079,274 +3836,6 @@ func (m *NatSetWorkersReply) Unmarshal(b []byte) error {
 	return nil
 }
 
-// NatShowConfig defines message 'nat_show_config'.
-// Deprecated: the message will be removed in the future versions
-type NatShowConfig struct{}
-
-func (m *NatShowConfig) Reset()               { *m = NatShowConfig{} }
-func (*NatShowConfig) GetMessageName() string { return "nat_show_config" }
-func (*NatShowConfig) GetCrcString() string   { return "51077d14" }
-func (*NatShowConfig) GetMessageType() api.MessageType {
-	return api.RequestMessage
-}
-
-func (m *NatShowConfig) Size() (size int) {
-	if m == nil {
-		return 0
-	}
-	return size
-}
-func (m *NatShowConfig) Marshal(b []byte) ([]byte, error) {
-	if b == nil {
-		b = make([]byte, m.Size())
-	}
-	buf := codec.NewBuffer(b)
-	return buf.Bytes(), nil
-}
-func (m *NatShowConfig) Unmarshal(b []byte) error {
-	return nil
-}
-
-// NatShowConfig2 defines message 'nat_show_config_2'.
-// Deprecated: the message will be removed in the future versions
-type NatShowConfig2 struct{}
-
-func (m *NatShowConfig2) Reset()               { *m = NatShowConfig2{} }
-func (*NatShowConfig2) GetMessageName() string { return "nat_show_config_2" }
-func (*NatShowConfig2) GetCrcString() string   { return "51077d14" }
-func (*NatShowConfig2) GetMessageType() api.MessageType {
-	return api.RequestMessage
-}
-
-func (m *NatShowConfig2) Size() (size int) {
-	if m == nil {
-		return 0
-	}
-	return size
-}
-func (m *NatShowConfig2) Marshal(b []byte) ([]byte, error) {
-	if b == nil {
-		b = make([]byte, m.Size())
-	}
-	buf := codec.NewBuffer(b)
-	return buf.Bytes(), nil
-}
-func (m *NatShowConfig2) Unmarshal(b []byte) error {
-	return nil
-}
-
-// NatShowConfig2Reply defines message 'nat_show_config_2_reply'.
-// Deprecated: the message will be removed in the future versions
-type NatShowConfig2Reply struct {
-	Retval                          int32  `binapi:"i32,name=retval" json:"retval,omitempty"`
-	StaticMappingOnly               bool   `binapi:"bool,name=static_mapping_only" json:"static_mapping_only,omitempty"`
-	StaticMappingConnectionTracking bool   `binapi:"bool,name=static_mapping_connection_tracking" json:"static_mapping_connection_tracking,omitempty"`
-	Deterministic                   bool   `binapi:"bool,name=deterministic" json:"deterministic,omitempty"`
-	EndpointDependent               bool   `binapi:"bool,name=endpoint_dependent" json:"endpoint_dependent,omitempty"`
-	Out2inDpo                       bool   `binapi:"bool,name=out2in_dpo" json:"out2in_dpo,omitempty"`
-	DsliteCe                        bool   `binapi:"bool,name=dslite_ce" json:"dslite_ce,omitempty"`
-	TranslationBuckets              uint32 `binapi:"u32,name=translation_buckets" json:"translation_buckets,omitempty"`
-	TranslationMemorySize           uint64 `binapi:"u64,name=translation_memory_size" json:"translation_memory_size,omitempty"`
-	UserBuckets                     uint32 `binapi:"u32,name=user_buckets" json:"user_buckets,omitempty"`
-	UserMemorySize                  uint64 `binapi:"u64,name=user_memory_size" json:"user_memory_size,omitempty"`
-	MaxTranslationsPerUser          uint32 `binapi:"u32,name=max_translations_per_user" json:"max_translations_per_user,omitempty"`
-	OutsideVrfID                    uint32 `binapi:"u32,name=outside_vrf_id" json:"outside_vrf_id,omitempty"`
-	InsideVrfID                     uint32 `binapi:"u32,name=inside_vrf_id" json:"inside_vrf_id,omitempty"`
-	Nat64BibBuckets                 uint32 `binapi:"u32,name=nat64_bib_buckets" json:"nat64_bib_buckets,omitempty"`
-	Nat64BibMemorySize              uint64 `binapi:"u64,name=nat64_bib_memory_size" json:"nat64_bib_memory_size,omitempty"`
-	Nat64StBuckets                  uint32 `binapi:"u32,name=nat64_st_buckets" json:"nat64_st_buckets,omitempty"`
-	Nat64StMemorySize               uint64 `binapi:"u64,name=nat64_st_memory_size" json:"nat64_st_memory_size,omitempty"`
-	MaxTranslationsPerThread        uint32 `binapi:"u32,name=max_translations_per_thread" json:"max_translations_per_thread,omitempty"`
-	MaxUsersPerThread               uint32 `binapi:"u32,name=max_users_per_thread" json:"max_users_per_thread,omitempty"`
-}
-
-func (m *NatShowConfig2Reply) Reset()               { *m = NatShowConfig2Reply{} }
-func (*NatShowConfig2Reply) GetMessageName() string { return "nat_show_config_2_reply" }
-func (*NatShowConfig2Reply) GetCrcString() string   { return "0404a5b4" }
-func (*NatShowConfig2Reply) GetMessageType() api.MessageType {
-	return api.ReplyMessage
-}
-
-func (m *NatShowConfig2Reply) Size() (size int) {
-	if m == nil {
-		return 0
-	}
-	size += 4 // m.Retval
-	size += 1 // m.StaticMappingOnly
-	size += 1 // m.StaticMappingConnectionTracking
-	size += 1 // m.Deterministic
-	size += 1 // m.EndpointDependent
-	size += 1 // m.Out2inDpo
-	size += 1 // m.DsliteCe
-	size += 4 // m.TranslationBuckets
-	size += 8 // m.TranslationMemorySize
-	size += 4 // m.UserBuckets
-	size += 8 // m.UserMemorySize
-	size += 4 // m.MaxTranslationsPerUser
-	size += 4 // m.OutsideVrfID
-	size += 4 // m.InsideVrfID
-	size += 4 // m.Nat64BibBuckets
-	size += 8 // m.Nat64BibMemorySize
-	size += 4 // m.Nat64StBuckets
-	size += 8 // m.Nat64StMemorySize
-	size += 4 // m.MaxTranslationsPerThread
-	size += 4 // m.MaxUsersPerThread
-	return size
-}
-func (m *NatShowConfig2Reply) Marshal(b []byte) ([]byte, error) {
-	if b == nil {
-		b = make([]byte, m.Size())
-	}
-	buf := codec.NewBuffer(b)
-	buf.EncodeInt32(m.Retval)
-	buf.EncodeBool(m.StaticMappingOnly)
-	buf.EncodeBool(m.StaticMappingConnectionTracking)
-	buf.EncodeBool(m.Deterministic)
-	buf.EncodeBool(m.EndpointDependent)
-	buf.EncodeBool(m.Out2inDpo)
-	buf.EncodeBool(m.DsliteCe)
-	buf.EncodeUint32(m.TranslationBuckets)
-	buf.EncodeUint64(m.TranslationMemorySize)
-	buf.EncodeUint32(m.UserBuckets)
-	buf.EncodeUint64(m.UserMemorySize)
-	buf.EncodeUint32(m.MaxTranslationsPerUser)
-	buf.EncodeUint32(m.OutsideVrfID)
-	buf.EncodeUint32(m.InsideVrfID)
-	buf.EncodeUint32(m.Nat64BibBuckets)
-	buf.EncodeUint64(m.Nat64BibMemorySize)
-	buf.EncodeUint32(m.Nat64StBuckets)
-	buf.EncodeUint64(m.Nat64StMemorySize)
-	buf.EncodeUint32(m.MaxTranslationsPerThread)
-	buf.EncodeUint32(m.MaxUsersPerThread)
-	return buf.Bytes(), nil
-}
-func (m *NatShowConfig2Reply) Unmarshal(b []byte) error {
-	buf := codec.NewBuffer(b)
-	m.Retval = buf.DecodeInt32()
-	m.StaticMappingOnly = buf.DecodeBool()
-	m.StaticMappingConnectionTracking = buf.DecodeBool()
-	m.Deterministic = buf.DecodeBool()
-	m.EndpointDependent = buf.DecodeBool()
-	m.Out2inDpo = buf.DecodeBool()
-	m.DsliteCe = buf.DecodeBool()
-	m.TranslationBuckets = buf.DecodeUint32()
-	m.TranslationMemorySize = buf.DecodeUint64()
-	m.UserBuckets = buf.DecodeUint32()
-	m.UserMemorySize = buf.DecodeUint64()
-	m.MaxTranslationsPerUser = buf.DecodeUint32()
-	m.OutsideVrfID = buf.DecodeUint32()
-	m.InsideVrfID = buf.DecodeUint32()
-	m.Nat64BibBuckets = buf.DecodeUint32()
-	m.Nat64BibMemorySize = buf.DecodeUint64()
-	m.Nat64StBuckets = buf.DecodeUint32()
-	m.Nat64StMemorySize = buf.DecodeUint64()
-	m.MaxTranslationsPerThread = buf.DecodeUint32()
-	m.MaxUsersPerThread = buf.DecodeUint32()
-	return nil
-}
-
-// NatShowConfigReply defines message 'nat_show_config_reply'.
-// Deprecated: the message will be removed in the future versions
-type NatShowConfigReply struct {
-	Retval                          int32  `binapi:"i32,name=retval" json:"retval,omitempty"`
-	StaticMappingOnly               bool   `binapi:"bool,name=static_mapping_only" json:"static_mapping_only,omitempty"`
-	StaticMappingConnectionTracking bool   `binapi:"bool,name=static_mapping_connection_tracking" json:"static_mapping_connection_tracking,omitempty"`
-	Deterministic                   bool   `binapi:"bool,name=deterministic" json:"deterministic,omitempty"`
-	EndpointDependent               bool   `binapi:"bool,name=endpoint_dependent" json:"endpoint_dependent,omitempty"`
-	Out2inDpo                       bool   `binapi:"bool,name=out2in_dpo" json:"out2in_dpo,omitempty"`
-	DsliteCe                        bool   `binapi:"bool,name=dslite_ce" json:"dslite_ce,omitempty"`
-	TranslationBuckets              uint32 `binapi:"u32,name=translation_buckets" json:"translation_buckets,omitempty"`
-	TranslationMemorySize           uint32 `binapi:"u32,name=translation_memory_size" json:"translation_memory_size,omitempty"`
-	UserBuckets                     uint32 `binapi:"u32,name=user_buckets" json:"user_buckets,omitempty"`
-	UserMemorySize                  uint64 `binapi:"u64,name=user_memory_size" json:"user_memory_size,omitempty"`
-	MaxTranslationsPerUser          uint32 `binapi:"u32,name=max_translations_per_user" json:"max_translations_per_user,omitempty"`
-	OutsideVrfID                    uint32 `binapi:"u32,name=outside_vrf_id" json:"outside_vrf_id,omitempty"`
-	InsideVrfID                     uint32 `binapi:"u32,name=inside_vrf_id" json:"inside_vrf_id,omitempty"`
-	Nat64BibBuckets                 uint32 `binapi:"u32,name=nat64_bib_buckets" json:"nat64_bib_buckets,omitempty"`
-	Nat64BibMemorySize              uint64 `binapi:"u64,name=nat64_bib_memory_size" json:"nat64_bib_memory_size,omitempty"`
-	Nat64StBuckets                  uint32 `binapi:"u32,name=nat64_st_buckets" json:"nat64_st_buckets,omitempty"`
-	Nat64StMemorySize               uint64 `binapi:"u64,name=nat64_st_memory_size" json:"nat64_st_memory_size,omitempty"`
-}
-
-func (m *NatShowConfigReply) Reset()               { *m = NatShowConfigReply{} }
-func (*NatShowConfigReply) GetMessageName() string { return "nat_show_config_reply" }
-func (*NatShowConfigReply) GetCrcString() string   { return "7903ef06" }
-func (*NatShowConfigReply) GetMessageType() api.MessageType {
-	return api.ReplyMessage
-}
-
-func (m *NatShowConfigReply) Size() (size int) {
-	if m == nil {
-		return 0
-	}
-	size += 4 // m.Retval
-	size += 1 // m.StaticMappingOnly
-	size += 1 // m.StaticMappingConnectionTracking
-	size += 1 // m.Deterministic
-	size += 1 // m.EndpointDependent
-	size += 1 // m.Out2inDpo
-	size += 1 // m.DsliteCe
-	size += 4 // m.TranslationBuckets
-	size += 4 // m.TranslationMemorySize
-	size += 4 // m.UserBuckets
-	size += 8 // m.UserMemorySize
-	size += 4 // m.MaxTranslationsPerUser
-	size += 4 // m.OutsideVrfID
-	size += 4 // m.InsideVrfID
-	size += 4 // m.Nat64BibBuckets
-	size += 8 // m.Nat64BibMemorySize
-	size += 4 // m.Nat64StBuckets
-	size += 8 // m.Nat64StMemorySize
-	return size
-}
-func (m *NatShowConfigReply) Marshal(b []byte) ([]byte, error) {
-	if b == nil {
-		b = make([]byte, m.Size())
-	}
-	buf := codec.NewBuffer(b)
-	buf.EncodeInt32(m.Retval)
-	buf.EncodeBool(m.StaticMappingOnly)
-	buf.EncodeBool(m.StaticMappingConnectionTracking)
-	buf.EncodeBool(m.Deterministic)
-	buf.EncodeBool(m.EndpointDependent)
-	buf.EncodeBool(m.Out2inDpo)
-	buf.EncodeBool(m.DsliteCe)
-	buf.EncodeUint32(m.TranslationBuckets)
-	buf.EncodeUint32(m.TranslationMemorySize)
-	buf.EncodeUint32(m.UserBuckets)
-	buf.EncodeUint64(m.UserMemorySize)
-	buf.EncodeUint32(m.MaxTranslationsPerUser)
-	buf.EncodeUint32(m.OutsideVrfID)
-	buf.EncodeUint32(m.InsideVrfID)
-	buf.EncodeUint32(m.Nat64BibBuckets)
-	buf.EncodeUint64(m.Nat64BibMemorySize)
-	buf.EncodeUint32(m.Nat64StBuckets)
-	buf.EncodeUint64(m.Nat64StMemorySize)
-	return buf.Bytes(), nil
-}
-func (m *NatShowConfigReply) Unmarshal(b []byte) error {
-	buf := codec.NewBuffer(b)
-	m.Retval = buf.DecodeInt32()
-	m.StaticMappingOnly = buf.DecodeBool()
-	m.StaticMappingConnectionTracking = buf.DecodeBool()
-	m.Deterministic = buf.DecodeBool()
-	m.EndpointDependent = buf.DecodeBool()
-	m.Out2inDpo = buf.DecodeBool()
-	m.DsliteCe = buf.DecodeBool()
-	m.TranslationBuckets = buf.DecodeUint32()
-	m.TranslationMemorySize = buf.DecodeUint32()
-	m.UserBuckets = buf.DecodeUint32()
-	m.UserMemorySize = buf.DecodeUint64()
-	m.MaxTranslationsPerUser = buf.DecodeUint32()
-	m.OutsideVrfID = buf.DecodeUint32()
-	m.InsideVrfID = buf.DecodeUint32()
-	m.Nat64BibBuckets = buf.DecodeUint32()
-	m.Nat64BibMemorySize = buf.DecodeUint64()
-	m.Nat64StBuckets = buf.DecodeUint32()
-	m.Nat64StMemorySize = buf.DecodeUint64()
-	return nil
-}
-
 // NatWorkerDetails defines message 'nat_worker_details'.
 type NatWorkerDetails struct {
 	WorkerIndex uint32 `binapi:"u32,name=worker_index" json:"worker_index,omitempty"`
@@ -4437,6 +3926,10 @@ func file_nat44_ed_binapi_init() {
 	api.RegisterMessage((*Nat44DelUserReply)(nil), "nat44_del_user_reply_e8d4e804")
 	api.RegisterMessage((*Nat44EdAddDelOutputInterface)(nil), "nat44_ed_add_del_output_interface_47d6e753")
 	api.RegisterMessage((*Nat44EdAddDelOutputInterfaceReply)(nil), "nat44_ed_add_del_output_interface_reply_e8d4e804")
+	api.RegisterMessage((*Nat44EdAddDelVrfRoute)(nil), "nat44_ed_add_del_vrf_route_59187407")
+	api.RegisterMessage((*Nat44EdAddDelVrfRouteReply)(nil), "nat44_ed_add_del_vrf_route_reply_e8d4e804")
+	api.RegisterMessage((*Nat44EdAddDelVrfTable)(nil), "nat44_ed_add_del_vrf_table_08330904")
+	api.RegisterMessage((*Nat44EdAddDelVrfTableReply)(nil), "nat44_ed_add_del_vrf_table_reply_e8d4e804")
 	api.RegisterMessage((*Nat44EdOutputInterfaceDetails)(nil), "nat44_ed_output_interface_details_0b45011c")
 	api.RegisterMessage((*Nat44EdOutputInterfaceGet)(nil), "nat44_ed_output_interface_get_f75ba505")
 	api.RegisterMessage((*Nat44EdOutputInterfaceGetReply)(nil), "nat44_ed_output_interface_get_reply_53b48f5d")
@@ -4446,30 +3939,22 @@ func file_nat44_ed_binapi_init() {
 	api.RegisterMessage((*Nat44EdSetFqOptionsReply)(nil), "nat44_ed_set_fq_options_reply_e8d4e804")
 	api.RegisterMessage((*Nat44EdShowFqOptions)(nil), "nat44_ed_show_fq_options_51077d14")
 	api.RegisterMessage((*Nat44EdShowFqOptionsReply)(nil), "nat44_ed_show_fq_options_reply_7213b545")
+	api.RegisterMessage((*Nat44EdVrfTablesDetails)(nil), "nat44_ed_vrf_tables_details_7b264e4f")
+	api.RegisterMessage((*Nat44EdVrfTablesDump)(nil), "nat44_ed_vrf_tables_dump_51077d14")
 	api.RegisterMessage((*Nat44ForwardingEnableDisable)(nil), "nat44_forwarding_enable_disable_b3e225d2")
 	api.RegisterMessage((*Nat44ForwardingEnableDisableReply)(nil), "nat44_forwarding_enable_disable_reply_e8d4e804")
-	api.RegisterMessage((*Nat44ForwardingIsEnabled)(nil), "nat44_forwarding_is_enabled_51077d14")
-	api.RegisterMessage((*Nat44ForwardingIsEnabledReply)(nil), "nat44_forwarding_is_enabled_reply_46924a06")
 	api.RegisterMessage((*Nat44IdentityMappingDetails)(nil), "nat44_identity_mapping_details_2a52a030")
 	api.RegisterMessage((*Nat44IdentityMappingDump)(nil), "nat44_identity_mapping_dump_51077d14")
 	api.RegisterMessage((*Nat44InterfaceAddDelFeature)(nil), "nat44_interface_add_del_feature_f3699b83")
 	api.RegisterMessage((*Nat44InterfaceAddDelFeatureReply)(nil), "nat44_interface_add_del_feature_reply_e8d4e804")
-	api.RegisterMessage((*Nat44InterfaceAddDelOutputFeature)(nil), "nat44_interface_add_del_output_feature_f3699b83")
-	api.RegisterMessage((*Nat44InterfaceAddDelOutputFeatureReply)(nil), "nat44_interface_add_del_output_feature_reply_e8d4e804")
 	api.RegisterMessage((*Nat44InterfaceAddrDetails)(nil), "nat44_interface_addr_details_e4aca9ca")
 	api.RegisterMessage((*Nat44InterfaceAddrDump)(nil), "nat44_interface_addr_dump_51077d14")
 	api.RegisterMessage((*Nat44InterfaceDetails)(nil), "nat44_interface_details_5d286289")
 	api.RegisterMessage((*Nat44InterfaceDump)(nil), "nat44_interface_dump_51077d14")
-	api.RegisterMessage((*Nat44InterfaceOutputFeatureDetails)(nil), "nat44_interface_output_feature_details_5d286289")
-	api.RegisterMessage((*Nat44InterfaceOutputFeatureDump)(nil), "nat44_interface_output_feature_dump_51077d14")
 	api.RegisterMessage((*Nat44LbStaticMappingAddDelLocal)(nil), "nat44_lb_static_mapping_add_del_local_7ca47547")
 	api.RegisterMessage((*Nat44LbStaticMappingAddDelLocalReply)(nil), "nat44_lb_static_mapping_add_del_local_reply_e8d4e804")
 	api.RegisterMessage((*Nat44LbStaticMappingDetails)(nil), "nat44_lb_static_mapping_details_ed5ce876")
 	api.RegisterMessage((*Nat44LbStaticMappingDump)(nil), "nat44_lb_static_mapping_dump_51077d14")
-	api.RegisterMessage((*Nat44PluginEnableDisable)(nil), "nat44_plugin_enable_disable_dea0d501")
-	api.RegisterMessage((*Nat44PluginEnableDisableReply)(nil), "nat44_plugin_enable_disable_reply_e8d4e804")
-	api.RegisterMessage((*Nat44SessionCleanup)(nil), "nat44_session_cleanup_51077d14")
-	api.RegisterMessage((*Nat44SessionCleanupReply)(nil), "nat44_session_cleanup_reply_e8d4e804")
 	api.RegisterMessage((*Nat44SetSessionLimit)(nil), "nat44_set_session_limit_8899bbb1")
 	api.RegisterMessage((*Nat44SetSessionLimitReply)(nil), "nat44_set_session_limit_reply_e8d4e804")
 	api.RegisterMessage((*Nat44ShowRunningConfig)(nil), "nat44_show_running_config_51077d14")
@@ -4482,14 +3967,12 @@ func file_nat44_ed_binapi_init() {
 	api.RegisterMessage((*Nat44UserSessionDump)(nil), "nat44_user_session_dump_e1899c98")
 	api.RegisterMessage((*Nat44UserSessionV2Details)(nil), "nat44_user_session_v2_details_fd42b729")
 	api.RegisterMessage((*Nat44UserSessionV2Dump)(nil), "nat44_user_session_v2_dump_e1899c98")
-	api.RegisterMessage((*NatControlPing)(nil), "nat_control_ping_51077d14")
-	api.RegisterMessage((*NatControlPingReply)(nil), "nat_control_ping_reply_f6b0b8ca")
+	api.RegisterMessage((*Nat44UserSessionV3Details)(nil), "nat44_user_session_v3_details_edae926e")
+	api.RegisterMessage((*Nat44UserSessionV3Dump)(nil), "nat44_user_session_v3_dump_e1899c98")
 	api.RegisterMessage((*NatGetAddrAndPortAllocAlg)(nil), "nat_get_addr_and_port_alloc_alg_51077d14")
 	api.RegisterMessage((*NatGetAddrAndPortAllocAlgReply)(nil), "nat_get_addr_and_port_alloc_alg_reply_3607a7d0")
 	api.RegisterMessage((*NatGetMssClamping)(nil), "nat_get_mss_clamping_51077d14")
 	api.RegisterMessage((*NatGetMssClampingReply)(nil), "nat_get_mss_clamping_reply_1c0b2a78")
-	api.RegisterMessage((*NatGetTimeouts)(nil), "nat_get_timeouts_51077d14")
-	api.RegisterMessage((*NatGetTimeoutsReply)(nil), "nat_get_timeouts_reply_3c4df4e1")
 	api.RegisterMessage((*NatHaFlush)(nil), "nat_ha_flush_51077d14")
 	api.RegisterMessage((*NatHaFlushReply)(nil), "nat_ha_flush_reply_e8d4e804")
 	api.RegisterMessage((*NatHaGetFailover)(nil), "nat_ha_get_failover_51077d14")
@@ -4507,18 +3990,12 @@ func file_nat44_ed_binapi_init() {
 	api.RegisterMessage((*NatIpfixEnableDisableReply)(nil), "nat_ipfix_enable_disable_reply_e8d4e804")
 	api.RegisterMessage((*NatSetAddrAndPortAllocAlg)(nil), "nat_set_addr_and_port_alloc_alg_deeb746f")
 	api.RegisterMessage((*NatSetAddrAndPortAllocAlgReply)(nil), "nat_set_addr_and_port_alloc_alg_reply_e8d4e804")
-	api.RegisterMessage((*NatSetLogLevel)(nil), "nat_set_log_level_70076bfe")
-	api.RegisterMessage((*NatSetLogLevelReply)(nil), "nat_set_log_level_reply_e8d4e804")
 	api.RegisterMessage((*NatSetMssClamping)(nil), "nat_set_mss_clamping_25e90abb")
 	api.RegisterMessage((*NatSetMssClampingReply)(nil), "nat_set_mss_clamping_reply_e8d4e804")
 	api.RegisterMessage((*NatSetTimeouts)(nil), "nat_set_timeouts_d4746b16")
 	api.RegisterMessage((*NatSetTimeoutsReply)(nil), "nat_set_timeouts_reply_e8d4e804")
 	api.RegisterMessage((*NatSetWorkers)(nil), "nat_set_workers_da926638")
 	api.RegisterMessage((*NatSetWorkersReply)(nil), "nat_set_workers_reply_e8d4e804")
-	api.RegisterMessage((*NatShowConfig)(nil), "nat_show_config_51077d14")
-	api.RegisterMessage((*NatShowConfig2)(nil), "nat_show_config_2_51077d14")
-	api.RegisterMessage((*NatShowConfig2Reply)(nil), "nat_show_config_2_reply_0404a5b4")
-	api.RegisterMessage((*NatShowConfigReply)(nil), "nat_show_config_reply_7903ef06")
 	api.RegisterMessage((*NatWorkerDetails)(nil), "nat_worker_details_84bf06fc")
 	api.RegisterMessage((*NatWorkerDump)(nil), "nat_worker_dump_51077d14")
 }
@@ -4546,6 +4023,10 @@ func AllMessages() []api.Message {
 		(*Nat44DelUserReply)(nil),
 		(*Nat44EdAddDelOutputInterface)(nil),
 		(*Nat44EdAddDelOutputInterfaceReply)(nil),
+		(*Nat44EdAddDelVrfRoute)(nil),
+		(*Nat44EdAddDelVrfRouteReply)(nil),
+		(*Nat44EdAddDelVrfTable)(nil),
+		(*Nat44EdAddDelVrfTableReply)(nil),
 		(*Nat44EdOutputInterfaceDetails)(nil),
 		(*Nat44EdOutputInterfaceGet)(nil),
 		(*Nat44EdOutputInterfaceGetReply)(nil),
@@ -4555,30 +4036,22 @@ func AllMessages() []api.Message {
 		(*Nat44EdSetFqOptionsReply)(nil),
 		(*Nat44EdShowFqOptions)(nil),
 		(*Nat44EdShowFqOptionsReply)(nil),
+		(*Nat44EdVrfTablesDetails)(nil),
+		(*Nat44EdVrfTablesDump)(nil),
 		(*Nat44ForwardingEnableDisable)(nil),
 		(*Nat44ForwardingEnableDisableReply)(nil),
-		(*Nat44ForwardingIsEnabled)(nil),
-		(*Nat44ForwardingIsEnabledReply)(nil),
 		(*Nat44IdentityMappingDetails)(nil),
 		(*Nat44IdentityMappingDump)(nil),
 		(*Nat44InterfaceAddDelFeature)(nil),
 		(*Nat44InterfaceAddDelFeatureReply)(nil),
-		(*Nat44InterfaceAddDelOutputFeature)(nil),
-		(*Nat44InterfaceAddDelOutputFeatureReply)(nil),
 		(*Nat44InterfaceAddrDetails)(nil),
 		(*Nat44InterfaceAddrDump)(nil),
 		(*Nat44InterfaceDetails)(nil),
 		(*Nat44InterfaceDump)(nil),
-		(*Nat44InterfaceOutputFeatureDetails)(nil),
-		(*Nat44InterfaceOutputFeatureDump)(nil),
 		(*Nat44LbStaticMappingAddDelLocal)(nil),
 		(*Nat44LbStaticMappingAddDelLocalReply)(nil),
 		(*Nat44LbStaticMappingDetails)(nil),
 		(*Nat44LbStaticMappingDump)(nil),
-		(*Nat44PluginEnableDisable)(nil),
-		(*Nat44PluginEnableDisableReply)(nil),
-		(*Nat44SessionCleanup)(nil),
-		(*Nat44SessionCleanupReply)(nil),
 		(*Nat44SetSessionLimit)(nil),
 		(*Nat44SetSessionLimitReply)(nil),
 		(*Nat44ShowRunningConfig)(nil),
@@ -4591,14 +4064,12 @@ func AllMessages() []api.Message {
 		(*Nat44UserSessionDump)(nil),
 		(*Nat44UserSessionV2Details)(nil),
 		(*Nat44UserSessionV2Dump)(nil),
-		(*NatControlPing)(nil),
-		(*NatControlPingReply)(nil),
+		(*Nat44UserSessionV3Details)(nil),
+		(*Nat44UserSessionV3Dump)(nil),
 		(*NatGetAddrAndPortAllocAlg)(nil),
 		(*NatGetAddrAndPortAllocAlgReply)(nil),
 		(*NatGetMssClamping)(nil),
 		(*NatGetMssClampingReply)(nil),
-		(*NatGetTimeouts)(nil),
-		(*NatGetTimeoutsReply)(nil),
 		(*NatHaFlush)(nil),
 		(*NatHaFlushReply)(nil),
 		(*NatHaGetFailover)(nil),
@@ -4616,18 +4087,12 @@ func AllMessages() []api.Message {
 		(*NatIpfixEnableDisableReply)(nil),
 		(*NatSetAddrAndPortAllocAlg)(nil),
 		(*NatSetAddrAndPortAllocAlgReply)(nil),
-		(*NatSetLogLevel)(nil),
-		(*NatSetLogLevelReply)(nil),
 		(*NatSetMssClamping)(nil),
 		(*NatSetMssClampingReply)(nil),
 		(*NatSetTimeouts)(nil),
 		(*NatSetTimeoutsReply)(nil),
 		(*NatSetWorkers)(nil),
 		(*NatSetWorkersReply)(nil),
-		(*NatShowConfig)(nil),
-		(*NatShowConfig2)(nil),
-		(*NatShowConfig2Reply)(nil),
-		(*NatShowConfigReply)(nil),
 		(*NatWorkerDetails)(nil),
 		(*NatWorkerDump)(nil),
 	}

--- a/vpplink/binapi/vppapi/nat44_ed/nat44_ed_rpc.ba.go
+++ b/vpplink/binapi/vppapi/nat44_ed/nat44_ed_rpc.ba.go
@@ -23,32 +23,29 @@ type RPCService interface {
 	Nat44DelSession(ctx context.Context, in *Nat44DelSession) (*Nat44DelSessionReply, error)
 	Nat44DelUser(ctx context.Context, in *Nat44DelUser) (*Nat44DelUserReply, error)
 	Nat44EdAddDelOutputInterface(ctx context.Context, in *Nat44EdAddDelOutputInterface) (*Nat44EdAddDelOutputInterfaceReply, error)
+	Nat44EdAddDelVrfRoute(ctx context.Context, in *Nat44EdAddDelVrfRoute) (*Nat44EdAddDelVrfRouteReply, error)
+	Nat44EdAddDelVrfTable(ctx context.Context, in *Nat44EdAddDelVrfTable) (*Nat44EdAddDelVrfTableReply, error)
 	Nat44EdOutputInterfaceGet(ctx context.Context, in *Nat44EdOutputInterfaceGet) (RPCService_Nat44EdOutputInterfaceGetClient, error)
 	Nat44EdPluginEnableDisable(ctx context.Context, in *Nat44EdPluginEnableDisable) (*Nat44EdPluginEnableDisableReply, error)
 	Nat44EdSetFqOptions(ctx context.Context, in *Nat44EdSetFqOptions) (*Nat44EdSetFqOptionsReply, error)
 	Nat44EdShowFqOptions(ctx context.Context, in *Nat44EdShowFqOptions) (*Nat44EdShowFqOptionsReply, error)
+	Nat44EdVrfTablesDump(ctx context.Context, in *Nat44EdVrfTablesDump) (RPCService_Nat44EdVrfTablesDumpClient, error)
 	Nat44ForwardingEnableDisable(ctx context.Context, in *Nat44ForwardingEnableDisable) (*Nat44ForwardingEnableDisableReply, error)
-	Nat44ForwardingIsEnabled(ctx context.Context, in *Nat44ForwardingIsEnabled) (*Nat44ForwardingIsEnabledReply, error)
 	Nat44IdentityMappingDump(ctx context.Context, in *Nat44IdentityMappingDump) (RPCService_Nat44IdentityMappingDumpClient, error)
 	Nat44InterfaceAddDelFeature(ctx context.Context, in *Nat44InterfaceAddDelFeature) (*Nat44InterfaceAddDelFeatureReply, error)
-	Nat44InterfaceAddDelOutputFeature(ctx context.Context, in *Nat44InterfaceAddDelOutputFeature) (*Nat44InterfaceAddDelOutputFeatureReply, error)
 	Nat44InterfaceAddrDump(ctx context.Context, in *Nat44InterfaceAddrDump) (RPCService_Nat44InterfaceAddrDumpClient, error)
 	Nat44InterfaceDump(ctx context.Context, in *Nat44InterfaceDump) (RPCService_Nat44InterfaceDumpClient, error)
-	Nat44InterfaceOutputFeatureDump(ctx context.Context, in *Nat44InterfaceOutputFeatureDump) (RPCService_Nat44InterfaceOutputFeatureDumpClient, error)
 	Nat44LbStaticMappingAddDelLocal(ctx context.Context, in *Nat44LbStaticMappingAddDelLocal) (*Nat44LbStaticMappingAddDelLocalReply, error)
 	Nat44LbStaticMappingDump(ctx context.Context, in *Nat44LbStaticMappingDump) (RPCService_Nat44LbStaticMappingDumpClient, error)
-	Nat44PluginEnableDisable(ctx context.Context, in *Nat44PluginEnableDisable) (*Nat44PluginEnableDisableReply, error)
-	Nat44SessionCleanup(ctx context.Context, in *Nat44SessionCleanup) (*Nat44SessionCleanupReply, error)
 	Nat44SetSessionLimit(ctx context.Context, in *Nat44SetSessionLimit) (*Nat44SetSessionLimitReply, error)
 	Nat44ShowRunningConfig(ctx context.Context, in *Nat44ShowRunningConfig) (*Nat44ShowRunningConfigReply, error)
 	Nat44StaticMappingDump(ctx context.Context, in *Nat44StaticMappingDump) (RPCService_Nat44StaticMappingDumpClient, error)
 	Nat44UserDump(ctx context.Context, in *Nat44UserDump) (RPCService_Nat44UserDumpClient, error)
 	Nat44UserSessionDump(ctx context.Context, in *Nat44UserSessionDump) (RPCService_Nat44UserSessionDumpClient, error)
 	Nat44UserSessionV2Dump(ctx context.Context, in *Nat44UserSessionV2Dump) (RPCService_Nat44UserSessionV2DumpClient, error)
-	NatControlPing(ctx context.Context, in *NatControlPing) (*NatControlPingReply, error)
+	Nat44UserSessionV3Dump(ctx context.Context, in *Nat44UserSessionV3Dump) (RPCService_Nat44UserSessionV3DumpClient, error)
 	NatGetAddrAndPortAllocAlg(ctx context.Context, in *NatGetAddrAndPortAllocAlg) (*NatGetAddrAndPortAllocAlgReply, error)
 	NatGetMssClamping(ctx context.Context, in *NatGetMssClamping) (*NatGetMssClampingReply, error)
-	NatGetTimeouts(ctx context.Context, in *NatGetTimeouts) (*NatGetTimeoutsReply, error)
 	NatHaFlush(ctx context.Context, in *NatHaFlush) (*NatHaFlushReply, error)
 	NatHaGetFailover(ctx context.Context, in *NatHaGetFailover) (*NatHaGetFailoverReply, error)
 	NatHaGetListener(ctx context.Context, in *NatHaGetListener) (*NatHaGetListenerReply, error)
@@ -57,12 +54,9 @@ type RPCService interface {
 	NatHaSetListener(ctx context.Context, in *NatHaSetListener) (*NatHaSetListenerReply, error)
 	NatIpfixEnableDisable(ctx context.Context, in *NatIpfixEnableDisable) (*NatIpfixEnableDisableReply, error)
 	NatSetAddrAndPortAllocAlg(ctx context.Context, in *NatSetAddrAndPortAllocAlg) (*NatSetAddrAndPortAllocAlgReply, error)
-	NatSetLogLevel(ctx context.Context, in *NatSetLogLevel) (*NatSetLogLevelReply, error)
 	NatSetMssClamping(ctx context.Context, in *NatSetMssClamping) (*NatSetMssClampingReply, error)
 	NatSetTimeouts(ctx context.Context, in *NatSetTimeouts) (*NatSetTimeoutsReply, error)
 	NatSetWorkers(ctx context.Context, in *NatSetWorkers) (*NatSetWorkersReply, error)
-	NatShowConfig(ctx context.Context, in *NatShowConfig) (*NatShowConfigReply, error)
-	NatShowConfig2(ctx context.Context, in *NatShowConfig2) (*NatShowConfig2Reply, error)
 	NatWorkerDump(ctx context.Context, in *NatWorkerDump) (RPCService_NatWorkerDumpClient, error)
 }
 
@@ -198,6 +192,24 @@ func (c *serviceClient) Nat44EdAddDelOutputInterface(ctx context.Context, in *Na
 	return out, api.RetvalToVPPApiError(out.Retval)
 }
 
+func (c *serviceClient) Nat44EdAddDelVrfRoute(ctx context.Context, in *Nat44EdAddDelVrfRoute) (*Nat44EdAddDelVrfRouteReply, error) {
+	out := new(Nat44EdAddDelVrfRouteReply)
+	err := c.conn.Invoke(ctx, in, out)
+	if err != nil {
+		return nil, err
+	}
+	return out, api.RetvalToVPPApiError(out.Retval)
+}
+
+func (c *serviceClient) Nat44EdAddDelVrfTable(ctx context.Context, in *Nat44EdAddDelVrfTable) (*Nat44EdAddDelVrfTableReply, error) {
+	out := new(Nat44EdAddDelVrfTableReply)
+	err := c.conn.Invoke(ctx, in, out)
+	if err != nil {
+		return nil, err
+	}
+	return out, api.RetvalToVPPApiError(out.Retval)
+}
+
 func (c *serviceClient) Nat44EdOutputInterfaceGet(ctx context.Context, in *Nat44EdOutputInterfaceGet) (RPCService_Nat44EdOutputInterfaceGetClient, error) {
 	stream, err := c.conn.NewStream(ctx)
 	if err != nil {
@@ -265,6 +277,49 @@ func (c *serviceClient) Nat44EdShowFqOptions(ctx context.Context, in *Nat44EdSho
 	return out, api.RetvalToVPPApiError(out.Retval)
 }
 
+func (c *serviceClient) Nat44EdVrfTablesDump(ctx context.Context, in *Nat44EdVrfTablesDump) (RPCService_Nat44EdVrfTablesDumpClient, error) {
+	stream, err := c.conn.NewStream(ctx)
+	if err != nil {
+		return nil, err
+	}
+	x := &serviceClient_Nat44EdVrfTablesDumpClient{stream}
+	if err := x.Stream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err = x.Stream.SendMsg(&memclnt.ControlPing{}); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+type RPCService_Nat44EdVrfTablesDumpClient interface {
+	Recv() (*Nat44EdVrfTablesDetails, error)
+	api.Stream
+}
+
+type serviceClient_Nat44EdVrfTablesDumpClient struct {
+	api.Stream
+}
+
+func (c *serviceClient_Nat44EdVrfTablesDumpClient) Recv() (*Nat44EdVrfTablesDetails, error) {
+	msg, err := c.Stream.RecvMsg()
+	if err != nil {
+		return nil, err
+	}
+	switch m := msg.(type) {
+	case *Nat44EdVrfTablesDetails:
+		return m, nil
+	case *memclnt.ControlPingReply:
+		err = c.Stream.Close()
+		if err != nil {
+			return nil, err
+		}
+		return nil, io.EOF
+	default:
+		return nil, fmt.Errorf("unexpected message: %T %v", m, m)
+	}
+}
+
 func (c *serviceClient) Nat44ForwardingEnableDisable(ctx context.Context, in *Nat44ForwardingEnableDisable) (*Nat44ForwardingEnableDisableReply, error) {
 	out := new(Nat44ForwardingEnableDisableReply)
 	err := c.conn.Invoke(ctx, in, out)
@@ -272,15 +327,6 @@ func (c *serviceClient) Nat44ForwardingEnableDisable(ctx context.Context, in *Na
 		return nil, err
 	}
 	return out, api.RetvalToVPPApiError(out.Retval)
-}
-
-func (c *serviceClient) Nat44ForwardingIsEnabled(ctx context.Context, in *Nat44ForwardingIsEnabled) (*Nat44ForwardingIsEnabledReply, error) {
-	out := new(Nat44ForwardingIsEnabledReply)
-	err := c.conn.Invoke(ctx, in, out)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
 }
 
 func (c *serviceClient) Nat44IdentityMappingDump(ctx context.Context, in *Nat44IdentityMappingDump) (RPCService_Nat44IdentityMappingDumpClient, error) {
@@ -328,15 +374,6 @@ func (c *serviceClient_Nat44IdentityMappingDumpClient) Recv() (*Nat44IdentityMap
 
 func (c *serviceClient) Nat44InterfaceAddDelFeature(ctx context.Context, in *Nat44InterfaceAddDelFeature) (*Nat44InterfaceAddDelFeatureReply, error) {
 	out := new(Nat44InterfaceAddDelFeatureReply)
-	err := c.conn.Invoke(ctx, in, out)
-	if err != nil {
-		return nil, err
-	}
-	return out, api.RetvalToVPPApiError(out.Retval)
-}
-
-func (c *serviceClient) Nat44InterfaceAddDelOutputFeature(ctx context.Context, in *Nat44InterfaceAddDelOutputFeature) (*Nat44InterfaceAddDelOutputFeatureReply, error) {
-	out := new(Nat44InterfaceAddDelOutputFeatureReply)
 	err := c.conn.Invoke(ctx, in, out)
 	if err != nil {
 		return nil, err
@@ -430,49 +467,6 @@ func (c *serviceClient_Nat44InterfaceDumpClient) Recv() (*Nat44InterfaceDetails,
 	}
 }
 
-func (c *serviceClient) Nat44InterfaceOutputFeatureDump(ctx context.Context, in *Nat44InterfaceOutputFeatureDump) (RPCService_Nat44InterfaceOutputFeatureDumpClient, error) {
-	stream, err := c.conn.NewStream(ctx)
-	if err != nil {
-		return nil, err
-	}
-	x := &serviceClient_Nat44InterfaceOutputFeatureDumpClient{stream}
-	if err := x.Stream.SendMsg(in); err != nil {
-		return nil, err
-	}
-	if err = x.Stream.SendMsg(&memclnt.ControlPing{}); err != nil {
-		return nil, err
-	}
-	return x, nil
-}
-
-type RPCService_Nat44InterfaceOutputFeatureDumpClient interface {
-	Recv() (*Nat44InterfaceOutputFeatureDetails, error)
-	api.Stream
-}
-
-type serviceClient_Nat44InterfaceOutputFeatureDumpClient struct {
-	api.Stream
-}
-
-func (c *serviceClient_Nat44InterfaceOutputFeatureDumpClient) Recv() (*Nat44InterfaceOutputFeatureDetails, error) {
-	msg, err := c.Stream.RecvMsg()
-	if err != nil {
-		return nil, err
-	}
-	switch m := msg.(type) {
-	case *Nat44InterfaceOutputFeatureDetails:
-		return m, nil
-	case *memclnt.ControlPingReply:
-		err = c.Stream.Close()
-		if err != nil {
-			return nil, err
-		}
-		return nil, io.EOF
-	default:
-		return nil, fmt.Errorf("unexpected message: %T %v", m, m)
-	}
-}
-
 func (c *serviceClient) Nat44LbStaticMappingAddDelLocal(ctx context.Context, in *Nat44LbStaticMappingAddDelLocal) (*Nat44LbStaticMappingAddDelLocalReply, error) {
 	out := new(Nat44LbStaticMappingAddDelLocalReply)
 	err := c.conn.Invoke(ctx, in, out)
@@ -523,24 +517,6 @@ func (c *serviceClient_Nat44LbStaticMappingDumpClient) Recv() (*Nat44LbStaticMap
 	default:
 		return nil, fmt.Errorf("unexpected message: %T %v", m, m)
 	}
-}
-
-func (c *serviceClient) Nat44PluginEnableDisable(ctx context.Context, in *Nat44PluginEnableDisable) (*Nat44PluginEnableDisableReply, error) {
-	out := new(Nat44PluginEnableDisableReply)
-	err := c.conn.Invoke(ctx, in, out)
-	if err != nil {
-		return nil, err
-	}
-	return out, api.RetvalToVPPApiError(out.Retval)
-}
-
-func (c *serviceClient) Nat44SessionCleanup(ctx context.Context, in *Nat44SessionCleanup) (*Nat44SessionCleanupReply, error) {
-	out := new(Nat44SessionCleanupReply)
-	err := c.conn.Invoke(ctx, in, out)
-	if err != nil {
-		return nil, err
-	}
-	return out, api.RetvalToVPPApiError(out.Retval)
 }
 
 func (c *serviceClient) Nat44SetSessionLimit(ctx context.Context, in *Nat44SetSessionLimit) (*Nat44SetSessionLimitReply, error) {
@@ -733,13 +709,47 @@ func (c *serviceClient_Nat44UserSessionV2DumpClient) Recv() (*Nat44UserSessionV2
 	}
 }
 
-func (c *serviceClient) NatControlPing(ctx context.Context, in *NatControlPing) (*NatControlPingReply, error) {
-	out := new(NatControlPingReply)
-	err := c.conn.Invoke(ctx, in, out)
+func (c *serviceClient) Nat44UserSessionV3Dump(ctx context.Context, in *Nat44UserSessionV3Dump) (RPCService_Nat44UserSessionV3DumpClient, error) {
+	stream, err := c.conn.NewStream(ctx)
 	if err != nil {
 		return nil, err
 	}
-	return out, api.RetvalToVPPApiError(out.Retval)
+	x := &serviceClient_Nat44UserSessionV3DumpClient{stream}
+	if err := x.Stream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err = x.Stream.SendMsg(&memclnt.ControlPing{}); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+type RPCService_Nat44UserSessionV3DumpClient interface {
+	Recv() (*Nat44UserSessionV3Details, error)
+	api.Stream
+}
+
+type serviceClient_Nat44UserSessionV3DumpClient struct {
+	api.Stream
+}
+
+func (c *serviceClient_Nat44UserSessionV3DumpClient) Recv() (*Nat44UserSessionV3Details, error) {
+	msg, err := c.Stream.RecvMsg()
+	if err != nil {
+		return nil, err
+	}
+	switch m := msg.(type) {
+	case *Nat44UserSessionV3Details:
+		return m, nil
+	case *memclnt.ControlPingReply:
+		err = c.Stream.Close()
+		if err != nil {
+			return nil, err
+		}
+		return nil, io.EOF
+	default:
+		return nil, fmt.Errorf("unexpected message: %T %v", m, m)
+	}
 }
 
 func (c *serviceClient) NatGetAddrAndPortAllocAlg(ctx context.Context, in *NatGetAddrAndPortAllocAlg) (*NatGetAddrAndPortAllocAlgReply, error) {
@@ -753,15 +763,6 @@ func (c *serviceClient) NatGetAddrAndPortAllocAlg(ctx context.Context, in *NatGe
 
 func (c *serviceClient) NatGetMssClamping(ctx context.Context, in *NatGetMssClamping) (*NatGetMssClampingReply, error) {
 	out := new(NatGetMssClampingReply)
-	err := c.conn.Invoke(ctx, in, out)
-	if err != nil {
-		return nil, err
-	}
-	return out, api.RetvalToVPPApiError(out.Retval)
-}
-
-func (c *serviceClient) NatGetTimeouts(ctx context.Context, in *NatGetTimeouts) (*NatGetTimeoutsReply, error) {
-	out := new(NatGetTimeoutsReply)
 	err := c.conn.Invoke(ctx, in, out)
 	if err != nil {
 		return nil, err
@@ -841,15 +842,6 @@ func (c *serviceClient) NatSetAddrAndPortAllocAlg(ctx context.Context, in *NatSe
 	return out, api.RetvalToVPPApiError(out.Retval)
 }
 
-func (c *serviceClient) NatSetLogLevel(ctx context.Context, in *NatSetLogLevel) (*NatSetLogLevelReply, error) {
-	out := new(NatSetLogLevelReply)
-	err := c.conn.Invoke(ctx, in, out)
-	if err != nil {
-		return nil, err
-	}
-	return out, api.RetvalToVPPApiError(out.Retval)
-}
-
 func (c *serviceClient) NatSetMssClamping(ctx context.Context, in *NatSetMssClamping) (*NatSetMssClampingReply, error) {
 	out := new(NatSetMssClampingReply)
 	err := c.conn.Invoke(ctx, in, out)
@@ -870,24 +862,6 @@ func (c *serviceClient) NatSetTimeouts(ctx context.Context, in *NatSetTimeouts) 
 
 func (c *serviceClient) NatSetWorkers(ctx context.Context, in *NatSetWorkers) (*NatSetWorkersReply, error) {
 	out := new(NatSetWorkersReply)
-	err := c.conn.Invoke(ctx, in, out)
-	if err != nil {
-		return nil, err
-	}
-	return out, api.RetvalToVPPApiError(out.Retval)
-}
-
-func (c *serviceClient) NatShowConfig(ctx context.Context, in *NatShowConfig) (*NatShowConfigReply, error) {
-	out := new(NatShowConfigReply)
-	err := c.conn.Invoke(ctx, in, out)
-	if err != nil {
-		return nil, err
-	}
-	return out, api.RetvalToVPPApiError(out.Retval)
-}
-
-func (c *serviceClient) NatShowConfig2(ctx context.Context, in *NatShowConfig2) (*NatShowConfig2Reply, error) {
-	out := new(NatShowConfig2Reply)
 	err := c.conn.Invoke(ctx, in, out)
 	if err != nil {
 		return nil, err

--- a/vpplink/binapi/vppapi/punt/punt.ba.go
+++ b/vpplink/binapi/vppapi/punt/punt.ba.go
@@ -27,28 +27,28 @@ const _ = api.GoVppAPIPackageIsVersion2
 const (
 	APIFile    = "punt"
 	APIVersion = "2.2.1"
-	VersionCrc = 0xee63b6c7
+	VersionCrc = 0x24d11934
 )
 
 // PuntType defines enum 'punt_type'.
 type PuntType uint32
 
 const (
-	PUNT_API_TYPE_L4        PuntType = 1
-	PUNT_API_TYPE_IP_PROTO  PuntType = 2
-	PUNT_API_TYPE_EXCEPTION PuntType = 3
+	PUNT_API_TYPE_L4        PuntType = 0
+	PUNT_API_TYPE_IP_PROTO  PuntType = 1
+	PUNT_API_TYPE_EXCEPTION PuntType = 2
 )
 
 var (
 	PuntType_name = map[uint32]string{
-		1: "PUNT_API_TYPE_L4",
-		2: "PUNT_API_TYPE_IP_PROTO",
-		3: "PUNT_API_TYPE_EXCEPTION",
+		0: "PUNT_API_TYPE_L4",
+		1: "PUNT_API_TYPE_IP_PROTO",
+		2: "PUNT_API_TYPE_EXCEPTION",
 	}
 	PuntType_value = map[string]uint32{
-		"PUNT_API_TYPE_L4":        1,
-		"PUNT_API_TYPE_IP_PROTO":  2,
-		"PUNT_API_TYPE_EXCEPTION": 3,
+		"PUNT_API_TYPE_L4":        0,
+		"PUNT_API_TYPE_IP_PROTO":  1,
+		"PUNT_API_TYPE_EXCEPTION": 2,
 	}
 )
 
@@ -226,7 +226,7 @@ type PuntSocketDeregister struct {
 
 func (m *PuntSocketDeregister) Reset()               { *m = PuntSocketDeregister{} }
 func (*PuntSocketDeregister) GetMessageName() string { return "punt_socket_deregister" }
-func (*PuntSocketDeregister) GetCrcString() string   { return "98fc9102" }
+func (*PuntSocketDeregister) GetCrcString() string   { return "75afa766" }
 func (*PuntSocketDeregister) GetMessageType() api.MessageType {
 	return api.RequestMessage
 }
@@ -296,7 +296,7 @@ type PuntSocketDetails struct {
 
 func (m *PuntSocketDetails) Reset()               { *m = PuntSocketDetails{} }
 func (*PuntSocketDetails) GetMessageName() string { return "punt_socket_details" }
-func (*PuntSocketDetails) GetCrcString() string   { return "de575080" }
+func (*PuntSocketDetails) GetCrcString() string   { return "330466e4" }
 func (*PuntSocketDetails) GetMessageType() api.MessageType {
 	return api.ReplyMessage
 }
@@ -335,7 +335,7 @@ type PuntSocketDump struct {
 
 func (m *PuntSocketDump) Reset()               { *m = PuntSocketDump{} }
 func (*PuntSocketDump) GetMessageName() string { return "punt_socket_dump" }
-func (*PuntSocketDump) GetCrcString() string   { return "52974935" }
+func (*PuntSocketDump) GetCrcString() string   { return "916fb004" }
 func (*PuntSocketDump) GetMessageType() api.MessageType {
 	return api.RequestMessage
 }
@@ -370,7 +370,7 @@ type PuntSocketRegister struct {
 
 func (m *PuntSocketRegister) Reset()               { *m = PuntSocketRegister{} }
 func (*PuntSocketRegister) GetMessageName() string { return "punt_socket_register" }
-func (*PuntSocketRegister) GetCrcString() string   { return "95268cbf" }
+func (*PuntSocketRegister) GetCrcString() string   { return "7875badb" }
 func (*PuntSocketRegister) GetMessageType() api.MessageType {
 	return api.RequestMessage
 }
@@ -450,7 +450,7 @@ type SetPunt struct {
 
 func (m *SetPunt) Reset()               { *m = SetPunt{} }
 func (*SetPunt) GetMessageName() string { return "set_punt" }
-func (*SetPunt) GetCrcString() string   { return "aa83d523" }
+func (*SetPunt) GetCrcString() string   { return "47d0e347" }
 func (*SetPunt) GetMessageType() api.MessageType {
 	return api.RequestMessage
 }
@@ -519,13 +519,13 @@ func init() { file_punt_binapi_init() }
 func file_punt_binapi_init() {
 	api.RegisterMessage((*PuntReasonDetails)(nil), "punt_reason_details_2c9d4a40")
 	api.RegisterMessage((*PuntReasonDump)(nil), "punt_reason_dump_5c0dd4fe")
-	api.RegisterMessage((*PuntSocketDeregister)(nil), "punt_socket_deregister_98fc9102")
+	api.RegisterMessage((*PuntSocketDeregister)(nil), "punt_socket_deregister_75afa766")
 	api.RegisterMessage((*PuntSocketDeregisterReply)(nil), "punt_socket_deregister_reply_e8d4e804")
-	api.RegisterMessage((*PuntSocketDetails)(nil), "punt_socket_details_de575080")
-	api.RegisterMessage((*PuntSocketDump)(nil), "punt_socket_dump_52974935")
-	api.RegisterMessage((*PuntSocketRegister)(nil), "punt_socket_register_95268cbf")
+	api.RegisterMessage((*PuntSocketDetails)(nil), "punt_socket_details_330466e4")
+	api.RegisterMessage((*PuntSocketDump)(nil), "punt_socket_dump_916fb004")
+	api.RegisterMessage((*PuntSocketRegister)(nil), "punt_socket_register_7875badb")
 	api.RegisterMessage((*PuntSocketRegisterReply)(nil), "punt_socket_register_reply_bd30ae90")
-	api.RegisterMessage((*SetPunt)(nil), "set_punt_aa83d523")
+	api.RegisterMessage((*SetPunt)(nil), "set_punt_47d0e347")
 	api.RegisterMessage((*SetPuntReply)(nil), "set_punt_reply_e8d4e804")
 }
 

--- a/vpplink/binapi/vppapi/session/session.ba.go
+++ b/vpplink/binapi/vppapi/session/session.ba.go
@@ -26,7 +26,7 @@ const _ = api.GoVppAPIPackageIsVersion2
 const (
 	APIFile    = "session"
 	APIVersion = "4.0.0"
-	VersionCrc = 0x44a59e26
+	VersionCrc = 0x72bfc653
 )
 
 // SessionRuleScope defines enum 'session_rule_scope'.
@@ -63,27 +63,27 @@ func (x SessionRuleScope) String() string {
 type TransportProto uint8
 
 const (
-	TRANSPORT_PROTO_API_TCP  TransportProto = 1
-	TRANSPORT_PROTO_API_UDP  TransportProto = 2
-	TRANSPORT_PROTO_API_NONE TransportProto = 3
-	TRANSPORT_PROTO_API_TLS  TransportProto = 4
-	TRANSPORT_PROTO_API_QUIC TransportProto = 5
+	TRANSPORT_PROTO_API_TCP  TransportProto = 0
+	TRANSPORT_PROTO_API_UDP  TransportProto = 1
+	TRANSPORT_PROTO_API_NONE TransportProto = 2
+	TRANSPORT_PROTO_API_TLS  TransportProto = 3
+	TRANSPORT_PROTO_API_QUIC TransportProto = 4
 )
 
 var (
 	TransportProto_name = map[uint8]string{
-		1: "TRANSPORT_PROTO_API_TCP",
-		2: "TRANSPORT_PROTO_API_UDP",
-		3: "TRANSPORT_PROTO_API_NONE",
-		4: "TRANSPORT_PROTO_API_TLS",
-		5: "TRANSPORT_PROTO_API_QUIC",
+		0: "TRANSPORT_PROTO_API_TCP",
+		1: "TRANSPORT_PROTO_API_UDP",
+		2: "TRANSPORT_PROTO_API_NONE",
+		3: "TRANSPORT_PROTO_API_TLS",
+		4: "TRANSPORT_PROTO_API_QUIC",
 	}
 	TransportProto_value = map[string]uint8{
-		"TRANSPORT_PROTO_API_TCP":  1,
-		"TRANSPORT_PROTO_API_UDP":  2,
-		"TRANSPORT_PROTO_API_NONE": 3,
-		"TRANSPORT_PROTO_API_TLS":  4,
-		"TRANSPORT_PROTO_API_QUIC": 5,
+		"TRANSPORT_PROTO_API_TCP":  0,
+		"TRANSPORT_PROTO_API_UDP":  1,
+		"TRANSPORT_PROTO_API_NONE": 2,
+		"TRANSPORT_PROTO_API_TLS":  3,
+		"TRANSPORT_PROTO_API_QUIC": 4,
 	}
 )
 
@@ -1029,7 +1029,7 @@ type SessionRuleAddDel struct {
 
 func (m *SessionRuleAddDel) Reset()               { *m = SessionRuleAddDel{} }
 func (*SessionRuleAddDel) GetMessageName() string { return "session_rule_add_del" }
-func (*SessionRuleAddDel) GetCrcString() string   { return "e4895422" }
+func (*SessionRuleAddDel) GetCrcString() string   { return "82a90af5" }
 func (*SessionRuleAddDel) GetMessageType() api.MessageType {
 	return api.RequestMessage
 }
@@ -1142,7 +1142,7 @@ type SessionRulesDetails struct {
 
 func (m *SessionRulesDetails) Reset()               { *m = SessionRulesDetails{} }
 func (*SessionRulesDetails) GetMessageName() string { return "session_rules_details" }
-func (*SessionRulesDetails) GetCrcString() string   { return "28d71830" }
+func (*SessionRulesDetails) GetCrcString() string   { return "4ef746e7" }
 func (*SessionRulesDetails) GetMessageType() api.MessageType {
 	return api.ReplyMessage
 }
@@ -1323,9 +1323,9 @@ func file_session_binapi_init() {
 	api.RegisterMessage((*ApplicationTLSKeyAddReply)(nil), "application_tls_key_add_reply_e8d4e804")
 	api.RegisterMessage((*SessionEnableDisable)(nil), "session_enable_disable_c264d7bf")
 	api.RegisterMessage((*SessionEnableDisableReply)(nil), "session_enable_disable_reply_e8d4e804")
-	api.RegisterMessage((*SessionRuleAddDel)(nil), "session_rule_add_del_e4895422")
+	api.RegisterMessage((*SessionRuleAddDel)(nil), "session_rule_add_del_82a90af5")
 	api.RegisterMessage((*SessionRuleAddDelReply)(nil), "session_rule_add_del_reply_e8d4e804")
-	api.RegisterMessage((*SessionRulesDetails)(nil), "session_rules_details_28d71830")
+	api.RegisterMessage((*SessionRulesDetails)(nil), "session_rules_details_4ef746e7")
 	api.RegisterMessage((*SessionRulesDump)(nil), "session_rules_dump_51077d14")
 	api.RegisterMessage((*SessionSapiEnableDisable)(nil), "session_sapi_enable_disable_c264d7bf")
 	api.RegisterMessage((*SessionSapiEnableDisableReply)(nil), "session_sapi_enable_disable_reply_e8d4e804")

--- a/vpplink/binapi/vppapi/sr/sr.ba.go
+++ b/vpplink/binapi/vppapi/sr/sr.ba.go
@@ -5,7 +5,7 @@
 // Contents:
 //
 //	 2 structs
-//	22 messages
+//	24 messages
 package sr
 
 import (
@@ -25,7 +25,7 @@ const _ = api.GoVppAPIPackageIsVersion2
 const (
 	APIFile    = "sr"
 	APIVersion = "2.0.0"
-	VersionCrc = 0xb17a64be
+	VersionCrc = 0x66d92d1b
 )
 
 // Srv6SidList defines type 'srv6_sid_list'.
@@ -224,6 +224,115 @@ func (m *SrLocalsidsDump) Marshal(b []byte) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 func (m *SrLocalsidsDump) Unmarshal(b []byte) error {
+	return nil
+}
+
+// SrLocalsidsWithPacketStatsDetails defines message 'sr_localsids_with_packet_stats_details'.
+// InProgress: the message form may change in the future versions
+type SrLocalsidsWithPacketStatsDetails struct {
+	Addr                    ip_types.IP6Address `binapi:"ip6_address,name=addr" json:"addr,omitempty"`
+	EndPsp                  bool                `binapi:"bool,name=end_psp" json:"end_psp,omitempty"`
+	Behavior                sr_types.SrBehavior `binapi:"sr_behavior,name=behavior" json:"behavior,omitempty"`
+	FibTable                uint32              `binapi:"u32,name=fib_table" json:"fib_table,omitempty"`
+	VlanIndex               uint32              `binapi:"u32,name=vlan_index" json:"vlan_index,omitempty"`
+	XconnectNhAddr          ip_types.Address    `binapi:"address,name=xconnect_nh_addr" json:"xconnect_nh_addr,omitempty"`
+	XconnectIfaceOrVrfTable uint32              `binapi:"u32,name=xconnect_iface_or_vrf_table" json:"xconnect_iface_or_vrf_table,omitempty"`
+	GoodTrafficBytes        uint64              `binapi:"u64,name=good_traffic_bytes" json:"good_traffic_bytes,omitempty"`
+	GoodTrafficPktCount     uint64              `binapi:"u64,name=good_traffic_pkt_count" json:"good_traffic_pkt_count,omitempty"`
+	BadTrafficBytes         uint64              `binapi:"u64,name=bad_traffic_bytes" json:"bad_traffic_bytes,omitempty"`
+	BadTrafficPktCount      uint64              `binapi:"u64,name=bad_traffic_pkt_count" json:"bad_traffic_pkt_count,omitempty"`
+}
+
+func (m *SrLocalsidsWithPacketStatsDetails) Reset() { *m = SrLocalsidsWithPacketStatsDetails{} }
+func (*SrLocalsidsWithPacketStatsDetails) GetMessageName() string {
+	return "sr_localsids_with_packet_stats_details"
+}
+func (*SrLocalsidsWithPacketStatsDetails) GetCrcString() string { return "ce0b1ce0" }
+func (*SrLocalsidsWithPacketStatsDetails) GetMessageType() api.MessageType {
+	return api.ReplyMessage
+}
+
+func (m *SrLocalsidsWithPacketStatsDetails) Size() (size int) {
+	if m == nil {
+		return 0
+	}
+	size += 1 * 16 // m.Addr
+	size += 1      // m.EndPsp
+	size += 1      // m.Behavior
+	size += 4      // m.FibTable
+	size += 4      // m.VlanIndex
+	size += 1      // m.XconnectNhAddr.Af
+	size += 1 * 16 // m.XconnectNhAddr.Un
+	size += 4      // m.XconnectIfaceOrVrfTable
+	size += 8      // m.GoodTrafficBytes
+	size += 8      // m.GoodTrafficPktCount
+	size += 8      // m.BadTrafficBytes
+	size += 8      // m.BadTrafficPktCount
+	return size
+}
+func (m *SrLocalsidsWithPacketStatsDetails) Marshal(b []byte) ([]byte, error) {
+	if b == nil {
+		b = make([]byte, m.Size())
+	}
+	buf := codec.NewBuffer(b)
+	buf.EncodeBytes(m.Addr[:], 16)
+	buf.EncodeBool(m.EndPsp)
+	buf.EncodeUint8(uint8(m.Behavior))
+	buf.EncodeUint32(m.FibTable)
+	buf.EncodeUint32(m.VlanIndex)
+	buf.EncodeUint8(uint8(m.XconnectNhAddr.Af))
+	buf.EncodeBytes(m.XconnectNhAddr.Un.XXX_UnionData[:], 16)
+	buf.EncodeUint32(m.XconnectIfaceOrVrfTable)
+	buf.EncodeUint64(m.GoodTrafficBytes)
+	buf.EncodeUint64(m.GoodTrafficPktCount)
+	buf.EncodeUint64(m.BadTrafficBytes)
+	buf.EncodeUint64(m.BadTrafficPktCount)
+	return buf.Bytes(), nil
+}
+func (m *SrLocalsidsWithPacketStatsDetails) Unmarshal(b []byte) error {
+	buf := codec.NewBuffer(b)
+	copy(m.Addr[:], buf.DecodeBytes(16))
+	m.EndPsp = buf.DecodeBool()
+	m.Behavior = sr_types.SrBehavior(buf.DecodeUint8())
+	m.FibTable = buf.DecodeUint32()
+	m.VlanIndex = buf.DecodeUint32()
+	m.XconnectNhAddr.Af = ip_types.AddressFamily(buf.DecodeUint8())
+	copy(m.XconnectNhAddr.Un.XXX_UnionData[:], buf.DecodeBytes(16))
+	m.XconnectIfaceOrVrfTable = buf.DecodeUint32()
+	m.GoodTrafficBytes = buf.DecodeUint64()
+	m.GoodTrafficPktCount = buf.DecodeUint64()
+	m.BadTrafficBytes = buf.DecodeUint64()
+	m.BadTrafficPktCount = buf.DecodeUint64()
+	return nil
+}
+
+// SrLocalsidsWithPacketStatsDump defines message 'sr_localsids_with_packet_stats_dump'.
+// InProgress: the message form may change in the future versions
+type SrLocalsidsWithPacketStatsDump struct{}
+
+func (m *SrLocalsidsWithPacketStatsDump) Reset() { *m = SrLocalsidsWithPacketStatsDump{} }
+func (*SrLocalsidsWithPacketStatsDump) GetMessageName() string {
+	return "sr_localsids_with_packet_stats_dump"
+}
+func (*SrLocalsidsWithPacketStatsDump) GetCrcString() string { return "51077d14" }
+func (*SrLocalsidsWithPacketStatsDump) GetMessageType() api.MessageType {
+	return api.RequestMessage
+}
+
+func (m *SrLocalsidsWithPacketStatsDump) Size() (size int) {
+	if m == nil {
+		return 0
+	}
+	return size
+}
+func (m *SrLocalsidsWithPacketStatsDump) Marshal(b []byte) ([]byte, error) {
+	if b == nil {
+		b = make([]byte, m.Size())
+	}
+	buf := codec.NewBuffer(b)
+	return buf.Bytes(), nil
+}
+func (m *SrLocalsidsWithPacketStatsDump) Unmarshal(b []byte) error {
 	return nil
 }
 
@@ -1036,6 +1145,8 @@ func file_sr_binapi_init() {
 	api.RegisterMessage((*SrLocalsidAddDelReply)(nil), "sr_localsid_add_del_reply_e8d4e804")
 	api.RegisterMessage((*SrLocalsidsDetails)(nil), "sr_localsids_details_2e9221b9")
 	api.RegisterMessage((*SrLocalsidsDump)(nil), "sr_localsids_dump_51077d14")
+	api.RegisterMessage((*SrLocalsidsWithPacketStatsDetails)(nil), "sr_localsids_with_packet_stats_details_ce0b1ce0")
+	api.RegisterMessage((*SrLocalsidsWithPacketStatsDump)(nil), "sr_localsids_with_packet_stats_dump_51077d14")
 	api.RegisterMessage((*SrPoliciesDetails)(nil), "sr_policies_details_db6ff2a1")
 	api.RegisterMessage((*SrPoliciesDump)(nil), "sr_policies_dump_51077d14")
 	api.RegisterMessage((*SrPoliciesWithSlIndexDetails)(nil), "sr_policies_with_sl_index_details_ca2e9bc8")
@@ -1063,6 +1174,8 @@ func AllMessages() []api.Message {
 		(*SrLocalsidAddDelReply)(nil),
 		(*SrLocalsidsDetails)(nil),
 		(*SrLocalsidsDump)(nil),
+		(*SrLocalsidsWithPacketStatsDetails)(nil),
+		(*SrLocalsidsWithPacketStatsDump)(nil),
 		(*SrPoliciesDetails)(nil),
 		(*SrPoliciesDump)(nil),
 		(*SrPoliciesWithSlIndexDetails)(nil),

--- a/vpplink/binapi/vppapi/sr/sr_rpc.ba.go
+++ b/vpplink/binapi/vppapi/sr/sr_rpc.ba.go
@@ -15,6 +15,7 @@ import (
 type RPCService interface {
 	SrLocalsidAddDel(ctx context.Context, in *SrLocalsidAddDel) (*SrLocalsidAddDelReply, error)
 	SrLocalsidsDump(ctx context.Context, in *SrLocalsidsDump) (RPCService_SrLocalsidsDumpClient, error)
+	SrLocalsidsWithPacketStatsDump(ctx context.Context, in *SrLocalsidsWithPacketStatsDump) (RPCService_SrLocalsidsWithPacketStatsDumpClient, error)
 	SrPoliciesDump(ctx context.Context, in *SrPoliciesDump) (RPCService_SrPoliciesDumpClient, error)
 	SrPoliciesWithSlIndexDump(ctx context.Context, in *SrPoliciesWithSlIndexDump) (RPCService_SrPoliciesWithSlIndexDumpClient, error)
 	SrPolicyAdd(ctx context.Context, in *SrPolicyAdd) (*SrPolicyAddReply, error)
@@ -74,6 +75,49 @@ func (c *serviceClient_SrLocalsidsDumpClient) Recv() (*SrLocalsidsDetails, error
 	}
 	switch m := msg.(type) {
 	case *SrLocalsidsDetails:
+		return m, nil
+	case *memclnt.ControlPingReply:
+		err = c.Stream.Close()
+		if err != nil {
+			return nil, err
+		}
+		return nil, io.EOF
+	default:
+		return nil, fmt.Errorf("unexpected message: %T %v", m, m)
+	}
+}
+
+func (c *serviceClient) SrLocalsidsWithPacketStatsDump(ctx context.Context, in *SrLocalsidsWithPacketStatsDump) (RPCService_SrLocalsidsWithPacketStatsDumpClient, error) {
+	stream, err := c.conn.NewStream(ctx)
+	if err != nil {
+		return nil, err
+	}
+	x := &serviceClient_SrLocalsidsWithPacketStatsDumpClient{stream}
+	if err := x.Stream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err = x.Stream.SendMsg(&memclnt.ControlPing{}); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+type RPCService_SrLocalsidsWithPacketStatsDumpClient interface {
+	Recv() (*SrLocalsidsWithPacketStatsDetails, error)
+	api.Stream
+}
+
+type serviceClient_SrLocalsidsWithPacketStatsDumpClient struct {
+	api.Stream
+}
+
+func (c *serviceClient_SrLocalsidsWithPacketStatsDumpClient) Recv() (*SrLocalsidsWithPacketStatsDetails, error) {
+	msg, err := c.Stream.RecvMsg()
+	if err != nil {
+		return nil, err
+	}
+	switch m := msg.(type) {
+	case *SrLocalsidsWithPacketStatsDetails:
 		return m, nil
 	case *memclnt.ControlPingReply:
 		err = c.Stream.Close()

--- a/vpplink/binapi/vppapi/urpf/urpf.ba.go
+++ b/vpplink/binapi/vppapi/urpf/urpf.ba.go
@@ -27,31 +27,28 @@ const _ = api.GoVppAPIPackageIsVersion2
 const (
 	APIFile    = "urpf"
 	APIVersion = "1.0.0"
-	VersionCrc = 0xa015d999
+	VersionCrc = 0xd0c7b3c9
 )
 
 // UrpfMode defines enum 'urpf_mode'.
 type UrpfMode uint8
 
 const (
-	URPF_API_MODE_OFF        UrpfMode = 1
-	URPF_API_MODE_LOOSE      UrpfMode = 2
-	URPF_API_MODE_STRICT     UrpfMode = 3
-	URPF_API_MODE_CUSTOM_VRF UrpfMode = 4
+	URPF_API_MODE_OFF    UrpfMode = 0
+	URPF_API_MODE_LOOSE  UrpfMode = 1
+	URPF_API_MODE_STRICT UrpfMode = 2
 )
 
 var (
 	UrpfMode_name = map[uint8]string{
-		1: "URPF_API_MODE_OFF",
-		2: "URPF_API_MODE_LOOSE",
-		3: "URPF_API_MODE_STRICT",
-		4: "URPF_API_MODE_CUSTOM_VRF",
+		0: "URPF_API_MODE_OFF",
+		1: "URPF_API_MODE_LOOSE",
+		2: "URPF_API_MODE_STRICT",
 	}
 	UrpfMode_value = map[string]uint8{
-		"URPF_API_MODE_OFF":        1,
-		"URPF_API_MODE_LOOSE":      2,
-		"URPF_API_MODE_STRICT":     3,
-		"URPF_API_MODE_CUSTOM_VRF": 4,
+		"URPF_API_MODE_OFF":    0,
+		"URPF_API_MODE_LOOSE":  1,
+		"URPF_API_MODE_STRICT": 2,
 	}
 )
 
@@ -73,7 +70,7 @@ type UrpfUpdate struct {
 
 func (m *UrpfUpdate) Reset()               { *m = UrpfUpdate{} }
 func (*UrpfUpdate) GetMessageName() string { return "urpf_update" }
-func (*UrpfUpdate) GetCrcString() string   { return "2bf8a77c" }
+func (*UrpfUpdate) GetCrcString() string   { return "cc274cd1" }
 func (*UrpfUpdate) GetMessageType() api.MessageType {
 	return api.RequestMessage
 }
@@ -147,12 +144,12 @@ type UrpfUpdateV2 struct {
 	Mode      UrpfMode                       `binapi:"urpf_mode,name=mode" json:"mode,omitempty"`
 	Af        ip_types.AddressFamily         `binapi:"address_family,name=af" json:"af,omitempty"`
 	SwIfIndex interface_types.InterfaceIndex `binapi:"interface_index,name=sw_if_index" json:"sw_if_index,omitempty"`
-	TableID   uint32                         `binapi:"u32,name=table_id" json:"table_id,omitempty"`
+	TableID   uint32                         `binapi:"u32,name=table_id,default=4294967295" json:"table_id,omitempty"`
 }
 
 func (m *UrpfUpdateV2) Reset()               { *m = UrpfUpdateV2{} }
 func (*UrpfUpdateV2) GetMessageName() string { return "urpf_update_v2" }
-func (*UrpfUpdateV2) GetCrcString() string   { return "5fac3b85" }
+func (*UrpfUpdateV2) GetCrcString() string   { return "b873d028" }
 func (*UrpfUpdateV2) GetMessageType() api.MessageType {
 	return api.RequestMessage
 }
@@ -225,9 +222,9 @@ func (m *UrpfUpdateV2Reply) Unmarshal(b []byte) error {
 
 func init() { file_urpf_binapi_init() }
 func file_urpf_binapi_init() {
-	api.RegisterMessage((*UrpfUpdate)(nil), "urpf_update_2bf8a77c")
+	api.RegisterMessage((*UrpfUpdate)(nil), "urpf_update_cc274cd1")
 	api.RegisterMessage((*UrpfUpdateReply)(nil), "urpf_update_reply_e8d4e804")
-	api.RegisterMessage((*UrpfUpdateV2)(nil), "urpf_update_v2_5fac3b85")
+	api.RegisterMessage((*UrpfUpdateV2)(nil), "urpf_update_v2_b873d028")
 	api.RegisterMessage((*UrpfUpdateV2Reply)(nil), "urpf_update_v2_reply_e8d4e804")
 }
 

--- a/vpplink/binapi/vppapi/wireguard/wireguard.ba.go
+++ b/vpplink/binapi/vppapi/wireguard/wireguard.ba.go
@@ -185,7 +185,7 @@ func (m *WantWireguardPeerEventsReply) Unmarshal(b []byte) error {
 // WgSetAsyncMode defines message 'wg_set_async_mode'.
 // InProgress: the message form may change in the future versions
 type WgSetAsyncMode struct {
-	AsyncEnable bool `binapi:"bool,name=async_enable" json:"async_enable,omitempty"`
+	AsyncEnable bool `binapi:"bool,name=async_enable,default=false" json:"async_enable,omitempty"`
 }
 
 func (m *WgSetAsyncMode) Reset()               { *m = WgSetAsyncMode{} }

--- a/vpplink/urpf.go
+++ b/vpplink/urpf.go
@@ -27,7 +27,7 @@ import (
 func (v *VppLink) SetCustomURPF(swifindex uint32, tableId uint32) (err error) {
 	response := &urpf.UrpfUpdateV2Reply{}
 	request := &urpf.UrpfUpdateV2{
-		Mode:      urpf.URPF_API_MODE_CUSTOM_VRF,
+		Mode:      urpf.URPF_API_MODE_LOOSE,
 		SwIfIndex: interface_types.InterfaceIndex(swifindex),
 		Af:        ip_types.ADDRESS_IP4,
 		IsInput:   true,

--- a/yaml/overlays/dev/kustomize.sh
+++ b/yaml/overlays/dev/kustomize.sh
@@ -274,6 +274,7 @@ calico_create_template ()
   export CALICOVPP_DEFAULT_GW=${CALICOVPP_DEFAULT_GW}
   export CALICOVPP_DEBUG_ENABLE_GSO=${CALICOVPP_DEBUG_ENABLE_GSO:=true}
   export CALICOVPP_TAP_MTU=${CALICOVPP_TAP_MTU:=0}
+  export DEBUG=${DEBUG}
 
   ## calico-agent-config variables (extra variables for Calico-vpp-agent) ##
   export CALICOVPP_TAP_RX_QUEUES=${CALICOVPP_TAP_RX_QUEUES:=1}


### PR DESCRIPTION
This patch bumps (again) VPP to its latest version. Currently known issues doing this are :
- checksum are not properly computed on kind. Traffic from tap0 (traffic originated by the node) gets dropped in linux with a wrong checksum
- af-packet API has changed and needs adaptation.

Signed-off-by: Nathan Skrzypczak <nathan.skrzypczak@gmail.com>