### PR TITLE
kind: use default num workers

### DIFF
--- a/test/kind/Makefile
+++ b/test/kind/Makefile
@@ -1,8 +1,9 @@
 TAG ?= latest # Tag images with :$(TAG)
+N_KIND_WORKERS ?= 3
 
 .PHONY: new-cluster
 new-cluster:
-	@./new_cluster.sh $(nodes)
+	@N_KIND_WORKERS=$(N_KIND_WORKERS) ./new_cluster.sh
 
 .PHONY: delete-cluster
 delete-cluster:

--- a/test/kind/new_cluster.sh
+++ b/test/kind/new_cluster.sh
@@ -31,13 +31,12 @@ nodes:
 EOF
 )
 
-if [ "$1" == "" ]
-then
-echo "please specify number of nodes"
-exit 1
+if [ "$N_KIND_WORKERS" == "" ]; then
+	echo "Please Set N_KIND_WORKERS"
+	exit 1
 fi
 
-for ((i=1; i<=$1; i++)); do \
+for ((i=1; i<=$N_KIND_WORKERS; i++)); do \
 config=$(cat <<EOF
 $config
 - role: worker


### PR DESCRIPTION
This patch make the kind-new-cluster directive use a N_KIND_WORKERS variable, defaulting to 3 workers (so 4 nodes)

Signed-off-by: Nathan Skrzypczak <nathan.skrzypczak@gmail.com>