### PR TITLE
vpp: integrate gso fixes (3.24 backport)

### DIFF
--- a/vpplink/binapi/vpp_clone_current.sh
+++ b/vpplink/binapi/vpp_clone_current.sh
@@ -97,6 +97,9 @@ git_cherry_pick refs/changes/38/35438/1 # 35438: af_packet: fix tx stall by retr
 git_cherry_pick refs/changes/05/35805/2 # 35805: dpdk: add intf tag to dev{} subinput | https://gerrit.fd.io/r/c/vpp/+/35805
 git_cherry_pick refs/changes/78/35678/2 # 35678: dpdk: copy the enable_rxq_int flag from driver to conf | https://gerrit.fd.io/r/c/vpp/+/35678
 
+git_cherry_pick refs/changes/65/37365/2 # 37365: gso: set the header offsets in gro hdr fixup | https://gerrit.fd.io/r/c/vpp/+/37365
+git_cherry_pick refs/changes/64/37364/1 # 37364: gso: fix the checksum for odd number of data bytes | https://gerrit.fd.io/r/c/vpp/+/37364
+
 # --------------- Dedicated plugins ---------------
 git_cherry_pick refs/changes/64/33264/7 # 33264: pbl: Port based balancer | https://gerrit.fd.io/r/c/vpp/+/33264
 git_cherry_pick refs/changes/88/31588/1 # 31588: cnat: [WIP] no k8s maglev from pods | https://gerrit.fd.io/r/c/vpp/+/31588

--- a/vpplink/binapi/vppapi/abf/abf.ba.go
+++ b/vpplink/binapi/vppapi/abf/abf.ba.go
@@ -3,9 +3,9 @@
 // Package abf contains generated bindings for API file abf.api.
 //
 // Contents:
-//   2 structs
-//  10 messages
 //
