### PR TITLE
vpp-manager: Fix corefile cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,10 +192,12 @@ run-integration-tests:
 
 .PHONY: test
 test:
-	gofmt -s -l . | grep -v binapi | diff -u /dev/null -
+	gofmt -s -l . | grep -v binapi | grep -v vpp_build | diff -u /dev/null -
 	go vet ./...
+	go test ./...
 
 .PHONY: go-check
 go-check:
-	gofmt -s -l . | grep -v binapi | diff -u /dev/null -
+	gofmt -s -l . | grep -v binapi | grep -v vpp_build | diff -u /dev/null -
 	go vet ./...
+	go test ./...

--- a/config/startup/startup_test.go
+++ b/config/startup/startup_test.go
@@ -1,0 +1,76 @@
+// Copyright (C) 2022 Cisco Systems Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package startup
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestCleanupCoreFiles creates 4 files names file1..file3
+// it then calls CleanupCoreFiles() with maxCoreFiles=2 (default)
+// we assert that only file2 & file3 remain
+// then call CleanupCoreFiles() with maxCoreFiles=0
+// and assert no file remain
+func TestCleanupCoreFiles(t *testing.T) {
+	err := CleanupCoreFiles("")
+	if err != nil {
+		t.Errorf("Error calling CleanupCoreFiles(\"\") %s", err)
+	}
+
+	dir, err := os.MkdirTemp("", "TestCleanupCoreFiles")
+	if err != nil {
+		t.Errorf("Error MkdirTemp %s", err)
+	}
+	for i := 0; i < 4; i++ {
+		err := os.WriteFile(filepath.Join(dir, fmt.Sprintf("file%d", i)), []byte("data"), 0666)
+		if err != nil {
+			t.Errorf("Error WriteFile %d %s", 1, err)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	err = CleanupCoreFiles(filepath.Join(dir, "vppcore.%e.%p"))
+	if err != nil {
+		t.Errorf("Error calling CleanupCoreFiles %s", err)
+	}
+	for i := 0; i < 2; i++ {
+		_, err = os.Stat(filepath.Join(dir, fmt.Sprintf("file%d", i)))
+		if !os.IsNotExist(err) {
+			t.Errorf("file%d err is not ErrNotExist %s", i, err)
+		}
+	}
+	for i := 2; i < 4; i++ {
+		_, err = os.Stat(filepath.Join(dir, fmt.Sprintf("file%d", i)))
+		if err != nil {
+			t.Errorf("file%d stat errored %s", i, err)
+		}
+	}
+
+	maxCoreFiles = 0
+	err = CleanupCoreFiles(filepath.Join(dir, "vppcore.%e.%p"))
+	if err != nil {
+		t.Errorf("Error calling CleanupCoreFiles() max=0 %s", err)
+	}
+
+	err = os.Remove(dir)
+	if err != nil {
+		t.Errorf("Error calling os.Remove %s", err)
+	}
+}


### PR DESCRIPTION
This patch fixes a segfault happening when the corefile was not specified in the environment variable. It also tries to improve the logic a bit and adds a test for this function.

Additionnally this patch also enables running tests in `make test` and in the CI. This should not include the integration tests that require the envvar INTEGRATION_TEST to be set.

Signed-off-by: Nathan Skrzypczak <nathan.skrzypczak@gmail.com>