### PR TITLE
vpp-manager: fix corefile cleanup

### DIFF
--- a/config/startup/startup_test.go
+++ b/config/startup/startup_test.go
@@ -21,56 +21,63 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
+
+func TestCleanupCoreFiles(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Common CalicoVPP tests")
+}
 
 // TestCleanupCoreFiles creates 4 files names file1..file3
 // it then calls CleanupCoreFiles() with maxCoreFiles=2 (default)
 // we assert that only file2 & file3 remain
 // then call CleanupCoreFiles() with maxCoreFiles=0
 // and assert no file remain
-func TestCleanupCoreFiles(t *testing.T) {
-	err := CleanupCoreFiles("")
-	if err != nil {
-		t.Errorf("Error calling CleanupCoreFiles(\"\") %s", err)
-	}
+var _ = Describe("Test CleanupCoreFiles", func() {
+	It("Call CleanupCoreFiles with empty string", func() {
+		err := CleanupCoreFiles("")
+		Expect(err).ToNot(HaveOccurred(), "Error calling CleanupCoreFiles")
+	})
 
-	dir, err := os.MkdirTemp("", "TestCleanupCoreFiles")
-	if err != nil {
-		t.Errorf("Error MkdirTemp %s", err)
-	}
-	for i := 0; i < 4; i++ {
-		err := os.WriteFile(filepath.Join(dir, fmt.Sprintf("file%d", i)), []byte("data"), 0666)
-		if err != nil {
-			t.Errorf("Error WriteFile %d %s", 1, err)
+	It("Call CleanupCoreFiles with empty string", func() {
+		dir, err := os.MkdirTemp("", "TestCleanupCoreFiles")
+		Expect(err).ToNot(HaveOccurred(), "Error MkdirTemp")
+		for i := 0; i < 4; i++ {
+			err := os.WriteFile(filepath.Join(dir, fmt.Sprintf("vppcore.%d", i)), []byte("data"), 0666)
+			Expect(err).ToNot(HaveOccurred(), "Error Writing file")
+			time.Sleep(100 * time.Millisecond)
 		}
-		time.Sleep(100 * time.Millisecond)
-	}
+		err = os.WriteFile(filepath.Join(dir, fmt.Sprintf("notvppcore")), []byte("data"), 0666)
+		Expect(err).ToNot(HaveOccurred(), "Error Writing file")
 
-	err = CleanupCoreFiles(filepath.Join(dir, "vppcore.%e.%p"))
-	if err != nil {
-		t.Errorf("Error calling CleanupCoreFiles %s", err)
-	}
-	for i := 0; i < 2; i++ {
-		_, err = os.Stat(filepath.Join(dir, fmt.Sprintf("file%d", i)))
-		if !os.IsNotExist(err) {
-			t.Errorf("file%d err is not ErrNotExist %s", i, err)
+		err = CleanupCoreFiles(filepath.Join(dir, "vppcore.%e.%p"))
+		Expect(err).ToNot(HaveOccurred(), "Error calling CleanupCoreFiles")
+
+		for i := 0; i < 2; i++ {
+			_, err = os.Stat(filepath.Join(dir, fmt.Sprintf("vppcore.%d", i)))
+			Expect(os.IsNotExist(err)).To(BeTrue(), "vppcore.%d err is not ErrNotExist %s", i)
 		}
-	}
-	for i := 2; i < 4; i++ {
-		_, err = os.Stat(filepath.Join(dir, fmt.Sprintf("file%d", i)))
-		if err != nil {
-			t.Errorf("file%d stat errored %s", i, err)
+		for i := 2; i < 4; i++ {
+			_, err = os.Stat(filepath.Join(dir, fmt.Sprintf("vppcore.%d", i)))
+			Expect(err).ToNot(HaveOccurred(), "vppcore.%d not found", i)
 		}
-	}
+		_, err = os.Stat(filepath.Join(dir, fmt.Sprintf("notvppcore")))
+		Expect(err).ToNot(HaveOccurred(), "notvppcore not found")
 
-	maxCoreFiles = 0
-	err = CleanupCoreFiles(filepath.Join(dir, "vppcore.%e.%p"))
-	if err != nil {
-		t.Errorf("Error calling CleanupCoreFiles() max=0 %s", err)
-	}
+		maxCoreFiles = 0
+		err = CleanupCoreFiles(filepath.Join(dir, "vppcore.%e.%p"))
+		Expect(err).ToNot(HaveOccurred(), "Error calling CleanupCoreFiles")
 
-	err = os.Remove(dir)
-	if err != nil {
-		t.Errorf("Error calling os.Remove %s", err)
-	}
-}
+		_, err = os.Stat(filepath.Join(dir, fmt.Sprintf("notvppcore")))
+		Expect(err).ToNot(HaveOccurred(), "notvppcore not found")
+
+		err = os.Remove(filepath.Join(dir, fmt.Sprintf("notvppcore")))
+		Expect(err).ToNot(HaveOccurred(), "Could not remote notvppcore")
+
+		err = os.Remove(dir)
+		Expect(err).ToNot(HaveOccurred(), "Could not remove test directory")
+	})
+})

--- a/yaml/overlays/dev/kustomize.sh
+++ b/yaml/overlays/dev/kustomize.sh
@@ -114,7 +114,7 @@ function get_initial_config ()
     echo "
     {
       \"vppStartupSleepSeconds\": ${CALICOVPP_VPP_STARTUP_SLEEP:-0},
-      \"corePattern\": \"${CALICOVPP_CORE_PATTERN:-/repo/vppcore.%e.%p}\",
+      \"corePattern\": \"${CALICOVPP_CORE_PATTERN:-/var/lib/vpp/vppcore.%e.%p}\",
       \"defaultGWs\": \"${CALICOVPP_DEFAULT_GW}\"
     }
     "


### PR DESCRIPTION
This patch fixes the coredump file cleanup only targeting the files that have the same prefix as the corepattern (to avoid deleting non coredump files)

Signed-off-by: Nathan Skrzypczak <nathan.skrzypczak@gmail.com>