+//	 2 structs
+//	10 messages
 package abf
 
 import (

--- a/vpplink/binapi/vppapi/acl/acl.ba.go
+++ b/vpplink/binapi/vppapi/acl/acl.ba.go
@@ -3,8 +3,8 @@
 // Package acl contains generated bindings for API file acl.api.
 //
 // Contents:
-//  42 messages
 //
+//	42 messages
 package acl
 
 import (

--- a/vpplink/binapi/vppapi/acl_types/acl_types.ba.go
+++ b/vpplink/binapi/vppapi/acl_types/acl_types.ba.go
@@ -3,9 +3,9 @@
 // Package acl_types contains generated bindings for API file acl_types.api.
 //
 // Contents:
-//   1 enum
-//   2 structs
 //
+//	1 enum
+//	2 structs
 package acl_types
 
 import (

--- a/vpplink/binapi/vppapi/af_packet/af_packet.ba.go
+++ b/vpplink/binapi/vppapi/af_packet/af_packet.ba.go
@@ -3,8 +3,8 @@
 // Package af_packet contains generated bindings for API file af_packet.api.
 //
 // Contents:
-//  10 messages
 //
+//	10 messages
 package af_packet
 
 import (

--- a/vpplink/binapi/vppapi/af_xdp/af_xdp.ba.go
+++ b/vpplink/binapi/vppapi/af_xdp/af_xdp.ba.go
@@ -3,9 +3,9 @@
 // Package af_xdp contains generated bindings for API file af_xdp.api.
 //
 // Contents:
-//   2 enums
-//   6 messages
 //
+//	2 enums
+//	6 messages
 package af_xdp
 
 import (

--- a/vpplink/binapi/vppapi/arp/arp.ba.go
+++ b/vpplink/binapi/vppapi/arp/arp.ba.go
@@ -3,9 +3,9 @@
 // Package arp contains generated bindings for API file arp.api.
 //
 // Contents:
-//   1 struct
-//   8 messages
 //
+//	1 struct
+//	8 messages
 package arp
 
 import (

--- a/vpplink/binapi/vppapi/avf/avf.ba.go
+++ b/vpplink/binapi/vppapi/avf/avf.ba.go
@@ -3,8 +3,8 @@
 // Package avf contains generated bindings for API file avf.api.
 //
 // Contents:
-//   4 messages
 //
+//	4 messages
 package avf
 
 import (

--- a/vpplink/binapi/vppapi/capo/capo.ba.go
+++ b/vpplink/binapi/vppapi/capo/capo.ba.go
@@ -3,11 +3,11 @@
 // Package capo contains generated bindings for API file capo.api.
 //
 // Contents:
-//   4 enums
-//   8 structs
-//   2 unions
-//  24 messages
 //
+//	 4 enums
+//	 8 structs
+//	 2 unions
+//	24 messages
 package capo
 
 import (

--- a/vpplink/binapi/vppapi/cnat/cnat.ba.go
+++ b/vpplink/binapi/vppapi/cnat/cnat.ba.go
@@ -3,10 +3,10 @@
 // Package cnat contains generated bindings for API file cnat.api.
 //
 // Contents:
-//   5 enums
-//   4 structs
-//  20 messages
 //
+//	 5 enums
+//	 4 structs
+//	20 messages
 package cnat
 
 import (

--- a/vpplink/binapi/vppapi/crypto_sw_scheduler/crypto_sw_scheduler.ba.go
+++ b/vpplink/binapi/vppapi/crypto_sw_scheduler/crypto_sw_scheduler.ba.go
@@ -3,8 +3,8 @@
 // Package crypto_sw_scheduler contains generated bindings for API file crypto_sw_scheduler.api.
 //
 // Contents:
-//   2 messages
 //
+//	2 messages
 package crypto_sw_scheduler
 
 import (

--- a/vpplink/binapi/vppapi/ethernet_types/ethernet_types.ba.go
+++ b/vpplink/binapi/vppapi/ethernet_types/ethernet_types.ba.go
@@ -3,8 +3,8 @@
 // Package ethernet_types contains generated bindings for API file ethernet_types.api.
 //
 // Contents:
-//   1 alias
 //
+//	1 alias
 package ethernet_types
 
 import (

--- a/vpplink/binapi/vppapi/feature/feature.ba.go
+++ b/vpplink/binapi/vppapi/feature/feature.ba.go
@@ -3,8 +3,8 @@
 // Package feature contains generated bindings for API file feature.api.
 //
 // Contents:
-//   2 messages
 //
+//	2 messages
 package feature
 
 import (

--- a/vpplink/binapi/vppapi/fib_types/fib_types.ba.go
+++ b/vpplink/binapi/vppapi/fib_types/fib_types.ba.go
@@ -3,9 +3,9 @@
 // Package fib_types contains generated bindings for API file fib_types.api.
 //
 // Contents:
-//   3 enums
-//   3 structs
 //
+//	3 enums
+//	3 structs
 package fib_types
 
 import (

--- a/vpplink/binapi/vppapi/generate.log
+++ b/vpplink/binapi/vppapi/generate.log
@@ -1,4 +1,4 @@
-VPP Version                 : 22.06-rc0~254-g579e0ab92
+VPP Version                 : 22.06-rc0~256-gea624d436
 Binapi-generator version    : govpp v0.6.0-dev
 VPP Base commit             : 38659d8f2 sr: fix srv6 definition of behavior associated to a LocalSID
 ------------------ Cherry picked commits --------------------
@@ -7,6 +7,8 @@ gerrit:28513/28 capo: Calico Policies plugin
 gerrit:28083/21 acl: acl-plugin custom policies
 gerrit:31588/1 cnat: [WIP] no k8s maglev from pods
 gerrit:33264/7 pbl: Port based balancer
+gerrit:37364/1 gso: fix the checksum for odd number of data bytes
+gerrit:37365/2 gso: set the header offsets in gro hdr fixup
 gerrit:35678/2 dpdk: copy the enable_rxq_int flag from driver to conf
 gerrit:35805/2 dpdk: add intf tag to dev{} subinput
 gerrit:35438/1 af_packet: fix tx stall by retrying failed sendto

--- a/vpplink/binapi/vppapi/gso/gso.ba.go
+++ b/vpplink/binapi/vppapi/gso/gso.ba.go
@@ -3,8 +3,8 @@
 // Package gso contains generated bindings for API file gso.api.
 //
 // Contents:
-//   2 messages
 //
+//	2 messages
 package gso
 
 import (

--- a/vpplink/binapi/vppapi/ikev2/ikev2.ba.go
+++ b/vpplink/binapi/vppapi/ikev2/ikev2.ba.go
@@ -3,8 +3,8 @@
 // Package ikev2 contains generated bindings for API file ikev2.api.
 //
 // Contents:
-//  50 messages
 //
+//	50 messages
 package ikev2
 
 import (

--- a/vpplink/binapi/vppapi/ikev2_types/ikev2_types.ba.go
+++ b/vpplink/binapi/vppapi/ikev2_types/ikev2_types.ba.go
@@ -3,8 +3,8 @@
 // Package ikev2_types contains generated bindings for API file ikev2_types.api.
 //
 // Contents:
-//  12 structs
 //
+//	12 structs
 package ikev2_types
 
 import (

--- a/vpplink/binapi/vppapi/interface/interface.ba.go
+++ b/vpplink/binapi/vppapi/interface/interface.ba.go
@@ -3,8 +3,8 @@
 // Package interfaces contains generated bindings for API file interface.api.
 //
 // Contents:
-//  68 messages
 //
+//	68 messages
 package interfaces
 
 import (

--- a/vpplink/binapi/vppapi/interface_types/interface_types.ba.go
+++ b/vpplink/binapi/vppapi/interface_types/interface_types.ba.go
@@ -3,9 +3,9 @@
 // Package interface_types contains generated bindings for API file interface_types.api.
 //
 // Contents:
-//   1 alias
-//   7 enums
 //
+//	1 alias
+//	7 enums
 package interface_types
 
 import (

--- a/vpplink/binapi/vppapi/ip/ip.ba.go
+++ b/vpplink/binapi/vppapi/ip/ip.ba.go
@@ -3,10 +3,10 @@
 // Package ip contains generated bindings for API file ip.api.
 //
 // Contents:
-//   2 enums
-//   7 structs
-//  91 messages
 //
+//	 2 enums
+//	 7 structs
+//	91 messages
 package ip
 
 import (

--- a/vpplink/binapi/vppapi/ip6_nd/ip6_nd.ba.go
+++ b/vpplink/binapi/vppapi/ip6_nd/ip6_nd.ba.go
@@ -3,9 +3,9 @@
 // Package ip6_nd contains generated bindings for API file ip6_nd.api.
 //
 // Contents:
-//   1 struct
-//  15 messages
 //
+//	 1 struct
+//	15 messages
 package ip6_nd
 
 import (

--- a/vpplink/binapi/vppapi/ip_neighbor/ip_neighbor.ba.go
+++ b/vpplink/binapi/vppapi/ip_neighbor/ip_neighbor.ba.go
@@ -3,10 +3,10 @@
 // Package ip_neighbor contains generated bindings for API file ip_neighbor.api.
 //
 // Contents:
-//   2 enums
-//   1 struct
-//  18 messages
 //
+//	 2 enums
+//	 1 struct
+//	18 messages
 package ip_neighbor
 
 import (

--- a/vpplink/binapi/vppapi/ip_types/ip_types.ba.go
+++ b/vpplink/binapi/vppapi/ip_types/ip_types.ba.go
@@ -3,11 +3,11 @@
 // Package ip_types contains generated bindings for API file ip_types.api.
 //
 // Contents:
-//   5 aliases
-//   5 enums
-//   8 structs
-//   1 union
 //
+//	5 aliases
+//	5 enums
+//	8 structs
+//	1 union
 package ip_types
 
 import (

--- a/vpplink/binapi/vppapi/ipip/ipip.ba.go
+++ b/vpplink/binapi/vppapi/ipip/ipip.ba.go
@@ -3,9 +3,9 @@
 // Package ipip contains generated bindings for API file ipip.api.
 //
 // Contents:
-//   1 struct
-//  10 messages
 //
+//	 1 struct
+//	10 messages
 package ipip
 
 import (

--- a/vpplink/binapi/vppapi/ipsec/ipsec.ba.go
+++ b/vpplink/binapi/vppapi/ipsec/ipsec.ba.go
@@ -3,10 +3,10 @@
 // Package ipsec contains generated bindings for API file ipsec.api.
 //
 // Contents:
-//   1 enum
-//   3 structs
-//  46 messages
 //
+//	 1 enum
+//	 3 structs
+//	46 messages
 package ipsec
 
 import (

--- a/vpplink/binapi/vppapi/ipsec_types/ipsec_types.ba.go
+++ b/vpplink/binapi/vppapi/ipsec_types/ipsec_types.ba.go
@@ -3,9 +3,9 @@
 // Package ipsec_types contains generated bindings for API file ipsec_types.api.
 //
 // Contents:
-//   4 enums
-//   4 structs
 //
+//	4 enums
+//	4 structs
 package ipsec_types
 
 import (

--- a/vpplink/binapi/vppapi/memclnt/memclnt.ba.go
+++ b/vpplink/binapi/vppapi/memclnt/memclnt.ba.go
@@ -3,9 +3,9 @@
 // Package memclnt contains generated bindings for API file memclnt.api.
 //
 // Contents:
-//   2 structs
-//  24 messages
 //
+//	 2 structs
+//	24 messages
 package memclnt
 
 import (

--- a/vpplink/binapi/vppapi/memif/memif.ba.go
+++ b/vpplink/binapi/vppapi/memif/memif.ba.go
@@ -3,9 +3,9 @@
 // Package memif contains generated bindings for API file memif.api.
 //
 // Contents:
-//   2 enums
-//  12 messages
 //
+//	 2 enums
+//	12 messages
 package memif
 
 import (

--- a/vpplink/binapi/vppapi/mfib_types/mfib_types.ba.go
+++ b/vpplink/binapi/vppapi/mfib_types/mfib_types.ba.go
@@ -3,9 +3,9 @@
 // Package mfib_types contains generated bindings for API file mfib_types.api.
 //
 // Contents:
-//   2 enums
-//   1 struct
 //
+//	2 enums
+//	1 struct
 package mfib_types
 
 import (

--- a/vpplink/binapi/vppapi/nat44_ed/nat44_ed.ba.go
+++ b/vpplink/binapi/vppapi/nat44_ed/nat44_ed.ba.go
@@ -3,10 +3,11 @@
 // Package nat44_ed contains generated bindings for API file nat44_ed.api.
 //
 // Contents:
-//   1 enum
-//   1 struct
-// 104 messages
 //
+//	1 enum
+//	1 struct
+//
+// 104 messages
 package nat44_ed
 
 import (

--- a/vpplink/binapi/vppapi/nat_types/nat_types.ba.go
+++ b/vpplink/binapi/vppapi/nat_types/nat_types.ba.go
@@ -3,9 +3,9 @@
 // Package nat_types contains generated bindings for API file nat_types.api.
 //
 // Contents:
-//   2 enums
-//   1 struct
 //
+//	2 enums
+//	1 struct
 package nat_types
 
 import (

--- a/vpplink/binapi/vppapi/pbl/pbl.ba.go
+++ b/vpplink/binapi/vppapi/pbl/pbl.ba.go
@@ -3,10 +3,10 @@
 // Package pbl contains generated bindings for API file pbl.api.
 //
 // Contents:
-//   1 enum
-//   2 structs
-//   6 messages
 //
+//	1 enum
+//	2 structs
+//	6 messages
 package pbl
 
 import (

--- a/vpplink/binapi/vppapi/pci_types/pci_types.ba.go
+++ b/vpplink/binapi/vppapi/pci_types/pci_types.ba.go
@@ -3,8 +3,8 @@
 // Package pci_types contains generated bindings for API file pci_types.api.
 //
 // Contents:
-//   1 struct
 //
+//	1 struct
 package pci_types
 
 import (

--- a/vpplink/binapi/vppapi/punt/punt.ba.go
+++ b/vpplink/binapi/vppapi/punt/punt.ba.go
@@ -3,11 +3,11 @@
 // Package punt contains generated bindings for API file punt.api.
 //
 // Contents:
-//   1 enum
-//   5 structs
-//   1 union
-//  10 messages
 //
+//	 1 enum
+//	 5 structs
+//	 1 union
+//	10 messages
 package punt
 
 import (

--- a/vpplink/binapi/vppapi/rdma/rdma.ba.go
+++ b/vpplink/binapi/vppapi/rdma/rdma.ba.go
@@ -3,9 +3,9 @@
 // Package rdma contains generated bindings for API file rdma.api.
 //
 // Contents:
-//   3 enums
-//   8 messages
 //
+//	3 enums
+//	8 messages
 package rdma
 
 import (

--- a/vpplink/binapi/vppapi/session/session.ba.go
+++ b/vpplink/binapi/vppapi/session/session.ba.go
@@ -3,9 +3,9 @@
 // Package session contains generated bindings for API file session.api.
 //
 // Contents:
-//   2 enums
-//  28 messages
 //
+//	 2 enums
+//	28 messages
 package session
 
 import (

--- a/vpplink/binapi/vppapi/sr/sr.ba.go
+++ b/vpplink/binapi/vppapi/sr/sr.ba.go
@@ -3,9 +3,9 @@
 // Package sr contains generated bindings for API file sr.api.
 //
 // Contents:
-//   2 structs
-//  22 messages
 //
+//	 2 structs
+//	22 messages
 package sr
 
 import (

--- a/vpplink/binapi/vppapi/sr_types/sr_types.ba.go
+++ b/vpplink/binapi/vppapi/sr_types/sr_types.ba.go
@@ -3,8 +3,8 @@
 // Package sr_types contains generated bindings for API file sr_types.api.
 //
 // Contents:
-//   3 enums
 //
+//	3 enums
 package sr_types
 
 import (

--- a/vpplink/binapi/vppapi/tapv2/tapv2.ba.go
+++ b/vpplink/binapi/vppapi/tapv2/tapv2.ba.go
@@ -3,9 +3,9 @@
 // Package tapv2 contains generated bindings for API file tapv2.api.
 //
 // Contents:
-//   1 enum
-//   8 messages
 //
+//	1 enum
+//	8 messages
 package tapv2
 
 import (

--- a/vpplink/binapi/vppapi/tunnel_types/tunnel_types.ba.go
+++ b/vpplink/binapi/vppapi/tunnel_types/tunnel_types.ba.go
@@ -3,9 +3,9 @@
 // Package tunnel_types contains generated bindings for API file tunnel_types.api.
 //
 // Contents:
-//   3 enums
-//   1 struct
 //
+//	3 enums
+//	1 struct
 package tunnel_types
 
 import (

--- a/vpplink/binapi/vppapi/urpf/urpf.ba.go
+++ b/vpplink/binapi/vppapi/urpf/urpf.ba.go
@@ -3,9 +3,9 @@
 // Package urpf contains generated bindings for API file urpf.api.
 //
 // Contents:
-//   1 enum
-//   4 messages
 //
+//	1 enum
+//	4 messages
 package urpf
 
 import (

--- a/vpplink/binapi/vppapi/virtio/virtio.ba.go
+++ b/vpplink/binapi/vppapi/virtio/virtio.ba.go
@@ -3,9 +3,9 @@
 // Package virtio contains generated bindings for API file virtio.api.
 //
 // Contents:
-//   1 enum
-//   8 messages
 //
+//	1 enum
+//	8 messages
 package virtio
 
 import (

--- a/vpplink/binapi/vppapi/vlib/vlib.ba.go
+++ b/vpplink/binapi/vppapi/vlib/vlib.ba.go
@@ -3,9 +3,9 @@
 // Package vlib contains generated bindings for API file vlib.api.
 //
 // Contents:
-//   1 struct
-//  18 messages
 //
+//	 1 struct
+//	18 messages
 package vlib
 
 import (

--- a/vpplink/binapi/vppapi/vmxnet3/vmxnet3.ba.go
+++ b/vpplink/binapi/vppapi/vmxnet3/vmxnet3.ba.go
@@ -3,9 +3,9 @@
 // Package vmxnet3 contains generated bindings for API file vmxnet3.api.
 //
 // Contents:
-//   2 structs
-//   8 messages
 //
+//	2 structs
+//	8 messages
 package vmxnet3
 
 import (

--- a/vpplink/binapi/vppapi/vpe/vpe.ba.go
+++ b/vpplink/binapi/vppapi/vpe/vpe.ba.go
@@ -3,8 +3,8 @@
 // Package vpe contains generated bindings for API file vpe.api.
 //
 // Contents:
-//   6 messages
 //
+//	6 messages
 package vpe
 
 import (

--- a/vpplink/binapi/vppapi/vpe_types/vpe_types.ba.go
+++ b/vpplink/binapi/vppapi/vpe_types/vpe_types.ba.go
@@ -3,10 +3,10 @@
 // Package vpe_types contains generated bindings for API file vpe_types.api.
 //
 // Contents:
-//   2 aliases
-//   1 enum
-//   1 struct
 //
+//	2 aliases
+//	1 enum
+//	1 struct
 package vpe_types
 
 import (

--- a/vpplink/binapi/vppapi/vxlan/vxlan.ba.go
+++ b/vpplink/binapi/vppapi/vxlan/vxlan.ba.go
@@ -3,8 +3,8 @@
 // Package vxlan contains generated bindings for API file vxlan.api.
 //
 // Contents:
-//  14 messages
 //
+//	14 messages
 package vxlan
 
 import (

--- a/vpplink/binapi/vppapi/wireguard/wireguard.ba.go
+++ b/vpplink/binapi/vppapi/wireguard/wireguard.ba.go
@@ -3,10 +3,10 @@
 // Package wireguard contains generated bindings for API file wireguard.api.
 //
 // Contents:
-//   1 enum
-//   2 structs
-//  17 messages
 //
+//	 1 enum
+//	 2 structs
+//	17 messages
 package wireguard
 
 import (


### PR DESCRIPTION
This patch integrates two GSO fixes for cksum
calculation when the buffer length is odd.
- https://gerrit.fd.io/r/c/vpp/+/37364
- https://gerrit.fd.io/r/c/vpp/+/37365

Signed-off-by: Nathan Skrzypczak <nathan.skrzypczak@gmail.com>