### PR TITLE
Add release tag to master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,10 +156,12 @@ yaml:
 	$(MAKE) -C yaml
 
 .PHONY: release
-# TAG must be set to something like v0.6.0-calicov3.9.1
-# CALICO_TAG must be the latest calico release, like v3.20.1
+# TAG must be set to something like v3.24.0
+# CALICO_TAG must be the latest calico release, like v3.24.1
 release: check-TAG check-CALICO_TAG
 	@[ -z "$(shell git status --porcelain)" ] || (echo "Repo is not clean! Aborting." && exit 1)
+	git tag $(basename $(TAG)) # Tag the commit on master with major.minor
+	git push origin $(basename $(TAG))
 	# Generate yaml file for this release
 	sed -i.bak "s|:latest|:$(TAG)|g" yaml/base/calico-vpp-daemonset.yaml
 	rm yaml/base/calico-vpp-daemonset.yaml.bak


### PR DESCRIPTION
This patch adds a `major.minor` tag on the HEAD we are currently pointing to when creating the release branche.
This allows to have the tags being present in the main tree, for easier history exploration.

Signed-off-by: Nathan Skrzypczak <nathan.skrzypczak@gmail.com>