### PR TITLE
vpp: use capo RX/TX in vpp & ingress/egress in Calico.

### DIFF
--- a/vpplink/binapi/patches/0001-pbl-Port-based-balancer.patch
+++ b/vpplink/binapi/patches/0001-pbl-Port-based-balancer.patch
@@ -1,0 +1,1361 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nathan Skrzypczak <nathan.skrzypczak@gmail.com>
+Date: Tue, 27 Jul 2021 09:41:55 +0200
+Subject: [PATCH 1/4] pbl: Port based balancer
+
+Type: feature
+
+This is a POC for doing ABF like filtering
+but only with destination ports in the FIB.
+The target use-case is directing a range of ports
+to a memif while directing the rest of the traffic
+to a tuntap.
+
+Change-Id: I2af9ce0b28838838f575395bb16e0bc14ff593f7
+Signed-off-by: Nathan Skrzypczak <nathan.skrzypczak@gmail.com>
+---
+ MAINTAINERS                    |   5 +
+ src/plugins/pbl/CMakeLists.txt |  22 ++
+ src/plugins/pbl/FEATURE.yaml   |   8 +
+ src/plugins/pbl/pbl.api        |  89 +++++
+ src/plugins/pbl/pbl_api.c      | 179 +++++++++++
+ src/plugins/pbl/pbl_client.c   | 570 +++++++++++++++++++++++++++++++++
+ src/plugins/pbl/pbl_client.h   | 191 +++++++++++
+ src/plugins/pbl/pbl_error.def  |  16 +
+ src/plugins/pbl/pbl_node.c     | 183 +++++++++++
+ 9 files changed, 1263 insertions(+)
+ create mode 100644 src/plugins/pbl/CMakeLists.txt
+ create mode 100644 src/plugins/pbl/FEATURE.yaml
+ create mode 100644 src/plugins/pbl/pbl.api
+ create mode 100644 src/plugins/pbl/pbl_api.c
+ create mode 100644 src/plugins/pbl/pbl_client.c
+ create mode 100644 src/plugins/pbl/pbl_client.h
+ create mode 100644 src/plugins/pbl/pbl_error.def
+ create mode 100644 src/plugins/pbl/pbl_node.c
+
+diff --git a/MAINTAINERS b/MAINTAINERS
+index 9bc8be134..a1f8fed22 100644
+--- a/MAINTAINERS
++++ b/MAINTAINERS
+@@ -695,6 +695,11 @@ I:	svs
+ M:	Neale Ranns <neale@graphiant.com>
+ F:	src/plugins/svs/
+ 
++Plugin - PBL
++I:	pbl
++M:	Nathan Skrzypczak <nathan.skrzypczak@gmail.com>
++F:	src/plugins/pbl
++
+ Plugin - IPv6 Connection Tracker
+ I:	ct6
+ M:	Dave Barach <vpp@barachs.net>
+diff --git a/src/plugins/pbl/CMakeLists.txt b/src/plugins/pbl/CMakeLists.txt
+new file mode 100644
+index 000000000..a4ce971c2
+--- /dev/null
++++ b/src/plugins/pbl/CMakeLists.txt
+@@ -0,0 +1,22 @@
++# Copyright (c) 2021 Cisco and/or its affiliates.
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at:
++#
++#     http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++
++add_vpp_plugin(pbl
++  SOURCES
++  pbl_client.c
++  pbl_node.c
++  pbl_api.c
++
++  API_FILES
++  pbl.api
++)
+diff --git a/src/plugins/pbl/FEATURE.yaml b/src/plugins/pbl/FEATURE.yaml
+new file mode 100644
+index 000000000..34f3a479f
+--- /dev/null
++++ b/src/plugins/pbl/FEATURE.yaml
+@@ -0,0 +1,8 @@
++---
++name: PBL (Port based Balencer)
++maintainer: Nathan Skrzypczak <nathan.skrzypczak@gmail.com>
++features:
++  - Port based balancer
++description: "Feature that enables selective punting of flows to an interface"
++state: experimental
++properties: [MULTITHREAD]
+diff --git a/src/plugins/pbl/pbl.api b/src/plugins/pbl/pbl.api
+new file mode 100644
+index 000000000..eada35314
+--- /dev/null
++++ b/src/plugins/pbl/pbl.api
+@@ -0,0 +1,89 @@
++/* Hey Emacs use -*- mode: C -*- */
++/*
++ * Copyright (c) 2021 Cisco and/or its affiliates.
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at:
++ *
++ *     http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ */
++
++/** \file
++    This file defines the vpp control-plane API messages
++    used to control the PBL plugin
++*/
++
++option version = "0.1.0";
++import "vnet/ip/ip_types.api";
++import "vnet/fib/fib_types.api";
++import "vnet/interface_types.api";
++
++enum pbl_client_flags
++{
++  PBL_API_FLAG_EXCLUSIVE = 1,
++};
++
++typedef pbl_port_range
++{
++    u16 start;
++    u16 end;
++    vl_api_ip_proto_t iproto;
++};
++
++typedef pbl_client
++{
++  u32 id [default=0xffffffff];
++  vl_api_address_t addr;
++  vl_api_fib_path_t paths; /* we support only one now due to api limit */
++  u8 flags;
++  u32 table_id;
++  u32 n_ports;
++  vl_api_pbl_port_range_t port_ranges[n_ports];
++};
++
++define pbl_client_update
++{
++  u32 client_index;
++  u32 context;
++  vl_api_pbl_client_t client;
++};
++
++define pbl_client_update_reply
++{
++  u32 context;
++  i32 retval;
++  u32 id;
++};
++
++autoreply define pbl_client_del
++{
++  u32 client_index;
++  u32 context;
++  u32 id;
++};
++
++define pbl_client_details
++{
++  u32 context;
++  vl_api_pbl_client_t client;
++};
++
++define pbl_client_dump
++{
++  u32 client_index;
++  u32 context;
++};
++
++/*
++ * fd.io coding-style-patch-verification: ON
++ *
++ * Local Variables:
++ * eval: (c-set-style "gnu")
++ * End:
++ */
+diff --git a/src/plugins/pbl/pbl_api.c b/src/plugins/pbl/pbl_api.c
+new file mode 100644
+index 000000000..e948357b0
+--- /dev/null
++++ b/src/plugins/pbl/pbl_api.c
+@@ -0,0 +1,179 @@
++/*
++ * Copyright (c) 2016 Cisco and/or its affiliates.
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at:
++ *
++ *     http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ */
++
++#include <stddef.h>
++
++#include <vnet/vnet.h>
++#include <vnet/plugin/plugin.h>
++#include <pbl/pbl_client.h>
++
++#include <vnet/ip/ip_types_api.h>
++
++#include <vpp/app/version.h>
++#include <vnet/fib/fib_api.h>
++
++#include <vlibapi/api.h>
++#include <vlibmemory/api.h>
++
++/* define message IDs */
++#include <vnet/format_fns.h>
++#include <pbl/pbl.api_enum.h>
++#include <pbl/pbl.api_types.h>
++
++/**
++ * Base message ID fot the plugin
++ */
++static u32 pbl_base_msg_id;
++
++#define REPLY_MSG_ID_BASE pbl_base_msg_id
++
++#include <vlibapi/api_helper_macros.h>
++
++static void
++vl_api_pbl_client_update_t_handler (vl_api_pbl_client_update_t *mp)
++{
++  pbl_client_update_args_t _args = { 0 }, *args = &_args;
++  vl_api_pbl_client_update_reply_t *rmp;
++  pbl_client_port_map_proto_t proto;
++  fib_route_path_t *rpath;
++  ip_protocol_t iproto;
++  int rv = 0;
++  u32 ii, n_ports;
++  u16 port_a, port_b;
++
++  args->pci = clib_net_to_host_u32 (mp->client.id);
++  ip_address_decode2 (&mp->client.addr, &args->addr);
++
++  for (ii = 0; ii < PBL_CLIENT_PORT_MAP_N_PROTOS; ii++)
++    {
++      clib_bitmap_alloc (args->port_maps[ii], (1 << 16) - 1);
++      clib_bitmap_zero (args->port_maps[ii]);
++    }
++
++  n_ports = clib_net_to_host_u32 (mp->client.n_ports);
++  for (ii = 0; ii < n_ports; ii++)
++    {
++      port_a = clib_net_to_host_u16 (mp->client.port_ranges[ii].start);
++      port_b = clib_net_to_host_u16 (mp->client.port_ranges[ii].end);
++      port_b = clib_max (port_a, port_b);
++
++      rv = ip_proto_decode (mp->client.port_ranges[ii].iproto, &iproto);
++      if (rv)
++	goto done;
++      proto = pbl_iproto_to_port_map_proto (iproto);
++
++      if (proto < PBL_CLIENT_PORT_MAP_N_PROTOS)
++	clib_bitmap_set_region (args->port_maps[proto], port_a, 1,
++				port_b - port_a + 1);
++    }
++  args->flags = mp->client.flags;
++  args->table_id = clib_net_to_host_u32 (mp->client.table_id);
++
++  vec_validate (args->rpaths, 0);
++  rpath = &args->rpaths[0];
++
++  rv = fib_api_path_decode (&mp->client.paths, rpath);
++  if (rv)
++    goto done;
++
++  args->pci = pbl_client_update (args);
++
++done:
++  vec_free (args->rpaths);
++
++  REPLY_MACRO2 (VL_API_PBL_CLIENT_UPDATE_REPLY,
++		({ rmp->id = clib_host_to_net_u32 (args->pci); }));
++}
++
++static void
++vl_api_pbl_client_del_t_handler (vl_api_pbl_client_del_t *mp)
++{
++  vl_api_pbl_client_del_reply_t *rmp;
++  int rv;
++
++  rv = pbl_client_delete (ntohl (mp->id));
++
++  REPLY_MACRO (VL_API_PBL_CLIENT_DEL_REPLY);
++}
++
++typedef struct pbl_dump_walk_ctx_t_
++{
++  vl_api_registration_t *rp;
++  u32 context;
++} pbl_dump_walk_ctx_t;
++
++static walk_rc_t
++pbl_client_send_details (u32 cti, void *args)
++{
++  vl_api_pbl_client_details_t *mp;
++  pbl_dump_walk_ctx_t *ctx;
++  size_t msg_size;
++  pbl_client_t *pc;
++
++  ctx = args;
++  pc = pbl_client_get (cti);
++  msg_size = sizeof (*mp);
++
++  mp = vl_msg_api_alloc_zero (msg_size);
++  mp->_vl_msg_id = ntohs (VL_API_PBL_CLIENT_DETAILS + pbl_base_msg_id);
++
++  mp->client.id = clib_host_to_net_u32 (cti);
++  ip_address_encode2 (&pc->pc_addr, &mp->client.addr);
++  mp->client.flags = clib_host_to_net_u32 (pc->flags);
++
++  /* TODO : we miss routes & ports */
++
++  vl_api_send_msg (ctx->rp, (u8 *) mp);
++
++  return (WALK_CONTINUE);
++}
++
++static void
++vl_api_pbl_client_dump_t_handler (vl_api_pbl_client_dump_t *mp)
++{
++  vl_api_registration_t *rp;
++
++  rp = vl_api_client_index_to_registration (mp->client_index);
++  if (rp == 0)
++    return;
++
++  pbl_dump_walk_ctx_t ctx = {
++    .rp = rp,
++    .context = mp->context,
++  };
++
++  pbl_client_walk (pbl_client_send_details, &ctx);
++}
++
++#include <pbl/pbl.api.c>
++
++static clib_error_t *
++pbl_api_init (vlib_main_t *vm)
++{
++  /* Ask for a correctly-sized block of API message decode slots */
++  pbl_base_msg_id = setup_message_id_table ();
++
++  return 0;
++}
++
++VLIB_INIT_FUNCTION (pbl_api_init);
++
++/*
++ * fd.io coding-style-patch-verification: ON
++ *
++ * Local Variables:
++ * eval: (c-set-style "gnu")
++ * End:
++ */
+diff --git a/src/plugins/pbl/pbl_client.c b/src/plugins/pbl/pbl_client.c
+new file mode 100644
+index 000000000..dc527ca25
+--- /dev/null
++++ b/src/plugins/pbl/pbl_client.c
+@@ -0,0 +1,570 @@
++/*
++ * Copyright (c) 2020 Cisco and/or its affiliates.
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at:
++ *
++ *     http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ */
++
++#include <vnet/fib/fib_source.h>
++#include <vnet/fib/fib_table.h>
++#include <vnet/fib/fib_entry_track.h>
++#include <vnet/fib/fib_path_list.h>
++#include <vnet/dpo/load_balance.h>
++#include <vnet/dpo/drop_dpo.h>
++#include <vnet/plugin/plugin.h>
++#include <vpp/app/version.h>
++
++#include <pbl/pbl_client.h>
++
++char *pbl_error_strings[] = {
++#define pbl_error(n, s) s,
++#include <pbl/pbl_error.def>
++#undef pbl_error
++};
++
++pbl_client_t *pbl_client_pool;
++fib_source_t pbl_fib_source;
++dpo_type_t pbl_client_dpo;
++
++static fib_node_type_t pbl_client_fib_node_type;
++
++static_always_inline u8
++pbl_client_is_clone (pbl_client_t *pc)
++{
++  return (FIB_NODE_INDEX_INVALID == pc->pc_fei);
++}
++
++static u8 *
++format_pbl_ports (u8 *s, va_list *args)
++{
++  clib_bitmap_t *map = va_arg (*args, clib_bitmap_t *);
++  if (NULL == map)
++    {
++      s = format (s, "(empty)");
++      return (s);
++    }
++  u32 last, cur, next_set, next_clear;
++  last = clib_bitmap_last_set (map);
++  cur = clib_bitmap_first_set (map);
++
++  if (cur == (u32) -1)
++    {
++      s = format (s, "(empty)");
++      return (s);
++    }
++
++  while (cur <= last)
++    {
++      next_set = clib_bitmap_next_set (map, cur);
++      next_clear = clib_bitmap_next_clear (map, next_set + 1);
++      if (next_clear == next_set + 1)
++	s = format (s, " %d", next_set);
++      else
++	s = format (s, " %d-%d", next_set, next_clear - 1);
++      cur = next_clear;
++    }
++
++  return (s);
++}
++
++u8 *
++format_pbl_client (u8 *s, va_list *args)
++{
++  index_t pci = va_arg (*args, index_t);
++  pbl_client_t *pc = pool_elt_at_index (pbl_client_pool, pci);
++  u32 indent = va_arg (*args, u32);
++
++  s = format (s, "%U[%d] pbl-client: %U", format_white_space, indent, pci,
++	      format_ip_address, &pc->pc_addr);
++
++  if (pc->flags & PBL_FLAG_EXCLUSIVE)
++    s = format (s, " exclusive");
++
++  if (!pbl_client_is_clone (pc) && INDEX_INVALID != pc->clone_pci)
++    {
++      s = format (s, " clone:%d", pc->clone_pci);
++      return (s);
++    }
++
++  s = format (s, "\n%UTCP ports:%U", format_white_space, indent + 2,
++	      format_pbl_ports, pc->pc_port_maps[PBL_CLIENT_PORT_MAP_TCP]);
++
++  s = format (s, "\n%UUDP ports:%U", format_white_space, indent + 2,
++	      format_pbl_ports, pc->pc_port_maps[PBL_CLIENT_PORT_MAP_UDP]);
++
++  s = format (s, "\n%Umatched dpo\n%U%U", format_white_space, indent + 2,
++	      format_white_space, indent + 4, format_dpo_id, &pc->pc_dpo,
++	      indent + 4);
++
++  if (pbl_client_is_clone (pc))
++    {
++      s = format (s, "\n%Udefault dpo\n%U%U", format_white_space, indent + 2,
++		  format_white_space, indent + 4, format_dpo_id,
++		  &pc->pc_parent, indent + 4);
++    }
++
++  return (s);
++}
++
++/**
++ * Interpose a policy DPO
++ */
++static void
++pbl_client_dpo_interpose (const dpo_id_t *original, const dpo_id_t *parent,
++			  dpo_id_t *clone)
++{
++  pbl_client_t *pc, *pc_clone;
++  int ii;
++
++  pool_get_zero (pbl_client_pool, pc_clone);
++  pc = pbl_client_get (original->dpoi_index);
++
++  pc_clone->pc_fei = FIB_NODE_INDEX_INVALID;
++  pc_clone->clone_pci = INDEX_INVALID;
++  ip_address_copy (&pc_clone->pc_addr, &pc->pc_addr);
++  pc_clone->flags = pc->flags;
++  for (ii = 0; ii < PBL_CLIENT_PORT_MAP_N_PROTOS; ii++)
++    pc_clone->pc_port_maps[ii] = pc->pc_port_maps[ii];
++
++  dpo_copy (&pc_clone->pc_dpo, &pc->pc_dpo);
++
++  pc->clone_pci = pc_clone - pbl_client_pool;
++
++  /* stack the clone on the FIB provided parent */
++  dpo_stack (pbl_client_dpo, original->dpoi_proto, &pc_clone->pc_parent,
++	     parent);
++
++  /* return the clone */
++  dpo_set (clone, pbl_client_dpo, original->dpoi_proto,
++	   pc_clone - pbl_client_pool);
++}
++
++static clib_error_t *
++pbl_client_show (vlib_main_t *vm, unformat_input_t *input,
++		 vlib_cli_command_t *cmd)
++{
++  index_t pci;
++
++  pci = INDEX_INVALID;
++
++  while (unformat_check_input (input) != UNFORMAT_END_OF_INPUT)
++    {
++      if (unformat (input, "%d", &pci))
++	;
++      else
++	return (clib_error_return (0, "unknown input '%U'",
++				   format_unformat_error, input));
++    }
++
++  if (INDEX_INVALID == pci)
++    {
++      pool_foreach_index (pci, pbl_client_pool)
++	vlib_cli_output (vm, "%U", format_pbl_client, pci, 0);
++    }
++
++  return (NULL);
++}
++
++VLIB_CLI_COMMAND (pbl_client_show_cmd_node, static) = {
++  .path = "show pbl client",
++  .function = pbl_client_show,
++  .short_help = "show pbl client",
++  .is_mp_safe = 1,
++};
++
++const static char *const pbl_client_dpo_ip4_nodes[] = {
++  "ip4-pbl-tx",
++  NULL,
++};
++
++const static char *const pbl_client_dpo_ip6_nodes[] = {
++  "ip6-pbl-tx",
++  NULL,
++};
++
++const static char *const *const pbl_client_dpo_nodes[DPO_PROTO_NUM] = {
++  [DPO_PROTO_IP4] = pbl_client_dpo_ip4_nodes,
++  [DPO_PROTO_IP6] = pbl_client_dpo_ip6_nodes,
++};
++
++static void
++pbl_client_dpo_lock (dpo_id_t *dpo)
++{
++  pbl_client_t *pc;
++
++  pc = pbl_client_get (dpo->dpoi_index);
++
++  pc->pc_locks++;
++}
++
++static void
++pbl_client_dpo_unlock (dpo_id_t *dpo)
++{
++  pbl_client_t *pc;
++
++  pc = pbl_client_get (dpo->dpoi_index);
++
++  pc->pc_locks--;
++
++  if (0 == pc->pc_locks)
++    {
++      ASSERT (pbl_client_is_clone (pc));
++      dpo_reset (&pc->pc_parent);
++      pool_put (pbl_client_pool, pc);
++    }
++}
++
++u8 *
++format_pbl_client_dpo (u8 *s, va_list *ap)
++{
++  index_t pci = va_arg (*ap, index_t);
++  u32 indent = va_arg (*ap, u32);
++
++  s = format (s, "\n%U", format_pbl_client, pci, indent);
++
++  return (s);
++}
++
++const static dpo_vft_t pbl_client_dpo_vft = {
++  .dv_lock = pbl_client_dpo_lock,
++  .dv_unlock = pbl_client_dpo_unlock,
++  .dv_format = format_pbl_client_dpo,
++  .dv_mk_interpose = pbl_client_dpo_interpose,
++};
++
++static void
++pbl_client_stack (pbl_client_t *pc)
++{
++  dpo_id_t dpo = DPO_INVALID;
++  fib_protocol_t fproto;
++  vlib_node_t *pnode;
++  pbl_client_t *pc_clone;
++
++  fproto = ip_address_family_to_fib_proto (pc->pc_addr.version);
++  fib_path_list_contribute_forwarding (
++    pc->pc_pl, fib_forw_chain_type_from_fib_proto (fproto),
++    FIB_PATH_LIST_FWD_FLAG_COLLAPSE, &dpo);
++
++  if (AF_IP4 == pc->pc_addr.version)
++    pnode = vlib_get_node_by_name (vlib_get_main (), (u8 *) "ip4-pbl-tx");
++  else
++    pnode = vlib_get_node_by_name (vlib_get_main (), (u8 *) "ip6-pbl-tx");
++
++  dpo_stack_from_node (pnode->index, &pc->pc_dpo, &dpo);
++
++  if (INDEX_INVALID != pc->clone_pci)
++    {
++      pc_clone = pbl_client_get_if_exists (pc->clone_pci);
++      if (pc_clone)
++	dpo_copy (&pc_clone->pc_dpo, &pc->pc_dpo);
++    }
++
++  dpo_reset (&dpo);
++
++  pc->flags |= PBL_CLIENT_STACKED;
++}
++
++int
++pbl_client_delete (u32 id)
++{
++  pbl_client_t *pc;
++  int ii;
++
++  if (pool_is_free_index (pbl_client_pool, id))
++    return (VNET_API_ERROR_NO_SUCH_ENTRY);
++
++  pc = pool_elt_at_index (pbl_client_pool, id);
++
++  fib_path_list_child_remove (pc->pc_pl, pc->pc_sibling);
++
++  dpo_reset (&pc->pc_dpo);
++
++  ASSERT (!pbl_client_is_clone (pc));
++
++  ASSERT (fib_entry_is_sourced (pc->pc_fei, pbl_fib_source));
++  fib_table_entry_delete_index (pc->pc_fei, pbl_fib_source);
++
++  for (ii = 0; ii < PBL_CLIENT_PORT_MAP_N_PROTOS; ii++)
++    clib_bitmap_free (pc->pc_port_maps[ii]);
++
++  dpo_reset (&pc->pc_parent);
++  pool_put (pbl_client_pool, pc);
++
++  return (0);
++}
++
++u32
++pbl_client_update (pbl_client_update_args_t *args)
++{
++  pbl_client_t *pc;
++  dpo_id_t tmp = DPO_INVALID;
++  fib_node_index_t fei;
++  dpo_proto_t dproto;
++  fib_prefix_t pfx;
++  u32 fib_flags, fib_index;
++  int ii;
++
++  /* check again if we need this client */
++  pc = pbl_client_get_if_exists (args->pci);
++  if (NULL == pc)
++    {
++      pool_get_aligned (pbl_client_pool, pc, CLIB_CACHE_LINE_BYTES);
++      pc->pc_locks = 1;
++      args->pci = pc - pbl_client_pool;
++      pc->pc_index = pc - pbl_client_pool;
++      pc->flags = args->flags;
++      pc->clone_pci = INDEX_INVALID;
++      for (ii = 0; ii < PBL_CLIENT_PORT_MAP_N_PROTOS; ii++)
++	pc->pc_port_maps[ii] = args->port_maps[ii];
++      fib_node_init (&pc->pc_node, pbl_client_fib_node_type);
++
++      ip_address_copy (&pc->pc_addr, &args->addr);
++
++      ip_address_to_fib_prefix (&pc->pc_addr, &pfx);
++
++      dproto = fib_proto_to_dpo (pfx.fp_proto);
++      dpo_set (&tmp, pbl_client_dpo, dproto, args->pci);
++      dpo_stack (pbl_client_dpo, dproto, &pc->pc_parent,
++		 drop_dpo_get (dproto));
++
++      fib_flags = FIB_ENTRY_FLAG_LOOSE_URPF_EXEMPT;
++      fib_flags |= (args->flags & PBL_FLAG_EXCLUSIVE) ?
++		     FIB_ENTRY_FLAG_EXCLUSIVE :
++		     FIB_ENTRY_FLAG_INTERPOSE;
++
++      fib_index = fib_table_find (pfx.fp_proto, args->table_id);
++      fei = fib_table_entry_special_dpo_add (fib_index, &pfx, pbl_fib_source,
++					     fib_flags, &tmp);
++
++      /* in case of interpose, pool can grow */
++      pc = pool_elt_at_index (pbl_client_pool, args->pci);
++
++      pc->pc_fei = fei;
++
++      pc->flags = args->flags;
++      pc->flags &= ~PBL_CLIENT_STACKED;
++
++      /* Contribute in fib in fib */
++      pc->pc_pl = fib_path_list_create (
++	FIB_PATH_LIST_FLAG_SHARED | FIB_PATH_LIST_FLAG_NO_URPF, args->rpaths);
++
++      /*
++       * become a child of the path list so we get poked when
++       * the forwarding changes.
++       */
++      pc->pc_sibling = fib_path_list_child_add (
++	pc->pc_pl, pbl_client_fib_node_type, pc->pc_index);
++      pbl_client_stack (pc);
++    }
++  else
++    {
++      /* Update unimplemented */
++      clib_warning ("unimplemented");
++    }
++
++  return (pc->pc_index);
++}
++
++void
++pbl_client_walk (pbl_client_walk_cb_t cb, void *ctx)
++{
++  u32 api;
++
++  pool_foreach_index (api, pbl_client_pool)
++    {
++      if (!cb (api, ctx))
++	break;
++    }
++}
++
++int
++pbl_client_purge (void)
++{
++  /* purge all the clients */
++  index_t tri, *trp, *trs = NULL;
++
++  pool_foreach_index (tri, pbl_client_pool)
++    {
++      vec_add1 (trs, tri);
++    }
++
++  vec_foreach (trp, trs)
++    pbl_client_delete (*trp);
++
++  ASSERT (0 == pool_elts (pbl_client_pool));
++
++  vec_free (trs);
++
++  return (0);
++}
++
++static fib_node_t *
++pbl_client_get_node (fib_node_index_t index)
++{
++  pbl_client_t *pc = pbl_client_get (index);
++  return (&(pc->pc_node));
++}
++
++static pbl_client_t *
++pbl_client_get_from_node (fib_node_t *node)
++{
++  return ((pbl_client_t *) (((char *) node) -
++			    STRUCT_OFFSET_OF (pbl_client_t, pc_node)));
++}
++
++static void
++pbl_client_last_lock_gone (fib_node_t *node)
++{
++ /**/}
++
++ /*
++  * A back walk has reached this ABF policy
++  */
++ static fib_node_back_walk_rc_t
++ pbl_client_back_walk_notify (fib_node_t *node, fib_node_back_walk_ctx_t *ctx)
++ {
++   /*
++    * re-stack the fmask on the n-eos of the via
++    */
++   pbl_client_t *pc = pbl_client_get_from_node (node);
++
++   /* If we have more than FIB_PATH_LIST_POPULAR paths
++    * we might get called during path tracking */
++   if (!(pc->flags & PBL_CLIENT_STACKED))
++     return (FIB_NODE_BACK_WALK_CONTINUE);
++
++   pbl_client_stack (pc);
++
++   return (FIB_NODE_BACK_WALK_CONTINUE);
++ }
++
++ /*
++  * The client's graph node virtual function table
++  */
++ static const fib_node_vft_t pbl_client_vft = {
++   .fnv_get = pbl_client_get_node,
++   .fnv_last_lock = pbl_client_last_lock_gone,
++   .fnv_back_walk = pbl_client_back_walk_notify,
++ };
++
++ static clib_error_t *
++ pbl_client_cli_add_del (vlib_main_t *vm, unformat_input_t *input,
++			 vlib_cli_command_t *cmd)
++ {
++   pbl_client_update_args_t _args = { 0 }, *args = &_args;
++   unformat_input_t _line_input, *line_input = &_line_input;
++   dpo_proto_t payload_proto;
++   fib_route_path_t rpath;
++   clib_error_t *e = 0;
++   u32 port_a, port_b;
++   int is_add = 1, ii;
++   u32 iproto, proto;
++
++   args->pci = INDEX_INVALID;
++   for (ii = 0; ii < PBL_CLIENT_PORT_MAP_N_PROTOS; ii++)
++     {
++       clib_bitmap_alloc (args->port_maps[ii], (1 << 16) - 1);
++       clib_bitmap_zero (args->port_maps[ii]);
++     }
++
++   /* Get a line of input. */
++   if (!unformat_user (input, unformat_line_input, line_input))
++     return 0;
++
++   while (unformat_check_input (line_input) != UNFORMAT_END_OF_INPUT)
++     {
++       if (unformat (line_input, "addr %U", unformat_ip_address, &args->addr))
++	 ;
++       else if (unformat (line_input, "add"))
++	 is_add = 1;
++       else if (unformat (line_input, "del"))
++	 is_add = 0;
++       else if (unformat (line_input, "id %d", &args->pci))
++	 ;
++       else if (unformat (line_input, "table %d", &args->table_id))
++	 ;
++       else if (unformat (line_input, "exclusive"))
++	 args->flags = PBL_FLAG_EXCLUSIVE;
++       else if (unformat (line_input, "via %U", unformat_fib_route_path,
++			  &rpath, &payload_proto))
++	 vec_add1 (args->rpaths, rpath);
++       else if (unformat (line_input, "%U %u-%u", unformat_ip_protocol,
++			  &iproto, &port_a, &port_b))
++	 {
++	   proto = pbl_iproto_to_port_map_proto (iproto);
++	   port_b = clib_max (port_a, port_b);
++	   if (proto < PBL_CLIENT_PORT_MAP_N_PROTOS)
++	     clib_bitmap_set_region (args->port_maps[proto], (u16) port_a, 1,
++				     (u16) (port_b - port_a + 1));
++	 }
++       else if (unformat (line_input, "%U %u", unformat_ip_protocol, &iproto,
++			  &port_a))
++	 {
++	   proto = pbl_iproto_to_port_map_proto (iproto);
++	   if (proto < PBL_CLIENT_PORT_MAP_N_PROTOS)
++	     clib_bitmap_set (args->port_maps[proto], (u16) port_a, 1);
++	 }
++       else
++	 {
++	   e = clib_error_return (0, "unknown input '%U'",
++				  format_unformat_error, line_input);
++	   goto done;
++	 }
++     }
++
++   if (is_add)
++     pbl_client_update (args);
++   else
++     pbl_client_delete (args->pci);
++
++ done:
++   vec_free (args->rpaths);
++   unformat_free (line_input);
++   return (e);
++ }
++
++ VLIB_CLI_COMMAND (pbl_client_cli_add_del_command, static) = {
++   .path = "pbl client",
++   .short_help = "pbl client [add|del] [addr <address>] [via <path>]"
++		 "[[id <id>] [table <table-id>] [exclusive]]",
++   .function = pbl_client_cli_add_del,
++ };
++
++ static clib_error_t *
++ pbl_client_init (vlib_main_t *vm)
++ {
++   pbl_client_dpo =
++     dpo_register_new_type (&pbl_client_dpo_vft, pbl_client_dpo_nodes);
++
++   pbl_fib_source = fib_source_allocate ("pbl", PBL_FIB_SOURCE_PRIORITY,
++					 FIB_SOURCE_BH_SIMPLE);
++
++   pbl_client_fib_node_type =
++     fib_node_register_new_type ("pbl-client", &pbl_client_vft);
++
++   return (NULL);
++ }
++
++ VLIB_INIT_FUNCTION (pbl_client_init);
++
++ VLIB_PLUGIN_REGISTER () = {
++   .version = VPP_BUILD_VER,
++   .description = "Port based balancer (PBL)",
++   .default_disabled = 0,
++ };
++
++ /*
++  * fd.io coding-style-patch-verification: ON
++  *
++  * Local Variables:
++  * eval: (c-set-style "gnu")
++  * End:
++  */
+diff --git a/src/plugins/pbl/pbl_client.h b/src/plugins/pbl/pbl_client.h
+new file mode 100644
+index 000000000..431bdc53b
+--- /dev/null
++++ b/src/plugins/pbl/pbl_client.h
+@@ -0,0 +1,191 @@
++/*
++ * Copyright (c) 2020 Cisco and/or its affiliates.
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at:
++ *
++ *     http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ */
++
++#ifndef __PBL_CLIENT_H__
++#define __PBL_CLIENT_H__
++
++#include <vnet/ip/ip_types.h>
++#include <vnet/fib/fib_node.h>
++
++/* This should be strictly lower than FIB_SOURCE_INTERFACE
++ * from fib_source.h */
++#define PBL_FIB_SOURCE_PRIORITY FIB_SOURCE_SPECIAL
++
++typedef enum pbl_client_port_map_proto_t_
++{
++  PBL_CLIENT_PORT_MAP_TCP,
++  PBL_CLIENT_PORT_MAP_UDP,
++  PBL_CLIENT_PORT_MAP_N_PROTOS,
++  PBL_CLIENT_PORT_MAP_UNKNOWN = 255,
++} pbl_client_port_map_proto_t;
++
++/**
++ * A Translation represents the client of a VEP to one of a set
++ * of real server addresses
++ */
++typedef struct pbl_client_t_
++{
++  CLIB_CACHE_LINE_ALIGN_MARK (cacheline0);
++
++  /* Linkage into the FIB graph */
++  fib_node_t pc_node;
++
++  /**
++   * FIB hook for intercepting traffic
++   */
++
++  /* The address we intercept traffic to */
++  ip_address_t pc_addr;
++
++  /* How to send packets to this client post client */
++  dpo_id_t pc_parent;
++
++  /* the FIB entry this client sources */
++  fib_node_index_t pc_fei;
++
++  /* number of DPO locks */
++  u32 pc_locks;
++
++  /**
++   * Parent pbl_client index if cloned via interpose
++   * or own index if vanilla client.
++   * Used to get clients & update session_refcnt
++   */
++  index_t clone_pci;
++
++  /* Matched ports that will forward to pc_dpo */
++  clib_bitmap_t *pc_port_maps[PBL_CLIENT_PORT_MAP_N_PROTOS];
++
++  /**
++   * Forwarding
++   */
++
++  /* Sibling index on the path-list */
++  u32 pc_sibling;
++
++  /* The DPO actually used for forwarding */
++  dpo_id_t pc_dpo;
++
++  /* The path-list describing how to forward in case of a match */
++  fib_node_index_t pc_pl;
++
++  /* Own index (if copied for trace) */
++  index_t pc_index;
++
++  /* Client flags */
++  u8 flags;
++
++} pbl_client_t;
++
++typedef enum pbl_client_flag_t_
++{
++  /* Has this translation been satcked ?
++   * this allow not being called twice when
++   * with more then FIB_PATH_LIST_POPULAR backends  */
++  PBL_CLIENT_STACKED = (1 << 0),
++} pbl_client_flag_t;
++
++typedef struct pbl_client_update_args_t_
++{
++  index_t pci;
++  ip_address_t addr;
++  clib_bitmap_t *port_maps[PBL_CLIENT_PORT_MAP_N_PROTOS];
++  fib_route_path_t *rpaths;
++  u32 table_id;
++  u8 flags;
++} pbl_client_update_args_t;
++
++extern pbl_client_t *pbl_client_pool;
++
++/**
++ * create or update a client
++ *
++ * @param vip The Virtual Endpoint
++ * @param ip_proto The ip protocol to translate
++ * @param backends the backends to choose from
++ *
++ * @return the ID of the client. used to delete and gather stats
++ */
++extern u32 pbl_client_update (pbl_client_update_args_t *args);
++
++/**
++ * Delete a client
++ *
++ * @param id the ID as returned from the create
++ */
++extern int pbl_client_delete (u32 id);
++
++/**
++ * Callback function invoked during a walk of all clients
++ */
++typedef walk_rc_t (*pbl_client_walk_cb_t) (index_t index, void *ctx);
++
++/**
++ * Walk/visit each of the clients
++ */
++extern void pbl_client_walk (pbl_client_walk_cb_t cb, void *ctx);
++
++/**
++ * Purge all the trahslations
++ */
++extern int pbl_client_purge (void);
++
++static_always_inline pbl_client_port_map_proto_t
++pbl_iproto_to_port_map_proto (ip_protocol_t iproto)
++{
++  switch (iproto)
++    {
++    case IP_PROTOCOL_TCP:
++      return PBL_CLIENT_PORT_MAP_TCP;
++    case IP_PROTOCOL_UDP:
++      return PBL_CLIENT_PORT_MAP_UDP;
++    default:
++      return PBL_CLIENT_PORT_MAP_UNKNOWN;
++    }
++}
++
++/*
++ * Data plane functions
++ */
++
++static_always_inline pbl_client_t *
++pbl_client_get (index_t cti)
++{
++  return (pool_elt_at_index (pbl_client_pool, cti));
++}
++
++static_always_inline pbl_client_t *
++pbl_client_get_if_exists (index_t cti)
++{
++  if (pool_is_free_index (pbl_client_pool, cti))
++    return (NULL);
++  return (pool_elt_at_index (pbl_client_pool, cti));
++}
++
++typedef enum
++{
++  /* IP already present in the FIB, need to interpose dpo */
++  PBL_FLAG_EXCLUSIVE = (1 << 1),
++} pbl_entry_flag_t;
++
++/*
++ * fd.io coding-style-patch-verification: ON
++ *
++ * Local Variables:
++ * eval: (c-set-style "gnu")
++ * End:
++ */
++
++#endif
+diff --git a/src/plugins/pbl/pbl_error.def b/src/plugins/pbl/pbl_error.def
+new file mode 100644
+index 000000000..b135bf03c
+--- /dev/null
++++ b/src/plugins/pbl/pbl_error.def
+@@ -0,0 +1,16 @@
++/*
++ * Copyright (c) 2021 Cisco and/or its affiliates.
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at:
++ *
++ *     http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ */
++
++pbl_error (NONE, "no error")
+\ No newline at end of file
+diff --git a/src/plugins/pbl/pbl_node.c b/src/plugins/pbl/pbl_node.c
+new file mode 100644
+index 000000000..478584019
+--- /dev/null
++++ b/src/plugins/pbl/pbl_node.c
+@@ -0,0 +1,183 @@
++/*
++ * Copyright (c) 2020 Cisco and/or its affiliates.
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at:
++ *
++ *     http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ */
++
++#include <vlibmemory/api.h>
++#include <vnet/dpo/load_balance.h>
++#include <vnet/dpo/load_balance_map.h>
++
++#include <cnat/cnat_session.h>
++#include <cnat/cnat_client.h>
++#include <cnat/cnat_inline.h>
++#include <cnat/cnat_translation.h>
++
++#include <vnet/ip/ip4_inlines.h>
++#include <vnet/ip/ip6_inlines.h>
++
++#include <pbl/pbl_client.h>
++
++typedef enum pbl_translation_next_t_
++{
++  PBL_NEXT_DROP,
++  PBL_NEXT_LOOKUP,
++  PBL_TRANSLATION_N_NEXT,
++} pbl_translation_next_t;
++
++vlib_node_registration_t pbl_vip_ip4_node;
++vlib_node_registration_t pbl_vip_ip6_node;
++
++typedef struct
++{
++  u8 matched;
++} pbl_trace_t;
++
++static u8 *
++format_pbl_trace (u8 *s, va_list *args)
++{
++  vlib_main_t *__clib_unused vm = va_arg (*args, vlib_main_t *);
++  vlib_node_t *__clib_unused node = va_arg (*args, vlib_node_t *);
++  pbl_trace_t *t = va_arg (*args, pbl_trace_t *);
++  if (t->matched)
++    s = format (s, "matched PBL client");
++  else
++    s = format (s, "no match");
++  return s;
++}
++
++/* CNat sub for NAT behind a fib entry (VIP or interposed real IP) */
++static uword
++pbl_node_inline (vlib_main_t *vm, vlib_node_runtime_t *node,
++		 vlib_frame_t *frame, ip_address_family_t af, u8 do_trace)
++{
++
++  u32 n_left, *from;
++  vlib_buffer_t *bufs[VLIB_FRAME_SIZE];
++  vlib_buffer_t **b = bufs;
++  u16 nexts[VLIB_FRAME_SIZE], *next;
++  pbl_trace_t *t;
++  int matched = 0;
++
++  from = vlib_frame_vector_args (frame);
++  n_left = frame->n_vectors;
++  next = nexts;
++  vlib_get_buffers (vm, from, bufs, n_left);
++
++  while (n_left > 0)
++    {
++      ip4_header_t *ip4 = NULL;
++      ip6_header_t *ip6 = NULL;
++      pbl_client_port_map_proto_t proto;
++      udp_header_t *udp0;
++      pbl_client_t *pc;
++
++      if (AF_IP4 == af)
++	{
++	  ip4 = vlib_buffer_get_current (b[0]);
++	  proto = pbl_iproto_to_port_map_proto (ip4->protocol);
++	  udp0 = (udp_header_t *) (ip4 + 1);
++	}
++      else
++	{
++	  ip6 = vlib_buffer_get_current (b[0]);
++	  proto = pbl_iproto_to_port_map_proto (ip6->protocol);
++	  udp0 = (udp_header_t *) (ip6 + 1);
++	}
++
++      pc = pbl_client_get (vnet_buffer (b[0])->ip.adj_index[VLIB_TX]);
++      if (proto < PBL_CLIENT_PORT_MAP_N_PROTOS &&
++	  clib_bitmap_get (pc->pc_port_maps[proto],
++			   clib_net_to_host_u16 (udp0->dst_port)))
++	{
++	  /* matched */
++	  next[0] = pc->pc_dpo.dpoi_next_node;
++	  vnet_buffer (b[0])->ip.adj_index[VLIB_TX] = pc->pc_dpo.dpoi_index;
++	  matched = 1;
++	  goto trace;
++	}
++
++      /* Dont translate & Follow the fib programming */
++      matched = 0;
++      vnet_buffer (b[0])->ip.adj_index[VLIB_TX] = pc->pc_parent.dpoi_index;
++      next[0] = pc->pc_parent.dpoi_next_node;
++
++    trace:
++
++      if (do_trace)
++	{
++	  t = vlib_add_trace (vm, node, b[0], sizeof (*t));
++	  t->matched = matched;
++	}
++
++      b++;
++      next++;
++      n_left--;
++    }
++
++  vlib_buffer_enqueue_to_next (vm, node, from, nexts, frame->n_vectors);
++
++  return frame->n_vectors;
++}
++
++VLIB_NODE_FN (pbl_vip_ip4_node)
++(vlib_main_t *vm, vlib_node_runtime_t *node, vlib_frame_t *frame)
++{
++  if (PREDICT_FALSE ((node->flags & VLIB_NODE_FLAG_TRACE)))
++    return pbl_node_inline (vm, node, frame, AF_IP4, 1 /* do_trace */);
++  return pbl_node_inline (vm, node, frame, AF_IP4, 0 /* do_trace */);
++}
++
++VLIB_NODE_FN (pbl_vip_ip6_node)
++(vlib_main_t *vm, vlib_node_runtime_t *node, vlib_frame_t *frame)
++{
++  if (PREDICT_FALSE ((node->flags & VLIB_NODE_FLAG_TRACE)))
++    return pbl_node_inline (vm, node, frame, AF_IP6, 1 /* do_trace */);
++  return pbl_node_inline (vm, node, frame, AF_IP6, 0 /* do_trace */);
++}
++
++VLIB_REGISTER_NODE (pbl_vip_ip4_node) =
++{
++  .name = "ip4-pbl-tx",
++  .vector_size = sizeof (u32),
++  .format_trace = format_pbl_trace,
++  .type = VLIB_NODE_TYPE_INTERNAL,
++  .n_errors = 0,
++  .n_next_nodes = PBL_TRANSLATION_N_NEXT,
++  .next_nodes =
++  {
++    [PBL_NEXT_DROP] = "ip4-drop",
++    [PBL_NEXT_LOOKUP] = "ip4-lookup",
++  },
++};
++VLIB_REGISTER_NODE (pbl_vip_ip6_node) =
++{
++  .name = "ip6-pbl-tx",
++  .vector_size = sizeof (u32),
++  .format_trace = format_pbl_trace,
++  .type = VLIB_NODE_TYPE_INTERNAL,
++  .n_errors = 0,
++  .n_next_nodes = PBL_TRANSLATION_N_NEXT,
++  .next_nodes =
++  {
++    [PBL_NEXT_DROP] = "ip6-drop",
++    [PBL_NEXT_LOOKUP] = "ip6-lookup",
++  },
++};
++
++/*
++ * fd.io coding-style-patch-verification: ON
++ *
++ * Local Variables:
++ * eval: (c-set-style "gnu")
++ * End:
++ */
+-- 
+2.38.0
+

--- a/vpplink/binapi/patches/0002-cnat-WIP-no-k8s-maglev-from-pods.patch
+++ b/vpplink/binapi/patches/0002-cnat-WIP-no-k8s-maglev-from-pods.patch
@@ -1,0 +1,49 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nathan Skrzypczak <nathan.skrzypczak@gmail.com>
+Date: Mon, 8 Mar 2021 19:00:04 +0100
+Subject: [PATCH 2/4] cnat: [WIP] no k8s maglev from pods
+
+Type: improvement
+
+Change-Id: If0702dbc51c308f0bb0ed16149c293d7adf9a984
+Signed-off-by: Nathan Skrzypczak <nathan.skrzypczak@gmail.com>
+---
+ src/plugins/cnat/cnat_node_feature.c | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/src/plugins/cnat/cnat_node_feature.c b/src/plugins/cnat/cnat_node_feature.c
+index 76aa89398..fd3b90a1a 100644
+--- a/src/plugins/cnat/cnat_node_feature.c
++++ b/src/plugins/cnat/cnat_node_feature.c
+@@ -43,6 +43,7 @@ cnat_input_feature_fn (vlib_main_t *vm, vlib_node_runtime_t *node,
+ 		       int session_not_found, cnat_session_t *session)
+ {
+   vlib_combined_counter_main_t *cntm = &cnat_translation_counters;
++  cnat_snat_policy_main_t *cpm = &cnat_snat_policy_main;
+   const cnat_translation_t *ct = NULL;
+   ip4_header_t *ip4 = NULL;
+   ip_protocol_t iproto;
+@@ -53,6 +54,9 @@ cnat_input_feature_fn (vlib_main_t *vm, vlib_node_runtime_t *node,
+   index_t cti;
+   u8 trace_flags = 0;
+ 
++  u32 in_if = vnet_buffer (b)->sw_if_index[VLIB_RX];
++  int ispod;
++
+   /* By default follow arc default next */
+   vnet_feature_next (&next0, b);
+ 
+@@ -127,7 +131,9 @@ cnat_input_feature_fn (vlib_main_t *vm, vlib_node_runtime_t *node,
+       session->value.cs_port[VLIB_RX] = udp0->src_port;
+       session->value.flags = 0;
+ 
+-      if (trk0->ct_flags & CNAT_TRK_FLAG_NO_NAT)
++      ispod = clib_bitmap_get (
++	cpm->interface_maps[CNAT_SNAT_IF_MAP_INCLUDE_POD], in_if);
++      if (trk0->ct_flags & CNAT_TRK_FLAG_NO_NAT && !ispod)
+ 	{
+ 	  const dpo_id_t *dpo0;
+ 	  const load_balance_t *lb1;
+-- 
+2.38.0
+

--- a/vpplink/binapi/patches/0003-acl-acl-plugin-custom-policies.patch
+++ b/vpplink/binapi/patches/0003-acl-acl-plugin-custom-policies.patch
@@ -1,0 +1,810 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrew Yourtchenko <ayourtch@gmail.com>
+Date: Tue, 28 Jul 2020 10:23:06 +0000
+Subject: [PATCH 3/4] acl: acl-plugin custom policies
+
+Type: feature
+Change-Id: I3117e84d9e822b68b12265e9261992e4d7f50f0f
+Signed-off-by: Andrew Yourtchenko <ayourtch@gmail.com>
+Signed-off-by: Aloys Augustin <aloaugus@cisco.com>
+---
+ src/plugins/acl/CMakeLists.txt   |   2 +
+ src/plugins/acl/acl.c            |  27 +++-
+ src/plugins/acl/acl.h            |  21 ++-
+ src/plugins/acl/acl_caiop.c      | 249 +++++++++++++++++++++++++++++++
+ src/plugins/acl/acl_caiop.h      |  18 +++
+ src/plugins/acl/acl_util.h       |  17 +++
+ src/plugins/acl/dataplane_node.c | 194 ++++++++++++++++--------
+ src/plugins/acl/exported_types.h |  29 +++-
+ src/plugins/acl/lookup_context.c |   9 +-
+ 9 files changed, 489 insertions(+), 77 deletions(-)
+ create mode 100644 src/plugins/acl/acl_caiop.c
+ create mode 100644 src/plugins/acl/acl_caiop.h
+ create mode 100644 src/plugins/acl/acl_util.h
+
+diff --git a/src/plugins/acl/CMakeLists.txt b/src/plugins/acl/CMakeLists.txt
+index c43dd23ea..44e4e6a60 100644
+--- a/src/plugins/acl/CMakeLists.txt
++++ b/src/plugins/acl/CMakeLists.txt
+@@ -20,6 +20,8 @@ add_vpp_plugin(acl
+   dataplane_node.c
+   dataplane_node_nonip.c
+ 
++  acl_caiop.c
++
+   MULTIARCH_SOURCES
+   dataplane_node.c
+   dataplane_node_nonip.c
+diff --git a/src/plugins/acl/acl.c b/src/plugins/acl/acl.c
+index 064741c32..aa1b620b2 100644
+--- a/src/plugins/acl/acl.c
++++ b/src/plugins/acl/acl.c
+@@ -39,6 +39,7 @@
+ 
+ #include "fa_node.h"
+ #include "public_inlines.h"
++#include "acl_caiop.h"
+ 
+ acl_main_t acl_main;
+ 
+@@ -521,6 +522,11 @@ acl_clear_sessions (acl_main_t * am, u32 sw_if_index)
+ 			     sw_if_index);
+ }
+ 
++void
++acl_plugin_wip_clear_sessions (u32 sw_if_index)
++{
++  acl_clear_sessions (&acl_main, sw_if_index);
++}
+ 
+ static int
+ acl_interface_in_enable_disable (acl_main_t * am, u32 sw_if_index,
+@@ -605,8 +611,8 @@ acl_stats_intf_counters_enable_disable (acl_main_t * am, int enable_disable)
+   return rv;
+ }
+ 
+-static int
+-acl_interface_inout_enable_disable (acl_main_t * am, u32 sw_if_index,
++int
++acl_interface_inout_enable_disable (acl_main_t *am, u32 sw_if_index,
+ 				    int is_input, int enable_disable)
+ {
+   if (is_input)
+@@ -615,6 +621,12 @@ acl_interface_inout_enable_disable (acl_main_t * am, u32 sw_if_index,
+     return acl_interface_out_enable_disable (am, sw_if_index, enable_disable);
+ }
+ 
++int
++is_acl_enabled_on_sw_if_index (u32 sw_if_index, int is_input)
++{
++  return 1; /* TODO */
++}
++
+ static int
+ acl_is_not_defined (acl_main_t * am, u32 acl_list_index)
+ {
+@@ -751,8 +763,11 @@ acl_interface_set_inout_acl_list (acl_main_t * am, u32 sw_if_index,
+ 	}
+     }
+   /* ensure ACL processing is enabled/disabled as needed */
++  int feature_enable =
++    is_acl_caiop_enabled_on_sw_if_index (sw_if_index, is_input) ||
++    (vec_len (vec_acl_list_index) > 0);
+   acl_interface_inout_enable_disable (am, sw_if_index, is_input,
+-				      vec_len (vec_acl_list_index) > 0);
++				      feature_enable);
+ 
+ done:
+   clib_bitmap_free (change_acl_bitmap);
+@@ -3403,6 +3418,10 @@ acl_plugin_show_sessions (acl_main_t * am,
+ 		   ((f64) am->fa_current_cleaner_timer_wait_interval) *
+ 		   1000.0 / (f64) vm->clib_time.clocks_per_second);
+   vlib_cli_output (vm, "Reclassify sessions: %d", am->reclassify_sessions);
++  vlib_cli_output (vm, "Custom access input policies: %d",
++		   am->custom_access_input_policies_count);
++  vlib_cli_output (vm, "Custom access output policies: %d",
++		   am->custom_access_output_policies_count);
+ }
+ 
+ static clib_error_t *
+@@ -3718,6 +3737,8 @@ acl_init (vlib_main_t * vm)
+     ACL_FA_CONN_TABLE_DEFAULT_HASH_MEMORY_SIZE;
+   am->fa_conn_table_max_entries = ACL_FA_CONN_TABLE_DEFAULT_MAX_ENTRIES;
+   am->reclassify_sessions = 0;
++  am->custom_access_input_policies_count = 0;
++  am->custom_access_output_policies_count = 0;
+   vlib_thread_main_t *tm = vlib_get_thread_main ();
+ 
+   am->fa_min_deleted_sessions_per_interval =
+diff --git a/src/plugins/acl/acl.h b/src/plugins/acl/acl.h
+index c540bf8fb..440097899 100644
+--- a/src/plugins/acl/acl.h
++++ b/src/plugins/acl/acl.h
+@@ -113,6 +113,11 @@ typedef struct
+   u8 from_tm;
+ } ace_mask_type_entry_t;
+ 
++/* This is a private experimental type, subject to change */
++typedef int (*acl_plugin_private_caiop_match_5tuple_func_t) (
++  void *p_acl_main, u32 sw_if_index, u32 is_inbound,
++  fa_5tuple_opaque_t *pkt_5tuple, int is_ip6, u8 *r_action, u32 *trace_bitmap);
++
+ typedef struct {
+   /* API message ID base */
+   u16 msg_id_base;
+@@ -168,7 +173,18 @@ typedef struct {
+   /* whether we need to take the epoch of the session into account */
+   int reclassify_sessions;
+ 
++  /* activation of dataplane for custom policies  when > 0 */
++  int custom_access_input_policies_count;
++  int custom_access_output_policies_count;
++  /* bitmaps when set the processing is enabled on the interface */
++  uword *caip_on_sw_if_index;
++  uword *caop_on_sw_if_index;
+ 
++  /* CAIOP match function vectors by sw_if_index */
++  acl_plugin_private_caiop_match_5tuple_func_t *
++    *caip_match_func_by_sw_if_index;
++  acl_plugin_private_caiop_match_5tuple_func_t *
++    *caop_match_func_by_sw_if_index;
+ 
+   /* Total count of interface+direction pairs enabled */
+   u32 fa_total_enabled_count;
+@@ -376,7 +392,10 @@ typedef enum {
+   ACL_FA_N_REQ,
+ } acl_fa_sess_req_t;
+ 
++int acl_interface_inout_enable_disable (acl_main_t *am, u32 sw_if_index,
++					int is_input, int enable_disable);
++int is_acl_enabled_on_sw_if_index (u32 sw_if_index, int is_input);
+ void aclp_post_session_change_request(acl_main_t *am, u32 target_thread, u32 target_session, acl_fa_sess_req_t request_type);
+ void aclp_swap_wip_and_pending_session_change_requests(acl_main_t *am, u32 target_thread);
+-
++void acl_plugin_wip_clear_sessions (u32 sw_if_index);
+ #endif
+diff --git a/src/plugins/acl/acl_caiop.c b/src/plugins/acl/acl_caiop.c
+new file mode 100644
+index 000000000..fa11d32a0
+--- /dev/null
++++ b/src/plugins/acl/acl_caiop.c
+@@ -0,0 +1,249 @@
++/*
++ * Copyright (c) 2016-2018 Cisco and/or its affiliates.
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at:
++ *
++ *     http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ */
++#include <stddef.h>
++#include <netinet/in.h>
++
++#include <vlib/vlib.h>
++#include <vnet/vnet.h>
++#include <vnet/pg/pg.h>
++#include <vppinfra/error.h>
++
++#include <acl/acl.h>
++#include <vnet/ip/icmp46_packet.h>
++
++#include <plugins/acl/fa_node.h>
++#include <plugins/acl/acl.h>
++#include <plugins/acl/lookup_context.h>
++#include <plugins/acl/public_inlines.h>
++#include <plugins/acl/session_inlines.h>
++#include <plugins/acl/acl_util.h>
++#include <plugins/acl/acl_caiop.h>
++
++int
++is_acl_caiop_enabled_on_sw_if_index (u32 sw_if_index, int is_input)
++{
++  acl_main_t *am = &acl_main;
++  int ret = 0;
++  if (is_input)
++    {
++      ret = clib_bitmap_get (am->caip_on_sw_if_index, sw_if_index);
++    }
++  else
++    {
++      ret = clib_bitmap_get (am->caop_on_sw_if_index, sw_if_index);
++    }
++  return ret;
++}
++
++void
++acl_caiop_enable_disable (u32 sw_if_index, int is_input, int enable_disable)
++{
++  acl_main_t *am = &acl_main;
++
++  if (is_input)
++    {
++      ASSERT (clib_bitmap_get (am->caip_on_sw_if_index, sw_if_index) !=
++	      enable_disable);
++      am->caip_on_sw_if_index =
++	clib_bitmap_set (am->caip_on_sw_if_index, sw_if_index, enable_disable);
++    }
++  else
++    {
++      ASSERT (clib_bitmap_get (am->caop_on_sw_if_index, sw_if_index) !=
++	      enable_disable);
++      am->caop_on_sw_if_index =
++	clib_bitmap_set (am->caop_on_sw_if_index, sw_if_index, enable_disable);
++    }
++}
++
++static int
++not_found (u32 index)
++{
++  return (index == ((u32) ~0));
++}
++
++static int
++caiop_add (u32 sw_if_index, int is_input,
++	   acl_plugin_private_caiop_match_5tuple_func_t func)
++{
++  acl_main_t *am = &acl_main;
++  acl_plugin_private_caiop_match_5tuple_func_t ***pvecvec =
++    is_input ? &am->caip_match_func_by_sw_if_index :
++	       &am->caop_match_func_by_sw_if_index;
++  uword **pbitmap =
++    is_input ? &am->caip_on_sw_if_index : &am->caop_on_sw_if_index;
++  int *pcount = is_input ? &am->custom_access_input_policies_count :
++			   &am->custom_access_output_policies_count;
++
++  vec_validate (*pvecvec, sw_if_index);
++  u32 index = vec_search ((*pvecvec)[sw_if_index], func);
++  if (not_found (index))
++    {
++      vec_add1 ((*pvecvec)[sw_if_index], func);
++      *pbitmap = clib_bitmap_set (*pbitmap, sw_if_index, 1);
++      (*pcount)++;
++      return acl_interface_inout_enable_disable (am, sw_if_index, is_input, 1);
++    }
++  else
++    {
++      clib_warning ("Existing Index: %d", index);
++      return -2;
++    }
++}
++
++static int
++caiop_del (u32 sw_if_index, int is_input,
++	   acl_plugin_private_caiop_match_5tuple_func_t func)
++{
++  acl_main_t *am = &acl_main;
++  acl_plugin_private_caiop_match_5tuple_func_t ***pvecvec =
++    is_input ? &am->caip_match_func_by_sw_if_index :
++	       &am->caop_match_func_by_sw_if_index;
++  uword **pbitmap =
++    is_input ? &am->caip_on_sw_if_index : &am->caop_on_sw_if_index;
++  int *pcount = is_input ? &am->custom_access_input_policies_count :
++			   &am->custom_access_output_policies_count;
++
++  if (sw_if_index >= vec_len (*pvecvec))
++    {
++      return -2;
++    }
++  else
++    {
++      u32 index = vec_search ((*pvecvec)[sw_if_index], func);
++      if (not_found (index))
++	{
++	  return -3;
++	}
++      else
++	{
++	  vec_del1 ((*pvecvec)[sw_if_index], index);
++	  *pbitmap = clib_bitmap_set (*pbitmap, sw_if_index, 0);
++	  (*pcount)--;
++	  int enable = (*pcount > 0) ||
++		       is_acl_enabled_on_sw_if_index (sw_if_index, is_input);
++	  return acl_interface_inout_enable_disable (am, sw_if_index, is_input,
++						     enable);
++	}
++    }
++}
++
++int
++acl_caiop_add_del (int is_add, u32 sw_if_index, int is_input,
++		   acl_plugin_private_caiop_match_5tuple_func_t func)
++{
++  acl_main_t *am = &acl_main;
++  if (!vnet_sw_interface_is_api_valid (am->vnet_main, sw_if_index))
++    {
++      return -1;
++    }
++  return is_add ? caiop_add (sw_if_index, is_input, func) :
++		  caiop_del (sw_if_index, is_input, func);
++}
++
++void
++show_custom_access_policies (vlib_main_t *vm, u32 verbose)
++{
++  acl_main_t *am = &acl_main;
++  int i;
++  vlib_cli_output (vm, "\nCustom access policies:");
++  acl_cli_output_u (vm, am->custom_access_input_policies_count);
++  acl_cli_output_u (vm, am->custom_access_output_policies_count);
++  acl_cli_output_bitmap (vm, am->caip_on_sw_if_index);
++  acl_cli_output_bitmap (vm, am->caop_on_sw_if_index);
++  for (i = 0; i < vec_len (am->caip_match_func_by_sw_if_index); i++)
++    {
++      if (i == 0)
++	{
++	  vlib_cli_output (vm, "\n input function pointers:");
++	}
++      vlib_cli_output (vm, "sw_if_index: %d vector: %U", i, format_vec_uword,
++		       am->caip_match_func_by_sw_if_index[i], "%p");
++    }
++  for (i = 0; i < vec_len (am->caop_match_func_by_sw_if_index); i++)
++    {
++      if (i == 0)
++	{
++	  vlib_cli_output (vm, "\n output function pointers:");
++	}
++      vlib_cli_output (vm, "sw_if_index: %d vector: %U", i, format_vec_uword,
++		       am->caop_match_func_by_sw_if_index[i], "%p");
++    }
++}
++
++static clib_error_t *
++acl_show_custom_access_policies_fn (vlib_main_t *vm, unformat_input_t *input,
++				    vlib_cli_command_t *cmd)
++{
++  clib_error_t *error = 0;
++
++  u32 show_policies_verbose = 0;
++  (void) unformat (input, "verbose %u", &show_policies_verbose);
++
++  show_custom_access_policies (vm, show_policies_verbose);
++  return error;
++}
++
++static int
++dummy_match_5tuple_fun (void *p_acl_main, u32 sw_if_index, u32 is_inbound,
++			fa_5tuple_opaque_t *pkt_5tuple, int is_ip6,
++			u8 *r_action, u32 *trace_bitmap)
++{
++  /* permit and create connection */
++  *r_action = 2;
++  return 1;
++}
++
++static clib_error_t *
++acl_test_custom_access_policy_fn (vlib_main_t *vm, unformat_input_t *input,
++				  vlib_cli_command_t *cmd)
++{
++  clib_error_t *error = 0;
++  int is_del = unformat (input, "del");
++  int is_input = unformat (input, "input");
++  u32 sw_if_index = ~0;
++  (void) unformat (input, "sw_if_index %u", &sw_if_index);
++  vlib_cli_output (vm, "Test %s %s sw_if_index: %d", is_del ? "del" : "add",
++		   is_input ? "input" : "output", sw_if_index);
++  u32 ret =
++    acl_caiop_add_del (!is_del, sw_if_index, is_input, dummy_match_5tuple_fun);
++  if (ret != 0)
++    {
++      error = clib_error_return (0, "non-zero ret code: %d", ret);
++    }
++
++  return error;
++}
++
++VLIB_CLI_COMMAND (aclplugin_set_custom_policy_command, static) = {
++  .path = "show acl-plugin custom-access-policies",
++  .short_help = "show acl-plugin custom-access-policies [verbose]",
++  .function = acl_show_custom_access_policies_fn,
++};
++
++VLIB_CLI_COMMAND (aclplugin_test_custom_policy_command, static) = {
++  .path = "test acl-plugin custom-access-policy",
++  .short_help =
++    "test acl-plugin custom-access-policy [del] [input] [sw_if_index <N>]",
++  .function = acl_test_custom_access_policy_fn,
++};
++
++/*
++ * fd.io coding-style-patch-verification: ON
++ *
++ * Local Variables:
++ * eval: (c-set-style "gnu")
++ * End:
++ */
+diff --git a/src/plugins/acl/acl_caiop.h b/src/plugins/acl/acl_caiop.h
+new file mode 100644
+index 000000000..d26f39d6d
+--- /dev/null
++++ b/src/plugins/acl/acl_caiop.h
+@@ -0,0 +1,18 @@
++#ifndef vpp_acl_caiop_h
++#define vpp_acl_caiop_h
++
++#include <plugins/acl/acl.h>
++
++int is_acl_caiop_enabled_on_sw_if_index (u32 sw_if_index, int is_input);
++int acl_caiop_add_del (int is_add, u32 sw_if_index, int is_input,
++		       acl_plugin_private_caiop_match_5tuple_func_t func);
++
++#endif
++
++/*
++ * fd.io coding-style-patch-verification: ON
++ *
++ * Local Variables:
++ * eval: (c-set-style "gnu")
++ * End:
++ */
+diff --git a/src/plugins/acl/acl_util.h b/src/plugins/acl/acl_util.h
+new file mode 100644
+index 000000000..843a671ad
+--- /dev/null
++++ b/src/plugins/acl/acl_util.h
+@@ -0,0 +1,17 @@
++#ifndef vpp_acl_plugin_util_h
++#define vpp_acl_plugin_util_h
++
++#define acl_cli_output_u(vm, value)                                           \
++  vlib_cli_output (vm, "  %s: %u", #value, value)
++#define acl_cli_output_bitmap(vm, bitmap)                                     \
++  vlib_cli_output (vm, "  %s bitmap: %U", #bitmap, format_bitmap_hex, bitmap)
++
++#endif
++
++/*
++ * fd.io coding-style-patch-verification: ON
++ *
++ * Local Variables:
++ * eval: (c-set-style "gnu")
++ * End:
++ */
+diff --git a/src/plugins/acl/dataplane_node.c b/src/plugins/acl/dataplane_node.c
+index 4bef8f077..4ccc2a4b1 100644
+--- a/src/plugins/acl/dataplane_node.c
++++ b/src/plugins/acl/dataplane_node.c
+@@ -25,6 +25,7 @@
+ 
+ #include <plugins/acl/fa_node.h>
+ #include <plugins/acl/acl.h>
++#include <plugins/acl/acl_caiop.h>
+ #include <plugins/acl/lookup_context.h>
+ #include <plugins/acl/public_inlines.h>
+ #include <plugins/acl/session_inlines.h>
+@@ -318,13 +319,12 @@ acl_fa_node_common_prepare_fn (vlib_main_t * vm,
+     }
+ }
+ 
+-
+ always_inline uword
+-acl_fa_inner_node_fn (vlib_main_t * vm,
+-		      vlib_node_runtime_t * node, vlib_frame_t * frame,
+-		      int is_ip6, int is_input, int is_l2_path,
+-		      int with_stateful_datapath, int node_trace_on,
+-		      int reclassify_sessions)
++acl_fa_inner_node_fn (vlib_main_t *vm, vlib_node_runtime_t *node,
++		      vlib_frame_t *frame, int is_ip6, int is_input,
++		      int is_l2_path, int with_stateful_datapath,
++		      int node_trace_on, int reclassify_sessions,
++		      const int do_custom_access_policies)
+ {
+   u32 n_left;
+   u32 pkts_exist_session = 0;
+@@ -465,39 +465,85 @@ acl_fa_inner_node_fn (vlib_main_t * vm,
+ 
+ 	  if (acl_check_needed)
+ 	    {
+-	      if (is_input)
+-		lc_index0 = am->input_lc_index_by_sw_if_index[sw_if_index[0]];
+-	      else
+-		lc_index0 =
+-		  am->output_lc_index_by_sw_if_index[sw_if_index[0]];
+-
+-	      action = 0;	/* deny by default */
+-	      int is_match = acl_plugin_match_5tuple_inline (am, lc_index0,
+-							     (fa_5tuple_opaque_t *) & fa_5tuple[0], is_ip6,
+-							     &action,
+-							     &match_acl_pos,
+-							     &match_acl_in_index,
+-							     &match_rule_index,
+-							     &trace_bitmap);
+-	      if (PREDICT_FALSE
+-		  (is_match && am->interface_acl_counters_enabled))
++	      if (do_custom_access_policies)
+ 		{
+-		  u32 buf_len = vlib_buffer_length_in_chain (vm, b[0]);
+-		  vlib_increment_combined_counter (am->combined_acl_counters +
+-						   saved_matched_acl_index,
+-						   thread_index,
+-						   saved_matched_ace_index,
+-						   saved_packet_count,
+-						   saved_byte_count);
+-		  saved_matched_acl_index = match_acl_in_index;
+-		  saved_matched_ace_index = match_rule_index;
+-		  saved_packet_count = 1;
+-		  saved_byte_count = buf_len;
+-		  /* prefetch the counter that we are going to increment */
+-		  vlib_prefetch_combined_counter (am->combined_acl_counters +
+-						  saved_matched_acl_index,
+-						  thread_index,
+-						  saved_matched_ace_index);
++		  if (is_acl_caiop_enabled_on_sw_if_index (sw_if_index[0],
++							   is_input))
++		    {
++		      acl_plugin_private_caiop_match_5tuple_func_t
++			*caiop_match_vec,
++			*pf;
++
++		      if (is_input)
++			{
++			  caiop_match_vec =
++			    vec_elt (am->caip_match_func_by_sw_if_index,
++				     sw_if_index[0]);
++			}
++		      else
++			{
++			  caiop_match_vec =
++			    vec_elt (am->caop_match_func_by_sw_if_index,
++				     sw_if_index[0]);
++			}
++		      vec_foreach (pf, caiop_match_vec)
++			{
++			  int is_match =
++			    (*pf) (am, sw_if_index[0], is_input,
++				   (fa_5tuple_opaque_t *) &fa_5tuple[0],
++				   is_ip6, &action, &trace_bitmap);
++			  if (is_match)
++			    {
++			      acl_check_needed = 0;
++			      break;
++			    }
++			}
++		      /* If no match in policy but no ACL configured, bypass
++		       * the ACL check, else it will crash */
++		      if (acl_check_needed)
++			{
++			  if (is_input)
++			    acl_check_needed =
++			      vec_len (am->input_lc_index_by_sw_if_index) >
++			      sw_if_index[0];
++			  else
++			    acl_check_needed =
++			      vec_len (am->output_lc_index_by_sw_if_index) >
++			      sw_if_index[0];
++			}
++		    }
++		}
++	      if (acl_check_needed)
++		{
++		  if (is_input)
++		    lc_index0 =
++		      am->input_lc_index_by_sw_if_index[sw_if_index[0]];
++		  else
++		    lc_index0 =
++		      am->output_lc_index_by_sw_if_index[sw_if_index[0]];
++
++		  action = 0; /* deny by default */
++		  int is_match = acl_plugin_match_5tuple_inline (
++		    am, lc_index0, (fa_5tuple_opaque_t *) &fa_5tuple[0],
++		    is_ip6, &action, &match_acl_pos, &match_acl_in_index,
++		    &match_rule_index, &trace_bitmap);
++		  if (PREDICT_FALSE (is_match &&
++				     am->interface_acl_counters_enabled))
++		    {
++		      u32 buf_len = vlib_buffer_length_in_chain (vm, b[0]);
++		      vlib_increment_combined_counter (
++			am->combined_acl_counters + saved_matched_acl_index,
++			thread_index, saved_matched_ace_index,
++			saved_packet_count, saved_byte_count);
++		      saved_matched_acl_index = match_acl_in_index;
++		      saved_matched_ace_index = match_rule_index;
++		      saved_packet_count = 1;
++		      saved_byte_count = buf_len;
++		      /* prefetch the counter that we are going to increment */
++		      vlib_prefetch_combined_counter (
++			am->combined_acl_counters + saved_matched_acl_index,
++			thread_index, saved_matched_ace_index);
++		    }
+ 		}
+ 
+ 	      b[0]->error = error_node->errors[action];
+@@ -582,11 +628,10 @@ acl_fa_inner_node_fn (vlib_main_t * vm,
+    * if we were had an acl match then we have a counter to increment.
+    * else it is all zeroes, so this will be harmless.
+    */
+-  vlib_increment_combined_counter (am->combined_acl_counters +
+-				   saved_matched_acl_index,
+-				   thread_index,
+-				   saved_matched_ace_index,
+-				   saved_packet_count, saved_byte_count);
++  if (am->combined_acl_counters && saved_packet_count)
++    vlib_increment_combined_counter (
++      am->combined_acl_counters + saved_matched_acl_index, thread_index,
++      saved_matched_ace_index, saved_packet_count, saved_byte_count);
+ 
+   vlib_node_increment_counter (vm, node->node_index,
+ 			       ACL_FA_ERROR_ACL_CHECK, frame->n_vectors);
+@@ -602,10 +647,10 @@ acl_fa_inner_node_fn (vlib_main_t * vm,
+ }
+ 
+ always_inline uword
+-acl_fa_outer_node_fn (vlib_main_t * vm,
+-		      vlib_node_runtime_t * node, vlib_frame_t * frame,
+-		      int is_ip6, int is_input, int is_l2_path,
+-		      int do_stateful_datapath)
++acl_fa_outer_node_fn (vlib_main_t *vm, vlib_node_runtime_t *node,
++		      vlib_frame_t *frame, int is_ip6, int is_input,
++		      int is_l2_path, int do_stateful_datapath,
++		      int do_custom_access_policies)
+ {
+   acl_main_t *am = &acl_main;
+ 
+@@ -615,25 +660,24 @@ acl_fa_outer_node_fn (vlib_main_t * vm,
+   if (am->reclassify_sessions)
+     {
+       if (PREDICT_FALSE (node->flags & VLIB_NODE_FLAG_TRACE))
+-	return acl_fa_inner_node_fn (vm, node, frame, is_ip6, is_input,
+-				     is_l2_path, do_stateful_datapath,
+-				     1 /* trace */ ,
+-				     1 /* reclassify */ );
++	return acl_fa_inner_node_fn (
++	  vm, node, frame, is_ip6, is_input, is_l2_path, do_stateful_datapath,
++	  1 /* trace */, 1 /* reclassify */, do_custom_access_policies);
+       else
+-	return acl_fa_inner_node_fn (vm, node, frame, is_ip6, is_input,
+-				     is_l2_path, do_stateful_datapath, 0,
+-				     1 /* reclassify */ );
++	return acl_fa_inner_node_fn (
++	  vm, node, frame, is_ip6, is_input, is_l2_path, do_stateful_datapath,
++	  0, 1 /* reclassify */, do_custom_access_policies);
+     }
+   else
+     {
+       if (PREDICT_FALSE (node->flags & VLIB_NODE_FLAG_TRACE))
+-	return acl_fa_inner_node_fn (vm, node, frame, is_ip6, is_input,
+-				     is_l2_path, do_stateful_datapath,
+-				     1 /* trace */ ,
+-				     0);
++	return acl_fa_inner_node_fn (
++	  vm, node, frame, is_ip6, is_input, is_l2_path, do_stateful_datapath,
++	  1 /* trace */, 0, do_custom_access_policies);
+       else
+ 	return acl_fa_inner_node_fn (vm, node, frame, is_ip6, is_input,
+-				     is_l2_path, do_stateful_datapath, 0, 0);
++				     is_l2_path, do_stateful_datapath, 0, 0,
++				     do_custom_access_policies);
+     }
+ }
+ 
+@@ -646,13 +690,35 @@ acl_fa_node_fn (vlib_main_t * vm,
+   acl_main_t *am = &acl_main;
+   acl_fa_per_worker_data_t *pw = &am->per_worker_data[vm->thread_index];
+   uword rv;
++  int do_custom_access_policies = 0;
++  if (is_input)
++    {
++      do_custom_access_policies = (am->custom_access_input_policies_count > 0);
++    }
++  else
++    {
++      do_custom_access_policies =
++	(am->custom_access_output_policies_count > 0);
++    }
+ 
+-  if (am->fa_sessions_hash_is_initialized)
+-    rv = acl_fa_outer_node_fn (vm, node, frame, is_ip6, is_input,
+-			       is_l2_path, 1);
++  if (do_custom_access_policies)
++    {
++      if (am->fa_sessions_hash_is_initialized)
++	rv = acl_fa_outer_node_fn (vm, node, frame, is_ip6, is_input,
++				   is_l2_path, 1, 1);
++      else
++	rv = acl_fa_outer_node_fn (vm, node, frame, is_ip6, is_input,
++				   is_l2_path, 0, 1);
++    }
+   else
+-    rv = acl_fa_outer_node_fn (vm, node, frame, is_ip6, is_input,
+-			       is_l2_path, 0);
++    {
++      if (am->fa_sessions_hash_is_initialized)
++	rv = acl_fa_outer_node_fn (vm, node, frame, is_ip6, is_input,
++				   is_l2_path, 1, 0);
++      else
++	rv = acl_fa_outer_node_fn (vm, node, frame, is_ip6, is_input,
++				   is_l2_path, 0, 0);
++    }
+ 
+   vlib_buffer_enqueue_to_next (vm, node, vlib_frame_vector_args (frame),
+ 			       pw->nexts, frame->n_vectors);
+diff --git a/src/plugins/acl/exported_types.h b/src/plugins/acl/exported_types.h
+index a5b1c3497..b052b818a 100644
+--- a/src/plugins/acl/exported_types.h
++++ b/src/plugins/acl/exported_types.h
+@@ -16,6 +16,9 @@
+ #ifndef included_acl_exported_types_h
+ #define included_acl_exported_types_h
+ 
++#include <vppinfra/types.h>
++#include <vlib/buffer.h>
++
+ /* 
+  * The overlay struct matching an internal type. Contents/size may change. 
+  * During the compile of the ACL plugin it is checked to have the same size
+@@ -74,15 +77,25 @@ typedef int (*acl_plugin_match_5tuple_fn_t) (u32 lc_index,
+                                            u32 * r_rule_match_p,
+                                            u32 * trace_bitmap);
+ 
++/*
++ * This is an experimental method, subject to change or disappear.
++ */
+ 
+-#define foreach_acl_plugin_exported_method_name \
+-_(acl_exists)                          \
+-_(register_user_module)                \
+-_(get_lookup_context_index)            \
+-_(put_lookup_context_index)            \
+-_(set_acl_vec_for_context)             \
+-_(fill_5tuple)                         \
+-_(match_5tuple)                        
++typedef int (*acl_plugin_wip_add_del_custom_access_io_policy_fn_t) (
++  int is_add, u32 sw_if_index, int is_input, void *func);
++
++typedef void (*acl_plugin_wip_clear_sessions_fn_t) (u32 sw_if_index);
++
++#define foreach_acl_plugin_exported_method_name                               \
++  _ (acl_exists)                                                              \
++  _ (register_user_module)                                                    \
++  _ (get_lookup_context_index)                                                \
++  _ (put_lookup_context_index)                                                \
++  _ (set_acl_vec_for_context)                                                 \
++  _ (wip_add_del_custom_access_io_policy)                                     \
++  _ (wip_clear_sessions)                                                      \
++  _ (fill_5tuple)                                                             \
++  _ (match_5tuple)
+ 
+ #define _(name) acl_plugin_ ## name ## _fn_t name;
+ typedef struct {
+diff --git a/src/plugins/acl/lookup_context.c b/src/plugins/acl/lookup_context.c
+index 8d1f3f20f..52641f9e7 100644
+--- a/src/plugins/acl/lookup_context.c
++++ b/src/plugins/acl/lookup_context.c
+@@ -14,6 +14,7 @@
+  */
+ 
+ #include <plugins/acl/acl.h>
++#include <plugins/acl/acl_caiop.h>
+ #include <plugins/acl/fa_node.h>
+ #include <vlib/unix/plugin.h>
+ #include <plugins/acl/public_inlines.h>
+@@ -282,7 +283,6 @@ void acl_plugin_lookup_context_notify_acl_change(u32 acl_num)
+   }
+ }
+ 
+-
+ /* Fill the 5-tuple from the packet */
+ 
+ static void acl_plugin_fill_5tuple (u32 lc_index, vlib_buffer_t * b0, int is_ip6, int is_input,
+@@ -302,6 +302,13 @@ static int acl_plugin_match_5tuple (u32 lc_index,
+   return acl_plugin_match_5tuple_inline (&acl_main, lc_index, pkt_5tuple, is_ip6, r_action, r_acl_pos_p, r_acl_match_p, r_rule_match_p, trace_bitmap);
+ }
+ 
++/* This is an experimental method, subject to change or disappear */
++static int
++acl_plugin_wip_add_del_custom_access_io_policy (int is_add, u32 sw_if_index,
++						int is_input, void *func)
++{
++  return acl_caiop_add_del (is_add, sw_if_index, is_input, func);
++}
+ 
+ void
+ acl_plugin_show_lookup_user (u32 user_index)
+-- 
+2.38.0
+

--- a/vpplink/binapi/patches/0004-capo-Calico-Policies-plugin.patch
+++ b/vpplink/binapi/patches/0004-capo-Calico-Policies-plugin.patch
@@ -1,0 +1,4992 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrew Yourtchenko <ayourtch@gmail.com>
+Date: Wed, 18 Aug 2021 20:10:22 +0200
+Subject: [PATCH 4/4] capo: Calico Policies plugin
+
+New plugin that implements Calico policies and profiles in VPP.
+
+Type: feature
+
+Change-Id: I49d9c2ee985eb0d4a55ca672da9916dc4afa89ef
+Signed-off-by: Andrew Yourtchenko <ayourtch@gmail.com>
+Signed-off-by: Nathan Skrzypczak <nathan.skrzypczak@gmail.com>
+Signed-off-by: Aloys Augustin <aloaugus@cisco.com>
+Signed-off-by: MathiasRaoul <mathias.raoul@gmail.com>
+---
+ MAINTAINERS                        |   5 +
+ src/plugins/capo/CMakeLists.txt    |  28 +
+ src/plugins/capo/bihash_8_24.h     | 107 ++++
+ src/plugins/capo/capo.api          | 260 ++++++++++
+ src/plugins/capo/capo.h            |  58 +++
+ src/plugins/capo/capo_api.c        | 444 ++++++++++++++++
+ src/plugins/capo/capo_interface.c  | 340 ++++++++++++
+ src/plugins/capo/capo_interface.h  |  40 ++
+ src/plugins/capo/capo_ipset.c      | 472 +++++++++++++++++
+ src/plugins/capo/capo_ipset.h      |  68 +++
+ src/plugins/capo/capo_match.c      | 736 ++++++++++++++++++++++++++
+ src/plugins/capo/capo_match.h      |  49 ++
+ src/plugins/capo/capo_policy.c     | 263 ++++++++++
+ src/plugins/capo/capo_policy.h     |  58 +++
+ src/plugins/capo/capo_rule.c       | 509 ++++++++++++++++++
+ src/plugins/capo/capo_rule.h       |  91 ++++
+ src/plugins/capo/capo_test.c       | 490 ++++++++++++++++++
+ src/plugins/capo/test/test_capo.py | 806 +++++++++++++++++++++++++++++
+ 18 files changed, 4824 insertions(+)
+ create mode 100644 src/plugins/capo/CMakeLists.txt
+ create mode 100644 src/plugins/capo/bihash_8_24.h
+ create mode 100644 src/plugins/capo/capo.api
+ create mode 100644 src/plugins/capo/capo.h
+ create mode 100644 src/plugins/capo/capo_api.c
+ create mode 100644 src/plugins/capo/capo_interface.c
+ create mode 100644 src/plugins/capo/capo_interface.h
+ create mode 100644 src/plugins/capo/capo_ipset.c
+ create mode 100644 src/plugins/capo/capo_ipset.h
+ create mode 100644 src/plugins/capo/capo_match.c
+ create mode 100644 src/plugins/capo/capo_match.h
+ create mode 100644 src/plugins/capo/capo_policy.c
+ create mode 100644 src/plugins/capo/capo_policy.h
+ create mode 100644 src/plugins/capo/capo_rule.c
+ create mode 100644 src/plugins/capo/capo_rule.h
+ create mode 100644 src/plugins/capo/capo_test.c
+ create mode 100644 src/plugins/capo/test/test_capo.py
+
+diff --git a/MAINTAINERS b/MAINTAINERS
+index a1f8fed22..27ac4b72a 100644
+--- a/MAINTAINERS
++++ b/MAINTAINERS
+@@ -738,6 +738,11 @@ M:	Nathan Skrzypczak <nathan.skrzypczak@gmail.com>
+ M:	Neale Ranns <neale@graphiant.com>
+ F:	src/plugins/cnat
+ 
++Plugin - Calico policies
++I:	capo
++M:	Aloys Augustin <aloaugus@cisco.com>
++F:	src/plugins/capo/
++
+ Plugin - Wireguard
+ I:	wireguard
+ M:	Artem Glazychev <artem.glazychev@xored.com>
+diff --git a/src/plugins/capo/CMakeLists.txt b/src/plugins/capo/CMakeLists.txt
+new file mode 100644
+index 000000000..9fa10f710
+--- /dev/null
++++ b/src/plugins/capo/CMakeLists.txt
+@@ -0,0 +1,28 @@
++# Copyright (c) 2020 Cisco and/or its affiliates.
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at:
++#
++#     http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++
++add_vpp_plugin(capo
++  SOURCES
++  capo_api.c
++  capo_policy.c
++  capo_rule.c
++  capo_ipset.c
++  capo_match.c
++  capo_interface.c
++
++  API_TEST_SOURCES
++  capo_test.c
++
++  API_FILES
++  capo.api
++)
+diff --git a/src/plugins/capo/bihash_8_24.h b/src/plugins/capo/bihash_8_24.h
+new file mode 100644
+index 000000000..79d1005bc
+--- /dev/null
++++ b/src/plugins/capo/bihash_8_24.h
+@@ -0,0 +1,107 @@
++/*
++ * Copyright (c) 2015 Cisco and/or its affiliates.
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at:
++ *
++ *     http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ */
++#undef BIHASH_TYPE
++#undef BIHASH_KVP_PER_PAGE
++#undef BIHASH_32_64_SVM
++#undef BIHASH_ENABLE_STATS
++#undef BIHASH_KVP_AT_BUCKET_LEVEL
++#undef BIHASH_LAZY_INSTANTIATE
++#undef BIHASH_BUCKET_PREFETCH_CACHE_LINES
++
++#define BIHASH_TYPE			   _8_24
++#define BIHASH_KVP_PER_PAGE		   4
++#define BIHASH_KVP_AT_BUCKET_LEVEL	   1
++#define BIHASH_LAZY_INSTANTIATE		   0
++#define BIHASH_BUCKET_PREFETCH_CACHE_LINES 2
++
++#ifndef __included_bihash_8_24_h__
++#define __included_bihash_8_24_h__
++
++#include <vppinfra/heap.h>
++#include <vppinfra/format.h>
++#include <vppinfra/pool.h>
++#include <vppinfra/xxhash.h>
++#include <vppinfra/crc32.h>
++
++/** 8 octet key, 32 octet key value pair */
++typedef struct
++{
++  u64 key;	/**< the key */
++  u64 value[3]; /**< the value */
++} clib_bihash_kv_8_24_t;
++
++/** Decide if a clib_bihash_kv_8_24_t instance is free
++    @param v- pointer to the (key,value) pair
++*/
++static inline int
++clib_bihash_is_free_8_24 (clib_bihash_kv_8_24_t *v)
++{
++  if (v->key == ~0ULL && v->value[0] == ~0ULL && v->value[1] == ~0ULL &&
++      v->value[2] == ~0ULL)
++    return 1;
++  return 0;
++}
++
++/** Hash a clib_bihash_kv_8_24_t instance
++    @param v - pointer to the (key,value) pair, hash the key (only)
++*/
++static inline u64
++clib_bihash_hash_8_24 (clib_bihash_kv_8_24_t *v)
++{
++  /* Note: to torture-test linear scan, make this fn return a constant */
++#ifdef clib_crc32c_uses_intrinsics
++  return clib_crc32c ((u8 *) &v->key, 8);
++#else
++  return clib_xxhash (v->key);
++#endif
++}
++
++/** Format a clib_bihash_kv_8_24_t instance
++    @param s - u8 * vector under construction
++    @param args (vararg) - the (key,value) pair to format
++    @return s - the u8 * vector under construction
++*/
++static inline u8 *
++format_bihash_kvp_8_24 (u8 *s, va_list *args)
++{
++  clib_bihash_kv_8_24_t *v = va_arg (*args, clib_bihash_kv_8_24_t *);
++
++  s = format (s, "key %lu value %lu %lu %lu", v->key, v->value[0], v->value[1],
++	      v->value[2]);
++  return s;
++}
++
++/** Compare two clib_bihash_kv_8_24_t instances
++    @param a - first key
++    @param b - second key
++*/
++static inline int
++clib_bihash_key_compare_8_24 (u64 a, u64 b)
++{
++  return a == b;
++}
++
++#undef __included_bihash_template_h__
++#include <vppinfra/bihash_template.h>
++
++#endif /* __included_bihash_8_24_h__ */
++
++/*
++ * fd.io coding-style-patch-verification: ON
++ *
++ * Local Variables:
++ * eval: (c-set-style "gnu")
++ * End:
++ */
+diff --git a/src/plugins/capo/capo.api b/src/plugins/capo/capo.api
+new file mode 100644
+index 000000000..48732828e
+--- /dev/null
++++ b/src/plugins/capo/capo.api
+@@ -0,0 +1,260 @@
++/*
++ * Copyright (c) 2020 Cisco and/or its affiliates.
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at:
++ *
++ *     http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ */
++
++/** \file
++    This file defines the vpp control-plane API messages
++    used to configure Calico policies
++*/
++
++option version = "0.1.0";
++import "vnet/ip/ip_types.api";
++import "vnet/fib/fib_types.api";
++
++/** \brief Get the plugin version
++    @param client_index - opaque cookie to identify the sender
++    @param context - sender context, to match reply w/ request
++*/
++
++define capo_get_version
++{
++  u32 client_index;
++  u32 context;
++};
++
++/** \brief Reply to get the plugin version
++    @param context - returned sender context, to match reply w/ request
++    @param major - Incremented every time a known breaking behavior change is introduced
++    @param minor - Incremented with small changes, may be used to avoid buggy versions
++*/
++
++define capo_get_version_reply
++{
++  u32 context;
++  u32 major;
++  u32 minor;
++};
++
++/** \brief Control ping from client to api server request
++    @param client_index - opaque cookie to identify the sender
++    @param context - sender context, to match reply w/ request
++*/
++define capo_control_ping
++{
++  u32 client_index;
++  u32 context;
++};
++
++/** \brief Control ping from the client to the server response
++    @param client_index - opaque cookie to identify the sender
++    @param context - sender context, to match reply w/ request
++    @param retval - return code for the request
++    @param vpe_pid - the pid of the vpe, returned by the server
++*/
++define capo_control_ping_reply
++{
++  u32 context;
++  i32 retval;
++  u32 client_index;
++  u32 vpe_pid;
++};
++
++
++enum capo_ipset_type : u8 {
++  CAPO_IP = 0,           /* Each member is an IP address */
++  CAPO_IP_AND_PORT = 1,  /* Each member is "<IP>,(tcp|udp):port" (3-tuple) */
++  CAPO_NET = 2,          /* Each member is a CIDR */
++};
++
++typedef capo_three_tuple {
++  vl_api_address_t address;
++  u8 l4_proto;
++  u16 port;
++};
++
++union capo_ipset_member_val {
++  vl_api_address_t address;
++  vl_api_prefix_t prefix;
++  vl_api_capo_three_tuple_t tuple;
++};
++
++typedef capo_ipset_member {
++  vl_api_capo_ipset_member_val_t val;
++};
++
++define capo_ipset_create
++{
++  u32 client_index;
++  u32 context;
++  vl_api_capo_ipset_type_t type;
++};
++
++define capo_ipset_create_reply
++{
++  u32 context;
++  i32 retval;
++  u32 set_id;
++};
++
++
++autoreply define capo_ipset_add_del_members
++{
++  u32 client_index;
++  u32 context;
++  u32 set_id;
++  bool is_add;
++  u32 len;
++  vl_api_capo_ipset_member_t members[len];
++};
++
++autoreply define capo_ipset_delete
++{
++  u32 client_index;
++  u32 context;
++  u32 set_id;
++};
++
++enum capo_rule_action : u8 {
++  CAPO_ALLOW = 0,  // Accept packet
++  CAPO_DENY,       // Drop / reject packet
++  CAPO_LOG,        // Ignored for now
++  CAPO_PASS,       // Skip following rules, resume evaluation at the policy
++                   // with the id configured in capo_configure_policies
++};
++
++enum capo_entry_type : u8 {
++  CAPO_CIDR = 0,     // simple prefix
++  CAPO_PORT_RANGE,
++  CAPO_PORT_IP_SET,  // Points to an ip + proto + port set
++  CAPO_IP_SET,       // Points to an ip only set
++};
++
++typedef capo_port_range {
++  u16 start;
++  u16 end;    // Inclusive, for a single port start==end
++};
++
++typedef capo_entry_set_id {
++  u32 set_id;
++};
++
++union capo_entry_data {
++  vl_api_prefix_t cidr;
++  vl_api_capo_port_range_t port_range;
++  vl_api_capo_entry_set_id_t set_id;
++};
++
++// A rule contains several such entries, each belong to a category
++// categories are: [not_]{src,dst}_{cidr,port_range,port_ip_set,ip_set}
++// (defined byt the 3 first fields in the rule_entry)
++// A rule matches a packet iff:
++// - for every "not" category, the source / destination do not match any entry
++// - for every positive match category, the source / destination matches at
++// least one entry in each category EXCEPT for port ranges and port+ip sets,
++// where the packet only needs to match one entry in either category
++
++typedef capo_rule_entry {
++  bool is_src;
++  bool is_not;
++  vl_api_capo_entry_type_t type;
++  vl_api_capo_entry_data_t data;
++};
++
++enum capo_rule_filter_type : u8 {
++  CAPO_RULE_FILTER_NONE_TYPE = 0,
++  CAPO_RULE_FILTER_ICMP_TYPE,
++  CAPO_RULE_FILTER_ICMP_CODE,
++  CAPO_RULE_FILTER_L4_PROTO,
++};
++
++typedef capo_rule_filter {
++  u32 value;
++  vl_api_capo_rule_filter_type_t type;
++  u8 should_match;
++};
++
++typedef capo_rule {
++  vl_api_address_family_t af;
++  vl_api_capo_rule_action_t action;
++  vl_api_capo_rule_filter_t filters[3];
++  u32 num_entries;
++  vl_api_capo_rule_entry_t matches[num_entries]; // List of other criteria
++};
++
++define capo_rule_create {
++  u32 client_index;
++  u32 context;
++  vl_api_capo_rule_t rule;
++};
++
++autoreply define capo_rule_update {
++  u32 client_index;
++  u32 context;
++  u32 rule_id;
++  vl_api_capo_rule_t rule;
++};
++
++define capo_rule_create_reply {
++  u32 context;
++  i32 retval;
++  u32 rule_id;
++};
++
++autoreply define capo_rule_delete {
++  u32 client_index;
++  u32 context;
++  u32 rule_id;
++};
++
++typedef capo_policy_item {
++  bool is_inbound; // 0 for outbound, 1 for is_inbound
++  u32 rule_id;
++};
++
++define capo_policy_create {
++  u32 client_index;
++  u32 context;
++  u32 num_items;
++  vl_api_capo_policy_item_t rules[num_items];
++};
++
++define capo_policy_create_reply {
++  u32 context;
++  i32 retval;
++  u32 policy_id;
++};
++
++autoreply define capo_policy_update {
++  u32 client_index;
++  u32 context;
++  u32 policy_id;
++  u32 num_items;
++  vl_api_capo_policy_item_t rules[num_items];
++};
++
++autoreply define capo_policy_delete {
++  u32 client_index;
++  u32 context;
++  u32 policy_id;
++};
++
++autoreply define capo_configure_policies {
++  u32 client_index;
++  u32 context;
++  u32 sw_if_index;
++  u32 num_ingress_policies;
++  u32 num_egress_policies;
++  u32 total_ids;
++  u32 policy_ids[total_ids]; // ingress, then egress, then profiles
++};
+diff --git a/src/plugins/capo/capo.h b/src/plugins/capo/capo.h
+new file mode 100644
+index 000000000..812d14831
+--- /dev/null
++++ b/src/plugins/capo/capo.h
+@@ -0,0 +1,58 @@
++/*
++ * Copyright (c) 2020 Cisco and/or its affiliates.
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at:
++ *
++ *     http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ */
++
++#ifndef included_capo_h
++#define included_capo_h
++
++#include <vnet/ip/ip.h>
++#include <vnet/ip/ip_types_api.h>
++#include <acl/public_inlines.h>
++#include <capo/bihash_8_24.h>
++
++#include <capo/capo.api_enum.h>
++#include <capo/capo.api_types.h>
++#include <capo/capo_interface.h>
++
++#define CAPO_INVALID_INDEX ((u32) ~0)
++
++typedef struct
++{
++  u16 start;
++  u16 end;
++} capo_port_range_t;
++
++typedef struct
++{
++  clib_bihash_8_24_t if_config; /* sw_if_index -> capo_interface_config */
++
++  u32 calico_acl_user_id;
++  acl_plugin_methods_t acl_plugin;
++
++  /* API message ID base */
++  u16 msg_id_base;
++
++} capo_main_t;
++
++extern capo_main_t capo_main;
++
++#endif
++
++/*
++ * fd.io coding-style-patch-verification: ON
++ *
++ * Local Variables:
++ * eval: (c-set-style "gnu")
++ * End:
++ */
+diff --git a/src/plugins/capo/capo_api.c b/src/plugins/capo/capo_api.c
+new file mode 100644
+index 000000000..c44b77eda
+--- /dev/null
++++ b/src/plugins/capo/capo_api.c
+@@ -0,0 +1,444 @@
++/*
++ * Copyright (c) 2020 Cisco and/or its affiliates.
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at:
++ *
++ *     http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ */
++
++#include <vnet/vnet.h>
++#include <vnet/plugin/plugin.h>
++#include <vlibapi/api.h>
++#include <vlibmemory/api.h>
++#include <vpp/app/version.h>
++#include <stdbool.h>
++
++#include <capo/capo.h>
++#include <capo/capo_rule.h>
++#include <capo/capo_policy.h>
++#include <capo/capo_ipset.h>
++#include <capo/capo_interface.h>
++
++#define REPLY_MSG_ID_BASE cpm->msg_id_base
++#include <vlibapi/api_helper_macros.h>
++
++#define CALICO_POLICY_VERSION_MAJOR 0
++#define CALICO_POLICY_VERSION_MINOR 0
++
++capo_main_t capo_main = { 0 };
++
++void
++capo_policy_rule_decode (const vl_api_capo_policy_item_t *in,
++			 capo_policy_rule_t *out)
++{
++  out->rule_id = clib_net_to_host_u32 (in->rule_id);
++  out->direction = in->is_inbound ? VLIB_RX : VLIB_TX;
++}
++
++int
++capo_ipset_member_decode (capo_ipset_type_t type,
++			  const vl_api_capo_ipset_member_t *in,
++			  capo_ipset_member_t *out)
++{
++  switch (type)
++    {
++    case IPSET_TYPE_IP:
++      ip_address_decode2 (&in->val.address, &out->address);
++      break;
++    case IPSET_TYPE_IPPORT:
++      ip_address_decode2 (&in->val.tuple.address, &out->ipport.addr);
++      out->ipport.l4proto = in->val.tuple.l4_proto;
++      out->ipport.port = clib_net_to_host_u16 (in->val.tuple.port);
++      break;
++    case IPSET_TYPE_NET:
++      return ip_prefix_decode2 (&in->val.prefix, &out->prefix);
++    }
++  return 0;
++}
++
++void
++capo_port_range_decode (const vl_api_capo_port_range_t *in,
++			capo_port_range_t *out)
++{
++  out->start = clib_net_to_host_u16 (in->start);
++  out->end = clib_net_to_host_u16 (in->end);
++}
++
++int
++capo_rule_entry_decode (const vl_api_capo_rule_entry_t *in,
++			capo_rule_entry_t *out)
++{
++  out->flags = 0;
++  if (in->is_src)
++    out->flags |= CAPO_IS_SRC;
++  if (in->is_not)
++    out->flags |= CAPO_IS_NOT;
++  out->type = (capo_entry_type_t) in->type;
++  switch (in->type)
++    {
++    case CAPO_CIDR:
++      return ip_prefix_decode2 (&in->data.cidr, &out->data.cidr);
++    case CAPO_PORT_RANGE:
++      capo_port_range_decode (&in->data.port_range, &out->data.port_range);
++      return 0;
++    case CAPO_PORT_IP_SET:
++    case CAPO_IP_SET:
++      out->data.set_id = clib_net_to_host_u32 (in->data.set_id.set_id);
++      return 0;
++    default:
++      return -1;
++    }
++}
++
++void
++capo_rule_filter_decode (const vl_api_capo_rule_filter_t *in,
++			 capo_rule_filter_t *out)
++{
++  out->type = (capo_rule_filter_type_t) in->type;
++  out->should_match = in->should_match;
++  out->value = clib_net_to_host_u32 (in->value);
++}
++
++static void
++vl_api_capo_get_version_t_handler (vl_api_capo_get_version_t *mp)
++{
++  capo_main_t *cpm = &capo_main;
++  vl_api_capo_get_version_reply_t *rmp;
++  int msg_size = sizeof (*rmp);
++  vl_api_registration_t *reg;
++
++  reg = vl_api_client_index_to_registration (mp->client_index);
++  if (!reg)
++    return;
++
++  rmp = vl_msg_api_alloc (msg_size);
++  clib_memset (rmp, 0, msg_size);
++  rmp->_vl_msg_id = ntohs (VL_API_CAPO_GET_VERSION_REPLY + cpm->msg_id_base);
++  rmp->context = mp->context;
++  rmp->major = htonl (CALICO_POLICY_VERSION_MAJOR);
++  rmp->minor = htonl (CALICO_POLICY_VERSION_MINOR);
++
++  vl_api_send_msg (reg, (u8 *) rmp);
++}
++
++static void
++vl_api_capo_control_ping_t_handler (vl_api_capo_control_ping_t *mp)
++{
++  capo_main_t *cpm = &capo_main;
++  vl_api_capo_control_ping_reply_t *rmp;
++  int rv = 0;
++
++  REPLY_MACRO2 (VL_API_CAPO_CONTROL_PING_REPLY,
++		({ rmp->vpe_pid = ntohl (getpid ()); }));
++}
++
++/* NAME: ipset_create */
++static void
++vl_api_capo_ipset_create_t_handler (vl_api_capo_ipset_create_t *mp)
++{
++  capo_main_t *cpm = &capo_main;
++  vl_api_capo_ipset_create_reply_t *rmp;
++  int rv = 0;
++  u32 id;
++
++  id = capo_ipset_create ((capo_ipset_type_t) mp->type);
++
++  REPLY_MACRO2 (VL_API_CAPO_IPSET_CREATE_REPLY,
++		({ rmp->set_id = clib_host_to_net_u32 (id); }));
++}
++
++/* NAME: ipset_add_del_members */
++static void
++vl_api_capo_ipset_add_del_members_t_handler (
++  vl_api_capo_ipset_add_del_members_t *mp)
++{
++  capo_main_t *cpm = &capo_main;
++  vl_api_capo_ipset_add_del_members_reply_t *rmp;
++  u32 set_id, i, n_members;
++  capo_ipset_type_t type;
++  int rv = 0;
++
++  set_id = clib_net_to_host_u32 (mp->set_id);
++  n_members = clib_net_to_host_u32 (mp->len);
++
++  rv = capo_ipset_get_type (set_id, &type);
++  if (rv)
++    goto done;
++
++  for (i = 0; i < n_members; i++)
++    {
++      capo_ipset_member_t _m, *member = &_m;
++      rv = capo_ipset_member_decode (type, &mp->members[i], member);
++      if (rv)
++	break;
++      if (mp->is_add)
++	rv = capo_ipset_add_member (set_id, member);
++      else
++	rv = capo_ipset_del_member (set_id, member);
++      if (rv)
++	break;
++    }
++
++done:
++  REPLY_MACRO (VL_API_CAPO_IPSET_ADD_DEL_MEMBERS_REPLY);
++}
++
++/* NAME: ipset_delete */
++static void
++vl_api_capo_ipset_delete_t_handler (vl_api_capo_ipset_delete_t *mp)
++{
++  capo_main_t *cpm = &capo_main;
++  vl_api_capo_ipset_delete_reply_t *rmp;
++  u32 set_id;
++  int rv;
++
++  set_id = clib_net_to_host_u32 (mp->set_id);
++  rv = capo_ipset_delete (set_id);
++
++  REPLY_MACRO (VL_API_CAPO_IPSET_DELETE_REPLY);
++}
++
++static int
++vl_api_capo_rule_update_create_handler (u32 *id, vl_api_capo_rule_t *rule)
++{
++  capo_rule_filter_t *filters = 0, *filter;
++  capo_rule_entry_t *entries = 0, *entry;
++  capo_rule_action_t action;
++  ip_address_family_t af = 0;
++  int rv;
++  u32 n_matches;
++  u32 i;
++
++  action = (capo_rule_action_t) rule->action;
++
++  // if ((rv = ip_address_family_decode (rule->af, &af)))
++  //   goto done;
++
++  for (i = 0; i < ARRAY_LEN (rule->filters); i++)
++    {
++      vec_add2 (filters, filter, 1);
++      capo_rule_filter_decode (&rule->filters[i], filter);
++    }
++
++  n_matches = clib_net_to_host_u32 (rule->num_entries);
++  for (i = 0; i < n_matches; i++)
++    {
++      vec_add2 (entries, entry, 1);
++      if ((rv = capo_rule_entry_decode (&rule->matches[i], entry)))
++	goto done;
++    }
++
++  rv = capo_rule_update (id, action, af, filters, entries);
++
++done:
++  vec_free (filters);
++  vec_free (entries);
++  return rv;
++}
++
++/* NAME: rule_create */
++static void
++vl_api_capo_rule_create_t_handler (vl_api_capo_rule_create_t *mp)
++{
++  vl_api_capo_rule_create_reply_t *rmp;
++  capo_main_t *cpm = &capo_main;
++  u32 id = CAPO_INVALID_INDEX;
++  int rv;
++
++  rv = vl_api_capo_rule_update_create_handler (&id, &mp->rule);
++
++  REPLY_MACRO2 (VL_API_CAPO_RULE_CREATE_REPLY,
++		({ rmp->rule_id = clib_host_to_net_u32 (id); }));
++}
++
++/* NAME: rule_update */
++static void
++vl_api_capo_rule_update_t_handler (vl_api_capo_rule_update_t *mp)
++{
++  vl_api_capo_rule_update_reply_t *rmp;
++  capo_main_t *cpm = &capo_main;
++  u32 id;
++  int rv;
++
++  id = clib_net_to_host_u32 (mp->rule_id);
++  rv = vl_api_capo_rule_update_create_handler (&id, &mp->rule);
++
++  REPLY_MACRO (VL_API_CAPO_RULE_UPDATE_REPLY);
++}
++
++/* NAME: rule_delete */
++static void
++vl_api_capo_rule_delete_t_handler (vl_api_capo_rule_delete_t *mp)
++{
++  vl_api_capo_rule_delete_reply_t *rmp;
++  capo_main_t *cpm = &capo_main;
++  u32 id;
++  int rv;
++
++  id = clib_net_to_host_u32 (mp->rule_id);
++  rv = capo_rule_delete (id);
++
++  REPLY_MACRO (VL_API_CAPO_RULE_DELETE_REPLY);
++}
++
++static int
++vl_api_capo_policy_update_create_handler (u32 *id, u32 n_rules,
++					  vl_api_capo_policy_item_t *api_rules)
++{
++  capo_policy_rule_t *rules = 0, *rule;
++  int rv;
++
++  for (u32 i = 0; i < n_rules; i++)
++    {
++      vec_add2 (rules, rule, 1);
++      capo_policy_rule_decode (&api_rules[i], rule);
++    }
++
++  rv = capo_policy_update (id, rules);
++
++  vec_free (rules);
++  return rv;
++}
++
++/* NAME: policy_create */
++static void
++vl_api_capo_policy_create_t_handler (vl_api_capo_policy_create_t *mp)
++{
++  vl_api_capo_policy_create_reply_t *rmp;
++  capo_main_t *cpm = &capo_main;
++  u32 id = CAPO_INVALID_INDEX, n_rules;
++  int rv;
++
++  n_rules = clib_net_to_host_u32 (mp->num_items);
++  rv = vl_api_capo_policy_update_create_handler (&id, n_rules, mp->rules);
++
++  REPLY_MACRO2 (VL_API_CAPO_POLICY_CREATE_REPLY,
++		({ rmp->policy_id = clib_host_to_net_u32 (id); }));
++}
++
++/* NAME: policy_update */
++static void
++vl_api_capo_policy_update_t_handler (vl_api_capo_policy_update_t *mp)
++{
++  vl_api_capo_policy_update_reply_t *rmp;
++  capo_main_t *cpm = &capo_main;
++  u32 id, n_rules;
++  int rv;
++
++  id = clib_net_to_host_u32 (mp->policy_id);
++  n_rules = clib_net_to_host_u32 (mp->num_items);
++  rv = vl_api_capo_policy_update_create_handler (&id, n_rules, mp->rules);
++
++  REPLY_MACRO (VL_API_CAPO_POLICY_UPDATE_REPLY);
++}
++
++/* NAME: policy_delete */
++static void
++vl_api_capo_policy_delete_t_handler (vl_api_capo_policy_delete_t *mp)
++{
++  vl_api_capo_policy_delete_reply_t *rmp;
++  capo_main_t *cpm = &capo_main;
++  u32 id;
++  int rv = 0;
++
++  id = clib_net_to_host_u32 (mp->policy_id);
++  rv = capo_policy_delete (id);
++
++  REPLY_MACRO (VL_API_CAPO_POLICY_DELETE_REPLY);
++}
++
++/* NAME: configure_policies */
++static void
++vl_api_capo_configure_policies_t_handler (vl_api_capo_configure_policies_t *mp)
++{
++  vl_api_capo_configure_policies_reply_t *rmp;
++  capo_main_t *cpm = &capo_main;
++  u32 num_profiles;
++  int rv = -1;
++  int i = 0;
++
++  mp->sw_if_index = clib_net_to_host_u32 (mp->sw_if_index);
++  mp->num_ingress_policies = clib_net_to_host_u32 (mp->num_ingress_policies);
++  mp->num_egress_policies = clib_net_to_host_u32 (mp->num_egress_policies);
++  mp->total_ids = clib_net_to_host_u32 (mp->total_ids);
++  num_profiles =
++    mp->total_ids - mp->num_ingress_policies - mp->num_egress_policies;
++  for (i = 0; i < mp->total_ids; i++)
++    {
++      mp->policy_ids[i] = clib_net_to_host_u32 (mp->policy_ids[i]);
++    }
++
++  rv = capo_configure_policies (mp->sw_if_index, mp->num_ingress_policies,
++				mp->num_egress_policies, num_profiles,
++				mp->policy_ids);
++
++  REPLY_MACRO (VL_API_CAPO_CONFIGURE_POLICIES_REPLY);
++}
++
++/* Set up the API message handling tables */
++#include <vnet/format_fns.h>
++#include <capo/capo.api.c>
++
++#include <vat/vat.h>
++#include <vlibapi/vat_helper_macros.h>
++
++/* Declare message IDs */
++#include <acl/acl.api_enum.h>
++#include <acl/acl.api_types.h>
++#undef vl_print
++#define vl_print(handle, ...)
++#undef vl_print
++#define vl_endianfun /* define message structures */
++#include <acl/acl.api.h>
++#undef vl_endianfun
++
++static clib_error_t *
++calpol_init (vlib_main_t *vm)
++{
++  capo_main_t *cpm = &capo_main;
++
++  clib_error_t *acl_init_res = acl_plugin_exports_init (&cpm->acl_plugin);
++  if (acl_init_res)
++    return (acl_init_res);
++
++  cpm->calico_acl_user_id =
++    cpm->acl_plugin.register_user_module ("Calico Policy Plugin", NULL, NULL);
++
++  cpm->msg_id_base = setup_message_id_table ();
++
++  clib_bihash_init_8_24 (&cpm->if_config, "capo interfaces", 512, 1 << 20);
++
++  return (NULL);
++}
++
++static clib_error_t *
++calpol_plugin_config (vlib_main_t *vm, unformat_input_t *input)
++{
++  return NULL;
++}
++
++VLIB_PLUGIN_REGISTER () = {
++  .version = VPP_BUILD_VER,
++  .description = "Calico Policy",
++};
++
++VLIB_CONFIG_FUNCTION (calpol_plugin_config, "calico-policy-plugin");
++
++VLIB_INIT_FUNCTION (calpol_init) = {
++  .runs_after = VLIB_INITS ("acl_init"),
++};
++
++/*
++ * fd.io coding-style-patch-verification: ON
++ *
++ * Local Variables:
++ * eval: (c-set-style "gnu")
++ * End:
++ */
+diff --git a/src/plugins/capo/capo_interface.c b/src/plugins/capo/capo_interface.c
+new file mode 100644
+index 000000000..d13d58ff4
+--- /dev/null
++++ b/src/plugins/capo/capo_interface.c
+@@ -0,0 +1,340 @@
++/*
++ * Copyright (c) 2020 Cisco and/or its affiliates.
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at:
++ *
++ *     http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ */
++
++#include <capo/capo.h>
++#include <capo/capo_match.h>
++#include <capo/capo_policy.h>
++
++uword unformat_sw_if_index (unformat_input_t *input, va_list *args);
++
++static int
++print_capo_interface2 (clib_bihash_kv_8_24_t *kv, void *arg)
++{
++  u8 **s = (u8 **) arg;
++  u32 sw_if_index = kv->key;
++  capo_interface_config_t *conf = (capo_interface_config_t *) kv->value;
++  *s = format (*s, "%U", format_capo_interface, sw_if_index, conf);
++  return BIHASH_WALK_CONTINUE;
++}
++
++void
++capo_interface_print_current_state ()
++{
++  u8 *s = 0;
++  clib_bihash_foreach_key_value_pair_8_24 (&capo_main.if_config,
++					   print_capo_interface2, (void *) &s);
++  clib_warning ("Current interface state:\n%s", s);
++  vec_free (s);
++}
++
++int
++capo_configure_policies (u32 sw_if_index, u32 num_ingress, u32 num_egress,
++			 u32 num_profiles, u32 *policy_ids)
++{
++  clib_bihash_kv_8_24_t kv = { sw_if_index, { 0 } };
++  capo_interface_config_t *conf = (capo_interface_config_t *) &kv.value;
++  capo_interface_config_t *old_conf;
++  u32 found = 0, i = 0;
++
++  if (pool_is_free_index (vnet_get_main ()->interface_main.sw_interfaces,
++			  sw_if_index))
++    {
++      clib_warning (
++	"configuring policies for interface %u which doesn't exist",
++	sw_if_index);
++      return VNET_API_ERROR_INVALID_SW_IF_INDEX;
++    }
++
++  if (clib_bihash_search_8_24 (&capo_main.if_config, &kv, &kv) >= 0)
++    {
++      old_conf = (capo_interface_config_t *) &kv.value;
++      vec_free (old_conf->ingress_policies);
++      vec_free (old_conf->egress_policies);
++      vec_free (old_conf->profiles);
++      found = 1;
++    }
++
++  clib_warning ("configuring policies for if %u", sw_if_index);
++
++  for (i = 0; i < num_ingress + num_egress + num_profiles; i++)
++    if (pool_is_free_index (capo_policies, policy_ids[i]))
++      goto error;
++
++  vec_resize (conf->ingress_policies, num_ingress);
++  for (i = 0; i < num_ingress; i++)
++    conf->ingress_policies[i] = policy_ids[i];
++  vec_resize (conf->egress_policies, num_egress);
++  for (i = 0; i < num_egress; i++)
++    conf->egress_policies[i] = policy_ids[num_ingress + i];
++  vec_resize (conf->profiles, num_profiles);
++  for (i = 0; i < num_profiles; i++)
++    conf->profiles[i] = policy_ids[num_ingress + num_egress + i];
++
++  clib_bihash_add_del_8_24 (&capo_main.if_config, &kv, 1 /* is_add */);
++
++  if (!found)
++    {
++      capo_main.acl_plugin.wip_add_del_custom_access_io_policy (
++	1 /* is_add */, sw_if_index, 0 /* is_input */, capo_match_func);
++      capo_main.acl_plugin.wip_add_del_custom_access_io_policy (
++	1 /* is_add */, sw_if_index, 1 /* is_input */, capo_match_func);
++    }
++
++  capo_main.acl_plugin.wip_clear_sessions (sw_if_index);
++  return 0;
++
++error:
++  clib_warning ("error configuring policies for %u", sw_if_index);
++  vec_resize (conf->ingress_policies, 0);
++  vec_resize (conf->egress_policies, 0);
++  vec_resize (conf->profiles, 0);
++  return 1;
++}
++
++static clib_error_t *
++capo_sw_interface_add_del (vnet_main_t *vnm, u32 sw_if_index, u32 is_add)
++{
++  clib_bihash_kv_8_24_t kv = { sw_if_index, { 0 } };
++  capo_interface_config_t *conf = (capo_interface_config_t *) &kv.value;
++  int rv = 0;
++
++  if (is_add)
++    return NULL;
++
++  if (clib_bihash_search_8_24 (&capo_main.if_config, &kv, &kv) >= 0)
++    {
++      conf = (capo_interface_config_t *) &kv.value;
++      vec_free (conf->ingress_policies);
++      vec_free (conf->egress_policies);
++      vec_free (conf->profiles);
++    }
++
++  clib_warning ("unconfiguring policies for if %u deleted", sw_if_index);
++  clib_bihash_add_del_8_24 (&capo_main.if_config, &kv, 0 /* is_add */);
++  rv = capo_main.acl_plugin.wip_add_del_custom_access_io_policy (
++    0 /* is_add */, sw_if_index, 0 /* is_input */
++    ,
++    capo_match_func);
++  if (rv)
++    clib_warning ("error deleting caiop (output): %d", rv);
++  rv = capo_main.acl_plugin.wip_add_del_custom_access_io_policy (
++    0 /* is_add */, sw_if_index, 1 /* is_input */
++    ,
++    capo_match_func);
++  if (rv)
++    clib_warning ("error deleting caiop (input): %d", rv);
++  return NULL;
++}
++
++VNET_SW_INTERFACE_ADD_DEL_FUNCTION (capo_sw_interface_add_del);
++
++u8 *
++format_capo_interface (u8 *s, va_list *args)
++{
++  u32 sw_if_index = va_arg (*args, u32);
++  capo_interface_config_t *conf = va_arg (*args, capo_interface_config_t *);
++  vnet_main_t *vnm = vnet_get_main ();
++  capo_policy_t *policy = NULL;
++  u32 i;
++
++  s = format (s, "[%U sw_if_index=%u addr=", format_vnet_sw_if_index_name, vnm,
++	      sw_if_index, sw_if_index);
++  ip4_address_t *ip4 = 0;
++  ip4 = ip4_interface_first_address (&ip4_main, sw_if_index, 0);
++  if (ip4)
++    s = format (s, "%U", format_ip4_address, ip4);
++  s = format (s, "]\n");
++  if (vec_len (conf->ingress_policies))
++    s = format (s, "  ingress:\n");
++  vec_foreach_index (i, conf->ingress_policies)
++    {
++      policy = capo_policy_get_if_exists (conf->ingress_policies[i]);
++      s = format (s, "    %U", format_capo_policy, policy, 4 /* indent */,
++		  CAPO_POLICY_ONLY_INGRESS);
++    }
++  if (vec_len (conf->egress_policies))
++    s = format (s, "  egress:\n");
++  vec_foreach_index (i, conf->egress_policies)
++    {
++      policy = capo_policy_get_if_exists (conf->egress_policies[i]);
++      s = format (s, "    %U", format_capo_policy, policy, 4 /* indent */,
++		  CAPO_POLICY_ONLY_EGRESS);
++    }
++  if (vec_len (conf->profiles))
++    s = format (s, "  profiles:\n");
++  vec_foreach_index (i, conf->profiles)
++    {
++      policy = capo_policy_get_if_exists (conf->profiles[i]);
++      s = format (s, "    %U", format_capo_policy, policy, 4 /* indent */,
++		  CAPO_POLICY_VERBOSE);
++    }
++  return s;
++}
++
++int
++print_capo_interface (clib_bihash_kv_8_24_t *kv, void *arg)
++{
++  vlib_main_t *vm = (vlib_main_t *) arg;
++  u32 sw_if_index = kv->key;
++  capo_interface_config_t *conf = (capo_interface_config_t *) kv->value;
++  vlib_cli_output (vm, "%U", format_capo_interface, sw_if_index, conf);
++  return BIHASH_WALK_CONTINUE;
++}
++
++static clib_error_t *
++capo_interface_show_cmd_fn (vlib_main_t *vm, unformat_input_t *input,
++			    vlib_cli_command_t *cmd)
++{
++  vlib_cli_output (vm, "Interfaces with policies configured:");
++  clib_bihash_foreach_key_value_pair_8_24 (&capo_main.if_config,
++					   print_capo_interface, vm);
++  return NULL;
++}
++
++VLIB_CLI_COMMAND (capo_policies_show_cmd, static) = {
++  .path = "show capo interfaces",
++  .function = capo_interface_show_cmd_fn,
++  .short_help = "show capo interfaces",
++};
++
++static clib_error_t *
++capo_interface_clear_cmd_fn (vlib_main_t *vm, unformat_input_t *input,
++			     vlib_cli_command_t *cmd)
++{
++  unformat_input_t _line_input, *line_input = &_line_input;
++  clib_error_t *error = 0;
++  u32 sw_if_index = CAPO_INVALID_INDEX;
++  int rv;
++
++  if (!unformat_user (input, unformat_line_input, line_input))
++    return clib_error_return (0, "missing parameters");
++
++  while (unformat_check_input (line_input) != UNFORMAT_END_OF_INPUT)
++    {
++      if (unformat (line_input, "%U", unformat_sw_if_index, NULL,
++		    &sw_if_index))
++	;
++      else if (unformat (line_input, "sw_if_index %d", &sw_if_index))
++	;
++      else
++	{
++	  error = clib_error_return (0, "unknown input '%U'",
++				     format_unformat_error, line_input);
++	  goto done;
++	}
++    }
++
++  if (sw_if_index == CAPO_INVALID_INDEX)
++    {
++      error = clib_error_return (0, "interface not specified");
++      goto done;
++    }
++
++  rv = capo_configure_policies (sw_if_index, 0, 0, 0, NULL);
++  if (rv)
++    error =
++      clib_error_return (0, "capo_configure_policies errored with %d", rv);
++  else
++    vlib_cli_output (vm, "capo interface %d cleared", sw_if_index);
++
++done:
++  unformat_free (line_input);
++  return error;
++}
++
++VLIB_CLI_COMMAND (capo_interface_clear_cmd, static) = {
++  .path = "capo interface clear",
++  .function = capo_interface_clear_cmd_fn,
++  .short_help = "capo interface clear [interface | sw_if_index N]",
++};
++
++static clib_error_t *
++capo_interface_configure_cmd_fn (vlib_main_t *vm, unformat_input_t *input,
++				 vlib_cli_command_t *cmd)
++{
++  unformat_input_t _line_input, *line_input = &_line_input;
++  clib_error_t *error = 0;
++  u32 sw_if_index = CAPO_INVALID_INDEX;
++  u32 num_ingress = 0;
++  u32 num_egress = 0;
++  u32 policy_id;
++  u32 *policy_list = NULL;
++  int rv;
++
++  if (!unformat_user (input, unformat_line_input, line_input))
++    return clib_error_return (0, "missing parameters");
++
++  while (unformat_check_input (line_input) != UNFORMAT_END_OF_INPUT)
++    {
++      if (unformat (line_input, "%U", unformat_sw_if_index, NULL,
++		    &sw_if_index))
++	;
++      else if (unformat (line_input, "sw_if_index %d", &sw_if_index))
++	;
++      else if (unformat (line_input, "in %d", &num_ingress))
++	;
++      else if (unformat (line_input, "out %d", &num_egress))
++	;
++      else if (unformat (line_input, "%d", &policy_id))
++	vec_add1 (policy_list, policy_id);
++      else
++	{
++	  error = clib_error_return (0, "unknown input '%U'",
++				     format_unformat_error, line_input);
++	  goto done;
++	}
++    }
++
++  if (sw_if_index == CAPO_INVALID_INDEX)
++    {
++      error = clib_error_return (0, "interface not specified");
++      goto done;
++    }
++  if (!vec_len (policy_list))
++    {
++      error = clib_error_return (0, "no policies specified");
++      goto done;
++    }
++
++  rv = capo_configure_policies (
++    sw_if_index, num_ingress, num_egress,
++    vec_len (policy_list) - num_ingress - num_egress, policy_list);
++
++  if (rv)
++    error =
++      clib_error_return (0, "capo_configure_policies errored with %d", rv);
++  else
++    vlib_cli_output (vm, "capo interface %d configured", sw_if_index);
++
++done:
++  unformat_free (line_input);
++  vec_free (policy_list);
++  return error;
++}
++
++VLIB_CLI_COMMAND (capo_interface_configure_cmd, static) = {
++  .path = "capo interface configure",
++  .function = capo_interface_configure_cmd_fn,
++  .short_help = "capo interface configure [interface | sw_if_index N] in "
++		"<num_ingress> out <num_egress> <policy_id> ...",
++};
++
++/*
++ * fd.io coding-style-patch-verification: ON
++ *
++ * Local Variables:
++ * eval: (c-set-style "gnu")
++ * End:
++ */
+diff --git a/src/plugins/capo/capo_interface.h b/src/plugins/capo/capo_interface.h
+new file mode 100644
+index 000000000..f02c608a8
+--- /dev/null
++++ b/src/plugins/capo/capo_interface.h
+@@ -0,0 +1,40 @@
++/*
++ * Copyright (c) 2020 Cisco and/or its affiliates.
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at:
++ *
++ *     http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ */
++
++#ifndef included_capo_interface_h
++#define included_capo_interface_h
++
++#include <vppinfra/clib.h>
++
++typedef struct
++{
++  u32 *ingress_policies;
++  u32 *egress_policies;
++  u32 *profiles;
++} capo_interface_config_t;
++
++int capo_configure_policies (u32 sw_if_index, u32 num_ingress, u32 num_egress,
++			     u32 num_profiles, u32 *policy_ids);
++u8 *format_capo_interface (u8 *s, va_list *args);
++
++#endif
++
++/*
++ * fd.io coding-style-patch-verification: ON
++ *
++ * Local Variables:
++ * eval: (c-set-style "gnu")
++ * End:
++ */
+diff --git a/src/plugins/capo/capo_ipset.c b/src/plugins/capo/capo_ipset.c
+new file mode 100644
+index 000000000..32db3b957
+--- /dev/null
++++ b/src/plugins/capo/capo_ipset.c
+@@ -0,0 +1,472 @@
++/*
++ * Copyright (c) 2020 Cisco and/or its affiliates.
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at:
++ *
++ *     http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ */
++
++#include <capo/capo.h>
++#include <capo/capo_ipset.h>
++
++capo_ipset_t *capo_ipsets;
++
++u8 *
++format_capo_ipport (u8 *s, va_list *args)
++{
++  capo_ipport_t *ipport = va_arg (*args, capo_ipport_t *);
++  return format (s, "%U %U;%u", format_ip_protocol, ipport->l4proto,
++		 format_ip_address, &ipport->addr, ipport->port);
++}
++
++u8 *
++format_capo_ipset_member (u8 *s, va_list *args)
++{
++  capo_ipset_member_t *member = va_arg (*args, capo_ipset_member_t *);
++  capo_ipset_type_t type = va_arg (*args, capo_ipset_type_t);
++  switch (type)
++    {
++    case IPSET_TYPE_IP:
++      return format (s, "%U", format_ip_address, &member->address);
++    case IPSET_TYPE_IPPORT:
++      return format (s, "%U", format_capo_ipport, &member->ipport);
++    case IPSET_TYPE_NET:
++      return format (s, "%U", format_ip_prefix, &member->prefix);
++    default:
++      return format (s, "unknown type");
++    }
++}
++
++uword
++unformat_capo_ipport (unformat_input_t *input, va_list *args)
++{
++  capo_ipport_t *ipport = va_arg (*args, capo_ipport_t *);
++  u32 proto;
++  u32 port;
++  if (unformat (input, "%U %U %d", unformat_ip_protocol, &proto,
++		unformat_ip_address, &ipport->addr, &port))
++    ;
++  else
++    return 0;
++
++  ipport->port = port;
++  ipport->l4proto = (u8) proto;
++  return 1;
++}
++
++u8 *
++format_capo_ipset_type (u8 *s, va_list *args)
++{
++  capo_ipset_type_t type = va_arg (*args, capo_ipset_type_t);
++  switch (type)
++    {
++    case IPSET_TYPE_IP:
++      return format (s, "ip");
++    case IPSET_TYPE_IPPORT:
++      return format (s, "ip+port");
++    case IPSET_TYPE_NET:
++      return format (s, "prefix");
++    default:
++      return format (s, "unknownipsettype");
++    }
++}
++
++uword
++unformat_capo_ipset_member (unformat_input_t *input, va_list *args)
++{
++  capo_ipset_member_t *member = va_arg (*args, capo_ipset_member_t *);
++  capo_ipset_type_t *type = va_arg (*args, capo_ipset_type_t *);
++  if (unformat_user (input, unformat_ip_prefix, &member->prefix))
++    *type = IPSET_TYPE_NET;
++  else if (unformat_user (input, unformat_ip_address, &member->address))
++    *type = IPSET_TYPE_IP;
++  else if (unformat_user (input, unformat_capo_ipport, &member->ipport))
++    *type = IPSET_TYPE_IPPORT;
++  else
++    return 0;
++
++  return 1;
++}
++
++u8 *
++format_capo_ipset (u8 *s, va_list *args)
++{
++  capo_ipset_t *ipset = va_arg (*args, capo_ipset_t *);
++  capo_ipset_member_t *member;
++
++  if (ipset == NULL)
++    return format (s, "deleted ipset");
++
++  s = format (s, "[ipset#%d;%U;", ipset - capo_ipsets, format_capo_ipset_type,
++	      ipset->type);
++
++  pool_foreach (member, ipset->members)
++    s = format (s, "%U,", format_capo_ipset_member, member, ipset->type);
++
++  s = format (s, "]");
++
++  return (s);
++}
++
++capo_ipset_t *
++capo_ipsets_get_if_exists (u32 index)
++{
++  if (pool_is_free_index (capo_ipsets, index))
++    return (NULL);
++  return pool_elt_at_index (capo_ipsets, index);
++}
++
++u32
++capo_ipset_create (capo_ipset_type_t type)
++{
++  capo_ipset_t *ipset;
++  pool_get (capo_ipsets, ipset);
++  ipset->type = type;
++  ipset->members = NULL;
++  return ipset - capo_ipsets;
++}
++
++int
++capo_ipset_delete (u32 id)
++{
++  capo_ipset_t *ipset;
++  ipset = capo_ipsets_get_if_exists (id);
++  if (NULL == ipset)
++    return VNET_API_ERROR_NO_SUCH_ENTRY;
++
++  pool_free (ipset->members);
++  pool_put (capo_ipsets, ipset);
++  return 0;
++}
++
++int
++capo_ipset_get_type (u32 id, capo_ipset_type_t *type)
++{
++  capo_ipset_t *ipset;
++  ipset = capo_ipsets_get_if_exists (id);
++  if (NULL == ipset)
++    return VNET_API_ERROR_NO_SUCH_ENTRY;
++
++  *type = ipset->type;
++  return 0;
++}
++
++int
++capo_ipset_add_member (u32 ipset_id, capo_ipset_member_t *member)
++{
++  capo_ipset_member_t *m;
++  capo_ipset_t *ipset = &capo_ipsets[ipset_id];
++
++  if (pool_is_free (capo_ipsets, ipset))
++    {
++      return 1;
++    }
++
++  /* zero so that we can memcmp later */
++  pool_get_zero (ipset->members, m);
++  clib_memcpy (m, member, sizeof (*m));
++  return 0;
++}
++
++static size_t
++capo_ipset_member_cmp (capo_ipset_member_t *m1, capo_ipset_member_t *m2,
++		       capo_ipset_type_t type)
++{
++  switch (type)
++    {
++    case IPSET_TYPE_IP:
++      return ip_address_cmp (&m1->address, &m2->address);
++    case IPSET_TYPE_IPPORT:
++      return ((m1->ipport.port == m2->ipport.port) &&
++	      (m1->ipport.l4proto == m2->ipport.l4proto) &&
++	      ip_address_cmp (&m1->ipport.addr, &m2->ipport.addr));
++    case IPSET_TYPE_NET:
++      return ip_prefix_cmp (&m1->prefix, &m2->prefix);
++    default:
++      return 1;
++    }
++}
++
++int
++capo_ipset_del_member (u32 id, capo_ipset_member_t *member)
++{
++  index_t *index, *indexes = NULL;
++  capo_ipset_member_t *m;
++  capo_ipset_t *ipset;
++
++  ipset = capo_ipsets_get_if_exists (id);
++  if (NULL == ipset)
++    return VNET_API_ERROR_NO_SUCH_ENTRY;
++
++  pool_foreach (m, ipset->members)
++    {
++      if (!capo_ipset_member_cmp (m, member, ipset->type))
++	vec_add1 (indexes, m - ipset->members);
++    }
++
++  vec_foreach (index, indexes)
++    pool_put_index (ipset->members, *index);
++  vec_free (indexes);
++
++  return 0;
++}
++
++static clib_error_t *
++capo_ipsets_show_cmd_fn (vlib_main_t *vm, unformat_input_t *input,
++			 vlib_cli_command_t *cmd)
++{
++  capo_ipset_t *ipset;
++
++  pool_foreach (ipset, capo_ipsets)
++    vlib_cli_output (vm, "%U", format_capo_ipset, ipset);
++
++  return 0;
++}
++
++VLIB_CLI_COMMAND (capo_ipsets_show_cmd, static) = {
++  .path = "show capo ipsets",
++  .function = capo_ipsets_show_cmd_fn,
++  .short_help = "show capo ipsets",
++};
++
++static clib_error_t *
++capo_ipsets_add_cmd_fn (vlib_main_t *vm, unformat_input_t *input,
++			vlib_cli_command_t *cmd)
++{
++  unformat_input_t _line_input, *line_input = &_line_input;
++  capo_ipset_member_t tmp, *members = 0, *member;
++  clib_error_t *error = 0;
++  capo_ipset_type_t type;
++  capo_ipset_t *ipset;
++  u32 id;
++  int rv;
++
++  id = capo_ipset_create ((capo_ipset_type_t) ~0);
++  vlib_cli_output (vm, "capo ipset %d added", id);
++
++  if (!unformat_user (input, unformat_line_input, line_input))
++    return 0;
++
++  while (unformat_check_input (line_input) != UNFORMAT_END_OF_INPUT)
++    {
++      if (unformat (line_input, "%U", unformat_capo_ipset_member, &tmp, &type))
++	vec_add1 (members, tmp);
++      else
++	{
++	  error = clib_error_return (0, "unknown input '%U'",
++				     format_unformat_error, line_input);
++	  goto done;
++	}
++    }
++
++  ipset = pool_elt_at_index (capo_ipsets, id);
++  ipset->type = type;
++
++  vec_foreach (member, members)
++    {
++      rv = capo_ipset_add_member (id, member);
++      if (rv)
++	error = clib_error_return (0, "capo_ipset_add_member error %d", rv);
++    }
++
++done:
++  vec_free (members);
++  unformat_free (line_input);
++  return error;
++}
++
++VLIB_CLI_COMMAND (capo_ipsets_add_cmd, static) = {
++  .path = "capo ipset add",
++  .function = capo_ipsets_add_cmd_fn,
++  .short_help = "capo ipset add [prefix|proto ip port|ip]",
++};
++
++static clib_error_t *
++capo_ipsets_del_cmd_fn (vlib_main_t *vm, unformat_input_t *input,
++			vlib_cli_command_t *cmd)
++{
++  unformat_input_t _line_input, *line_input = &_line_input;
++  clib_error_t *error = 0;
++  u32 id = CAPO_INVALID_INDEX;
++  int rv;
++
++  if (!unformat_user (input, unformat_line_input, line_input))
++    return clib_error_return (0, "missing ipset id");
++
++  while (unformat_check_input (line_input) != UNFORMAT_END_OF_INPUT)
++    {
++      if (unformat (line_input, "%u", &id))
++	;
++      else
++	{
++	  error = clib_error_return (0, "unknown input '%U'",
++				     format_unformat_error, line_input);
++	  goto done;
++	}
++    }
++
++  if (CAPO_INVALID_INDEX == id)
++    {
++      error = clib_error_return (0, "missing ipset id");
++      goto done;
++    }
++
++  rv = capo_ipset_delete (id);
++  if (rv)
++    error = clib_error_return (0, "capo_ipset_delete errored with %d", rv);
++
++done:
++  unformat_free (line_input);
++  return error;
++}
++
++VLIB_CLI_COMMAND (capo_ipsets_del_cmd, static) = {
++  .path = "capo ipset del",
++  .function = capo_ipsets_del_cmd_fn,
++  .short_help = "capo ipset del [id]",
++};
++
++static clib_error_t *
++capo_ipsets_add_member_cmd_fn (vlib_main_t *vm, unformat_input_t *input,
++			       vlib_cli_command_t *cmd)
++{
++  unformat_input_t _line_input, *line_input = &_line_input;
++  capo_ipset_member_t tmp, *members = 0, *member;
++  u32 id = CAPO_INVALID_INDEX;
++  clib_error_t *error = 0;
++  capo_ipset_type_t type;
++  capo_ipset_t *ipset;
++  int rv;
++
++  if (!unformat_user (input, unformat_line_input, line_input))
++    return clib_error_return (0, "missing parameters");
++
++  while (unformat_check_input (line_input) != UNFORMAT_END_OF_INPUT)
++    {
++      if (unformat (line_input, "id %u", &id))
++	;
++      else if (unformat (line_input, "%U", unformat_capo_ipset_member, &tmp,
++			 &type))
++	vec_add1 (members, tmp);
++      else
++	{
++	  error = clib_error_return (0, "unknown input '%U'",
++				     format_unformat_error, line_input);
++	  goto done;
++	}
++    }
++
++  if (CAPO_INVALID_INDEX == id)
++    {
++      error = clib_error_return (0, "missing ipset id");
++      goto done;
++    }
++
++  ipset = capo_ipsets_get_if_exists (id);
++  if (NULL == ipset)
++    return clib_error_return (0, "ipset not found");
++  if (ipset->type != type && ~0 != ipset->type)
++    {
++      error = clib_error_return (0, "cannot change ipset type");
++      goto done;
++    }
++  ipset->type = type;
++
++  vec_foreach (member, members)
++    {
++      rv = capo_ipset_add_member (id, member);
++      if (rv)
++	error = clib_error_return (0, "capo_ipset_add_member error %d", rv);
++    }
++
++done:
++  vec_free (members);
++  unformat_free (line_input);
++  return error;
++}
++
++VLIB_CLI_COMMAND (capo_ipsets_add_member_cmd, static) = {
++  .path = "capo ipset add member",
++  .function = capo_ipsets_add_member_cmd_fn,
++  .short_help = "capo ipset add member [id] [prefix]",
++};
++
++static clib_error_t *
++capo_ipsets_del_member_cmd_fn (vlib_main_t *vm, unformat_input_t *input,
++			       vlib_cli_command_t *cmd)
++{
++  unformat_input_t _line_input, *line_input = &_line_input;
++  clib_error_t *error = 0;
++  u32 id = CAPO_INVALID_INDEX;
++  capo_ipset_type_t type;
++  capo_ipset_member_t tmp, *members = 0, *member;
++  capo_ipset_t *ipset;
++  int rv;
++
++  if (!unformat_user (input, unformat_line_input, line_input))
++    return clib_error_return (0, "missing parameters");
++
++  while (unformat_check_input (line_input) != UNFORMAT_END_OF_INPUT)
++    {
++      if (unformat (line_input, "id %u", &id))
++	;
++      else if (unformat (line_input, "%U", unformat_capo_ipset_member, &tmp,
++			 &type))
++	vec_add1 (members, tmp);
++      else
++	{
++	  error = clib_error_return (0, "unknown input '%U'",
++				     format_unformat_error, line_input);
++	  goto done;
++	}
++    }
++
++  if (CAPO_INVALID_INDEX == id)
++    {
++      error = clib_error_return (0, "missing ipset id");
++      goto done;
++    }
++
++  ipset = capo_ipsets_get_if_exists (id);
++  if (NULL == ipset)
++    return clib_error_return (0, "ipset not found");
++  if (ipset->type != type)
++    {
++      error = clib_error_return (0, "wrong member type");
++      goto done;
++    }
++
++  vec_foreach (member, members)
++    {
++      rv = capo_ipset_del_member (id, member);
++      if (rv)
++	error =
++	  clib_error_return (0, "capo_ipset_del_member errored with %d", rv);
++    }
++
++done:
++  vec_free (members);
++  unformat_free (line_input);
++  return error;
++}
++
++VLIB_CLI_COMMAND (capo_ipsets_del_member_cmd, static) = {
++  .path = "capo ipset del member",
++  .function = capo_ipsets_del_member_cmd_fn,
++  .short_help = "capo ipset del member [id] [prefix]",
++};
++
++/*
++ * fd.io coding-style-patch-verification: ON
++ *
++ * Local Variables:
++ * eval: (c-set-style "gnu")
++ * End:
++ */
+diff --git a/src/plugins/capo/capo_ipset.h b/src/plugins/capo/capo_ipset.h
+new file mode 100644
+index 000000000..56bb0f466
+--- /dev/null
++++ b/src/plugins/capo/capo_ipset.h
+@@ -0,0 +1,68 @@
++/*
++ * Copyright (c) 2020 Cisco and/or its affiliates.
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at:
++ *
++ *     http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ */
++
++#ifndef included_capo_ipset_h
++#define included_capo_ipset_h
++
++#include <capo/capo.h>
++
++typedef enum
++{
++  IPSET_TYPE_IP = 0,
++  IPSET_TYPE_IPPORT = 1,
++  IPSET_TYPE_NET = 2
++} capo_ipset_type_t;
++
++typedef struct
++{
++  ip_address_t addr;
++  u16 port;
++  u8 l4proto;
++} capo_ipport_t;
++
++typedef union
++{
++  ip_address_t address;
++  capo_ipport_t ipport;
++  ip_prefix_t prefix;
++} capo_ipset_member_t;
++
++typedef struct
++{
++  capo_ipset_type_t type;
++  capo_ipset_member_t *members;
++} capo_ipset_t;
++
++u32 capo_ipset_create (capo_ipset_type_t type);
++int capo_ipset_delete (u32 id);
++
++int capo_ipset_add_member (u32 ipset_id, capo_ipset_member_t *member);
++int capo_ipset_del_member (u32 ipset_id, capo_ipset_member_t *member);
++
++int capo_ipset_get_type (u32 id, capo_ipset_type_t *type);
++u8 *format_capo_ipset (u8 *s, va_list *args);
++capo_ipset_t *capo_ipsets_get_if_exists (u32 index);
++
++extern capo_ipset_t *capo_ipsets;
++
++#endif
++
++/*
++ * fd.io coding-style-patch-verification: ON
++ *
++ * Local Variables:
++ * eval: (c-set-style "gnu")
++ * End:
++ */
+diff --git a/src/plugins/capo/capo_match.c b/src/plugins/capo/capo_match.c
+new file mode 100644
+index 000000000..eed0cb233
+--- /dev/null
++++ b/src/plugins/capo/capo_match.c
+@@ -0,0 +1,736 @@
++/*
++ * Copyright (c) 2020 Cisco and/or its affiliates.
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at:
++ *
++ *     http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ */
++
++#include <vnet/ip/ip.h>
++
++#include <capo/capo.h>
++#include <capo/capo_match.h>
++
++/* for our bihash 8_24 */
++#include <vppinfra/bihash_template.c>
++
++int
++capo_match_func (void *p_acl_main, u32 sw_if_index, u32 is_inbound,
++		 fa_5tuple_opaque_t *opaque_5tuple, int is_ip6, u8 *r_action,
++		 u32 *trace_bitmap)
++{
++  fa_5tuple_t *pkt_5tuple = (fa_5tuple_t *) opaque_5tuple;
++  clib_bihash_kv_8_24_t conf_kv;
++  capo_interface_config_t *if_config;
++  capo_policy_t *policy;
++  u32 *policies;
++  int r;
++  u32 i;
++
++  conf_kv.key = sw_if_index;
++  if (clib_bihash_search_8_24 (&capo_main.if_config, &conf_kv, &conf_kv) != 0)
++    {
++      /* no config for this interface found, allow */
++      *r_action = 2;
++      return 0;
++    }
++  if_config = (capo_interface_config_t *) conf_kv.value;
++  policies =
++    is_inbound ? if_config->egress_policies : if_config->ingress_policies;
++
++  if (vec_len (policies) == 0)
++    goto profiles; /* no policies, jump to profiles */
++
++  *r_action = 0; /* drop by default */
++
++  vec_foreach_index (i, policies)
++    {
++      policy = &capo_policies[policies[i]];
++      r = capo_match_policy (policy, is_inbound, is_ip6, pkt_5tuple);
++      switch (r)
++	{
++	case CAPO_ALLOW:
++	  *r_action = 2; /* allow */
++	  return 1;
++	case CAPO_DENY:
++	  return 1;
++	case CAPO_PASS:
++	  goto profiles;
++	case CAPO_LOG:
++	  /* TODO: support LOG action */
++	  break;
++	default:
++	  break;
++	}
++    };
++  /* nothing matched, deny */
++  return 1;
++
++profiles:
++  if (vec_len (if_config->profiles) == 0)
++    {
++      *r_action = 2; /* no profiles, allow */
++      return 1;
++    }
++
++  vec_foreach_index (i, if_config->profiles)
++    {
++      policy = &capo_policies[if_config->profiles[i]];
++      r = capo_match_policy (policy, is_inbound, is_ip6, pkt_5tuple);
++      switch (r)
++	{
++	case CAPO_ALLOW:
++	  *r_action = 2; /* allow */
++	  return 1;
++	case CAPO_DENY:
++	  return 1;
++	case CAPO_PASS:
++	  clib_warning ("error: pass in profile %u", if_config->profiles[i]);
++	  return 1;
++	case CAPO_LOG:
++	  /* TODO: support LOG action */
++	  break;
++	default:
++	  break;
++	}
++    };
++  /* nothing matched, deny */
++  return 1;
++}
++
++int
++capo_match_policy (capo_policy_t *policy, u32 is_inbound, u32 is_ip6,
++		   fa_5tuple_t *pkt_5tuple)
++{
++  /* inbound packet from VPP pov is outbound from container pov - need to match
++     it against TX policies */
++  u32 *rules =
++    is_inbound ? policy->rule_ids[VLIB_TX] : policy->rule_ids[VLIB_RX];
++  u32 *rule_id;
++  capo_rule_t *rule;
++  int r;
++
++  vec_foreach (rule_id, rules)
++    {
++      rule = &capo_rules[*rule_id];
++      r = capo_match_rule (rule, is_ip6, pkt_5tuple);
++      if (r >= 0)
++	{
++	  return r;
++	}
++    }
++  return -1;
++}
++
++#define SRC 0
++#define DST 1
++
++int
++capo_match_rule (capo_rule_t *rule, u32 is_ip6, fa_5tuple_t *pkt_5tuple)
++{
++  //   if (is_ip6 != (rule->af == AF_IP6)) {
++  //       return -1;
++  //   }
++
++  ip4_address_t *src_ip4 = &pkt_5tuple->ip4_addr[SRC];
++  ip4_address_t *dst_ip4 = &pkt_5tuple->ip4_addr[DST];
++  ip6_address_t *src_ip6 = &pkt_5tuple->ip6_addr[SRC];
++  ip6_address_t *dst_ip6 = &pkt_5tuple->ip6_addr[DST];
++  u8 l4proto = pkt_5tuple->l4.proto;
++  u16 src_port = pkt_5tuple->l4.port[SRC];
++  u16 dst_port = pkt_5tuple->l4.port[DST];
++  u16 type = pkt_5tuple->l4.port[0];
++  u16 code = pkt_5tuple->l4.port[1];
++
++  capo_rule_filter_t *filter;
++  vec_foreach (filter, rule->filters)
++    {
++      switch (filter->type)
++	{
++	case CAPO_RULE_FILTER_NONE_TYPE:
++	  break;
++	case CAPO_RULE_FILTER_L4_PROTO:
++	  if (filter->should_match && filter->value != l4proto)
++	    return -1;
++	  if (!filter->should_match && filter->value == l4proto)
++	    return -2;
++	  break;
++	case CAPO_RULE_FILTER_ICMP_TYPE:
++	  if (l4proto == IP_PROTOCOL_ICMP || l4proto == IP_PROTOCOL_ICMP6)
++	    {
++	      if (filter->should_match && filter->value != type)
++		return -3;
++	      if (!filter->should_match && filter->value == type)
++		return -4;
++	    }
++	  else
++	    // A rule with an ICMP type / code specified doesn't match a
++	    // non-icmp packet
++	    return -5;
++	  break;
++	case CAPO_RULE_FILTER_ICMP_CODE:
++	  if (l4proto == IP_PROTOCOL_ICMP || l4proto == IP_PROTOCOL_ICMP6)
++	    {
++	      if (filter->should_match && filter->value != code)
++		return -6;
++	      if (!filter->should_match && filter->value == code)
++		return -7;
++	    }
++	  else
++	    // A rule with an ICMP type / code specified doesn't match a
++	    // non-icmp packet
++	    return -8;
++	  break;
++	default:
++	  // clib_warning ("unimplemented capo filter!");
++	  break;
++	}
++    }
++
++  /* prefixes */
++  if (rule->prefixes[CAPO_SRC])
++    {
++      ip_prefix_t *prefix;
++      u8 found = 0;
++      vec_foreach (prefix, rule->prefixes[CAPO_SRC])
++	{
++	  u8 pfx_af = ip_prefix_version (prefix);
++	  if (is_ip6 && pfx_af == AF_IP6)
++	    {
++	      if (ip6_destination_matches_route (&ip6_main, src_ip6,
++						 &ip_addr_v6 (&prefix->addr),
++						 prefix->len))
++		{
++		  found = 1;
++		  break;
++		}
++	    }
++	  else if (!is_ip6 && pfx_af == AF_IP4)
++	    {
++	      if (ip4_destination_matches_route (&ip4_main, src_ip4,
++						 &ip_addr_v4 (&prefix->addr),
++						 prefix->len))
++		{
++		  found = 1;
++		  break;
++		}
++	    }
++	}
++      if (!found)
++	{
++	  return -9;
++	}
++    }
++
++  if (rule->prefixes[CAPO_NOT_SRC])
++    {
++      ip_prefix_t *prefix;
++      vec_foreach (prefix, rule->prefixes[CAPO_NOT_SRC])
++	{
++	  u8 pfx_af = ip_prefix_version (prefix);
++	  if (is_ip6 && pfx_af == AF_IP6)
++	    {
++	      if (ip6_destination_matches_route (&ip6_main, src_ip6,
++						 &ip_addr_v6 (&prefix->addr),
++						 prefix->len))
++		{
++		  return -10;
++		}
++	    }
++	  else if (!is_ip6 && pfx_af == AF_IP4)
++	    {
++	      if (ip4_destination_matches_route (&ip4_main, src_ip4,
++						 &ip_addr_v4 (&prefix->addr),
++						 prefix->len))
++		{
++		  return -11;
++		}
++	    }
++	}
++    }
++
++  if (rule->prefixes[CAPO_DST])
++    {
++      ip_prefix_t *prefix;
++      u8 found = 0;
++      vec_foreach (prefix, rule->prefixes[CAPO_DST])
++	{
++	  u8 pfx_af = ip_prefix_version (prefix);
++	  if (is_ip6 && pfx_af == AF_IP6)
++	    {
++	      if (ip6_destination_matches_route (&ip6_main, dst_ip6,
++						 &ip_addr_v6 (&prefix->addr),
++						 prefix->len))
++		{
++		  found = 1;
++		  break;
++		}
++	    }
++	  else if (!is_ip6 && pfx_af == AF_IP4)
++	    {
++	      if (ip4_destination_matches_route (&ip4_main, dst_ip4,
++						 &ip_addr_v4 (&prefix->addr),
++						 prefix->len))
++		{
++		  found = 1;
++		  break;
++		}
++	    }
++	}
++      if (!found)
++	{
++	  return -12;
++	}
++    }
++
++  if (rule->prefixes[CAPO_NOT_DST])
++    {
++      ip_prefix_t *prefix;
++      vec_foreach (prefix, rule->prefixes[CAPO_NOT_DST])
++	{
++	  u8 pfx_af = ip_prefix_version (prefix);
++	  if (is_ip6 && pfx_af == AF_IP6)
++	    {
++	      if (ip6_destination_matches_route (&ip6_main, dst_ip6,
++						 &ip_addr_v6 (&prefix->addr),
++						 prefix->len))
++		{
++		  return -13;
++		}
++	    }
++	  else if (!is_ip6 && pfx_af == AF_IP4)
++	    {
++	      if (ip4_destination_matches_route (&ip4_main, dst_ip4,
++						 &ip_addr_v4 (&prefix->addr),
++						 prefix->len))
++		{
++		  return -14;
++		}
++	    }
++	}
++    }
++
++  /* IP ipsets */
++  if (rule->ip_ipsets[CAPO_SRC])
++    {
++      u32 *ipset;
++      u8 found = 0;
++      vec_foreach (ipset, rule->ip_ipsets[CAPO_SRC])
++	{
++	  if (is_ip6)
++	    {
++	      if (ipset_contains_ip6 (&capo_ipsets[*ipset], src_ip6))
++		{
++		  found = 1;
++		  break;
++		}
++	    }
++	  else
++	    {
++	      if (ipset_contains_ip4 (&capo_ipsets[*ipset], src_ip4))
++		{
++		  found = 1;
++		  break;
++		}
++	    }
++	}
++      if (!found)
++	{
++	  return -15;
++	}
++    }
++
++  if (rule->ip_ipsets[CAPO_NOT_SRC])
++    {
++      u32 *ipset;
++      vec_foreach (ipset, rule->ip_ipsets[CAPO_NOT_SRC])
++	{
++	  if (is_ip6)
++	    {
++	      if (ipset_contains_ip6 (&capo_ipsets[*ipset], src_ip6))
++		{
++		  return -16;
++		}
++	    }
++	  else
++	    {
++	      if (ipset_contains_ip4 (&capo_ipsets[*ipset], src_ip4))
++		{
++		  return -17;
++		}
++	    }
++	}
++    }
++
++  if (rule->ip_ipsets[CAPO_DST])
++    {
++      u32 *ipset;
++      u8 found = 0;
++      vec_foreach (ipset, rule->ip_ipsets[CAPO_DST])
++	{
++	  if (is_ip6)
++	    {
++	      if (ipset_contains_ip6 (&capo_ipsets[*ipset], dst_ip6))
++		{
++		  found = 1;
++		  break;
++		}
++	    }
++	  else
++	    {
++	      if (ipset_contains_ip4 (&capo_ipsets[*ipset], dst_ip4))
++		{
++		  found = 1;
++		  break;
++		}
++	    }
++	}
++      if (!found)
++	{
++	  return -18;
++	}
++    }
++
++  if (rule->ip_ipsets[CAPO_NOT_DST])
++    {
++      u32 *ipset;
++      vec_foreach (ipset, rule->ip_ipsets[CAPO_NOT_DST])
++	{
++	  if (is_ip6)
++	    {
++	      if (ipset_contains_ip6 (&capo_ipsets[*ipset], dst_ip6))
++		{
++		  return -19;
++		}
++	    }
++	  else
++	    {
++	      if (ipset_contains_ip4 (&capo_ipsets[*ipset], dst_ip4))
++		{
++		  return -20;
++		}
++	    }
++	}
++    }
++
++  /* Special treatment for src / dst ports: they need to be in either the port
++     ranges or the port + ip ipsets / */
++  u8 src_port_found = 0;
++  u8 dst_port_found = 0;
++
++  /* port ranges */
++  if (rule->port_ranges[CAPO_SRC])
++    {
++      capo_port_range_t *range;
++      vec_foreach (range, rule->port_ranges[CAPO_SRC])
++	{
++	  if (range->start <= src_port && src_port <= range->end)
++	    {
++	      src_port_found = 1;
++	      break;
++	    }
++	}
++    }
++
++  if (rule->port_ranges[CAPO_NOT_SRC])
++    {
++      capo_port_range_t *range;
++      vec_foreach (range, rule->port_ranges[CAPO_NOT_SRC])
++	{
++	  if (range->start <= src_port && src_port <= range->end)
++	    {
++	      return -21;
++	    }
++	}
++    }
++
++  if (rule->port_ranges[CAPO_DST])
++    {
++      capo_port_range_t *range;
++      vec_foreach (range, rule->port_ranges[CAPO_DST])
++	{
++	  if (range->start <= dst_port && dst_port <= range->end)
++	    {
++	      dst_port_found = 1;
++	      break;
++	    }
++	}
++    }
++
++  if (rule->port_ranges[CAPO_NOT_DST])
++    {
++      capo_port_range_t *range;
++      vec_foreach (range, rule->port_ranges[CAPO_NOT_DST])
++	{
++	  if (range->start <= dst_port && dst_port <= range->end)
++	    {
++	      return -22;
++	    }
++	}
++    }
++
++  /* ipport ipsets */
++  if (rule->ipport_ipsets[CAPO_SRC])
++    {
++      u32 *ipset;
++      vec_foreach (ipset, rule->ipport_ipsets[CAPO_SRC])
++	{
++	  if (is_ip6)
++	    {
++	      if (ipport_ipset_contains_ip6 (&capo_ipsets[*ipset], src_ip6,
++					     l4proto, src_port))
++		{
++		  src_port_found = 1;
++		  break;
++		}
++	    }
++	  else
++	    {
++	      if (ipport_ipset_contains_ip4 (&capo_ipsets[*ipset], src_ip4,
++					     l4proto, src_port))
++		{
++		  src_port_found = 1;
++		  break;
++		}
++	    }
++	}
++    }
++
++  if (rule->ipport_ipsets[CAPO_NOT_SRC])
++    {
++      u32 *ipset;
++      vec_foreach (ipset, rule->ipport_ipsets[CAPO_NOT_SRC])
++	{
++	  if (is_ip6)
++	    {
++	      if (ipport_ipset_contains_ip6 (&capo_ipsets[*ipset], src_ip6,
++					     l4proto, src_port))
++		{
++		  return -23;
++		}
++	    }
++	  else
++	    {
++	      if (ipport_ipset_contains_ip4 (&capo_ipsets[*ipset], src_ip4,
++					     l4proto, src_port))
++		{
++		  return -24;
++		}
++	    }
++	}
++    }
++
++  if (rule->ipport_ipsets[CAPO_DST])
++    {
++      u32 *ipset;
++      vec_foreach (ipset, rule->ipport_ipsets[CAPO_DST])
++	{
++	  if (is_ip6)
++	    {
++	      if (ipport_ipset_contains_ip6 (&capo_ipsets[*ipset], dst_ip6,
++					     l4proto, dst_port))
++		{
++		  dst_port_found = 1;
++		  break;
++		}
++	    }
++	  else
++	    {
++	      if (ipport_ipset_contains_ip4 (&capo_ipsets[*ipset], dst_ip4,
++					     l4proto, dst_port))
++		{
++		  dst_port_found = 1;
++		  break;
++		}
++	    }
++	}
++    }
++
++  if (rule->ipport_ipsets[CAPO_NOT_DST])
++    {
++      u32 *ipset;
++      vec_foreach (ipset, rule->ipport_ipsets[CAPO_NOT_DST])
++	{
++	  if (is_ip6)
++	    {
++	      if (ipport_ipset_contains_ip6 (&capo_ipsets[*ipset], dst_ip6,
++					     l4proto, dst_port))
++		{
++		  return -25;
++		}
++	    }
++	  else
++	    {
++	      if (ipport_ipset_contains_ip4 (&capo_ipsets[*ipset], dst_ip4,
++					     l4proto, dst_port))
++		{
++		  return -26;
++		}
++	    }
++	}
++    }
++
++  if ((rule->port_ranges[CAPO_SRC] || rule->ipport_ipsets[CAPO_SRC]) &&
++      (!src_port_found))
++    {
++      return -27;
++    }
++  if ((rule->port_ranges[CAPO_DST] || rule->ipport_ipsets[CAPO_DST]) &&
++      (!dst_port_found))
++    {
++      return -28;
++    }
++
++  return rule->action;
++}
++
++u8
++ip_ipset_contains_ip4 (capo_ipset_t *ipset, ip4_address_t *addr)
++{
++  ASSERT (ipset->type == IPSET_TYPE_IP);
++  capo_ipset_member_t *member;
++  pool_foreach (member, ipset->members)
++    {
++      if (member->address.version != AF_IP4)
++	continue;
++      if (!ip4_address_compare (addr, &ip_addr_v4 (&member->address)))
++	return 1;
++    }
++  return 0;
++}
++
++u8
++ip_ipset_contains_ip6 (capo_ipset_t *ipset, ip6_address_t *addr)
++{
++  ASSERT (ipset->type == IPSET_TYPE_IP);
++  capo_ipset_member_t *member;
++  pool_foreach (member, ipset->members)
++    {
++      if (member->address.version != AF_IP6)
++	continue;
++      if (!ip6_address_compare (addr, &ip_addr_v6 (&member->address)))
++	return 1;
++    }
++  return 0;
++}
++
++u8
++net_ipset_contains_ip4 (capo_ipset_t *ipset, ip4_address_t *addr)
++{
++  ASSERT (ipset->type == IPSET_TYPE_NET);
++  capo_ipset_member_t *member;
++  pool_foreach (member, ipset->members)
++    {
++      if (member->prefix.addr.version != AF_IP4)
++	continue;
++      if (ip4_destination_matches_route (&ip4_main, addr,
++					 &ip_addr_v4 (&member->prefix.addr),
++					 member->prefix.len))
++	{
++	  return 1;
++	}
++    }
++  return 0;
++}
++
++u8
++net_ipset_contains_ip6 (capo_ipset_t *ipset, ip6_address_t *addr)
++{
++  ASSERT (ipset->type == IPSET_TYPE_NET);
++  capo_ipset_member_t *member;
++  pool_foreach (member, ipset->members)
++    {
++      if (member->prefix.addr.version != AF_IP6)
++	continue;
++      if (ip6_destination_matches_route (&ip6_main, addr,
++					 &ip_addr_v6 (&member->prefix.addr),
++					 member->prefix.len))
++	{
++	  return 1;
++	}
++    }
++  return 0;
++}
++
++u8
++ipset_contains_ip4 (capo_ipset_t *ipset, ip4_address_t *addr)
++{
++  switch (ipset->type)
++    {
++    case IPSET_TYPE_IP:
++      return ip_ipset_contains_ip4 (ipset, addr);
++    case IPSET_TYPE_NET:
++      return net_ipset_contains_ip4 (ipset, addr);
++    default:
++      clib_warning ("Wrong ipset type");
++    }
++  return 0;
++}
++
++u8
++ipset_contains_ip6 (capo_ipset_t *ipset, ip6_address_t *addr)
++{
++  switch (ipset->type)
++    {
++    case IPSET_TYPE_IP:
++      return ip_ipset_contains_ip6 (ipset, addr);
++    case IPSET_TYPE_NET:
++      return net_ipset_contains_ip6 (ipset, addr);
++    default:
++      clib_warning ("Wrong ipset type");
++    }
++  return 0;
++}
++
++u8
++ipport_ipset_contains_ip4 (capo_ipset_t *ipset, ip4_address_t *addr,
++			   u8 l4proto, u16 port)
++{
++  ASSERT (ipset->type == IPSET_TYPE_IPPORT);
++  capo_ipset_member_t *member;
++  pool_foreach (member, ipset->members)
++    {
++      if (member->ipport.addr.version != AF_IP4)
++	continue;
++      if (l4proto == member->ipport.l4proto && port == member->ipport.port &&
++	  !ip4_address_compare (addr, &ip_addr_v4 (&member->ipport.addr)))
++	{
++	  return 1;
++	}
++    }
++  return 0;
++}
++
++u8
++ipport_ipset_contains_ip6 (capo_ipset_t *ipset, ip6_address_t *addr,
++			   u8 l4proto, u16 port)
++{
++  ASSERT (ipset->type == IPSET_TYPE_IPPORT);
++  capo_ipset_member_t *member;
++  pool_foreach (member, ipset->members)
++    {
++      if (member->ipport.addr.version != AF_IP6)
++	continue;
++      if (l4proto == member->ipport.l4proto && port == member->ipport.port &&
++	  !ip6_address_compare (addr, &ip_addr_v6 (&member->ipport.addr)))
++	{
++	  return 1;
++	}
++    }
++  return 0;
++}
++
++/*
++ * fd.io coding-style-patch-verification: ON
++ *
++ * Local Variables:
++ * eval: (c-set-style "gnu")
++ * End:
++ */
+diff --git a/src/plugins/capo/capo_match.h b/src/plugins/capo/capo_match.h
+new file mode 100644
+index 000000000..fe1907485
+--- /dev/null
++++ b/src/plugins/capo/capo_match.h
+@@ -0,0 +1,49 @@
++/*
++ * Copyright (c) 2020 Cisco and/or its affiliates.
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at:
++ *
++ *     http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ */
++
++#ifndef included_capo_match_h
++#define included_capo_match_h
++
++#include <acl/acl.h>
++#include <acl/fa_node.h>
++
++#include <capo/capo_ipset.h>
++#include <capo/capo_policy.h>
++#include <capo/capo_rule.h>
++
++int capo_match_func (void *p_acl_main, u32 sw_if_index, u32 is_inbound,
++		     fa_5tuple_opaque_t *opaque_5tuple, int is_ip6,
++		     u8 *r_action, u32 *trace_bitmap);
++
++int capo_match_policy (capo_policy_t *policy, u32 is_inbound, u32 is_ip6,
++		       fa_5tuple_t *pkt_5tuple);
++int capo_match_rule (capo_rule_t *rule, u32 is_ip6, fa_5tuple_t *pkt_5tuple);
++
++u8 ipset_contains_ip4 (capo_ipset_t *ipset, ip4_address_t *addr);
++u8 ipset_contains_ip6 (capo_ipset_t *ipset, ip6_address_t *addr);
++u8 ipport_ipset_contains_ip4 (capo_ipset_t *ipset, ip4_address_t *addr,
++			      u8 l4proto, u16 port);
++u8 ipport_ipset_contains_ip6 (capo_ipset_t *ipset, ip6_address_t *addr,
++			      u8 l4proto, u16 port);
++
++#endif
++
++/*
++ * fd.io coding-style-patch-verification: ON
++ *
++ * Local Variables:
++ * eval: (c-set-style "gnu")
++ * End:
++ */
+diff --git a/src/plugins/capo/capo_policy.c b/src/plugins/capo/capo_policy.c
+new file mode 100644
+index 000000000..86c61b8cc
+--- /dev/null
++++ b/src/plugins/capo/capo_policy.c
+@@ -0,0 +1,263 @@
++/*
++ * Copyright (c) 2020 Cisco and/or its affiliates.
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at:
++ *
++ *     http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ */
++
++#include <capo/capo.h>
++#include <capo/capo_policy.h>
++#include <capo/capo_rule.h>
++
++capo_policy_t *capo_policies;
++
++static capo_policy_t *
++capo_policy_alloc ()
++{
++  capo_policy_t *policy;
++  pool_get_zero (capo_policies, policy);
++  return policy;
++}
++
++capo_policy_t *
++capo_policy_get_if_exists (u32 index)
++{
++  if (pool_is_free_index (capo_policies, index))
++    return (NULL);
++  return pool_elt_at_index (capo_policies, index);
++}
++
++static void
++capo_policy_cleanup (capo_policy_t *policy)
++{
++  for (int i = 0; i < VLIB_N_RX_TX; i++)
++    vec_free (policy->rule_ids[i]);
++}
++
++int
++capo_policy_update (u32 *id, capo_policy_rule_t *rules)
++{
++  capo_policy_t *policy;
++  capo_policy_rule_t *rule;
++
++  policy = capo_policy_get_if_exists (*id);
++  if (policy)
++    capo_policy_cleanup (policy);
++  else
++    policy = capo_policy_alloc ();
++
++  vec_foreach (rule, rules)
++    vec_add1 (policy->rule_ids[rule->direction], rule->rule_id);
++
++  *id = policy - capo_policies;
++  return 0;
++}
++
++int
++capo_policy_delete (u32 id)
++{
++  capo_policy_t *policy;
++  policy = capo_policy_get_if_exists (id);
++  if (NULL == policy)
++    return VNET_API_ERROR_NO_SUCH_ENTRY;
++
++  capo_policy_cleanup (policy);
++  pool_put (capo_policies, policy);
++
++  return 0;
++}
++
++u8 *
++format_capo_policy (u8 *s, va_list *args)
++{
++  capo_policy_t *policy = va_arg (*args, capo_policy_t *);
++  int indent = va_arg (*args, int);
++  int verbose = va_arg (*args, int);
++  u32 *rule_id;
++
++  if (policy == NULL)
++    return format (s, "deleted policy");
++
++  if (verbose)
++    {
++      s = format (s, "[policy#%u]\n", policy - capo_policies);
++      capo_rule_t *rule;
++      if (verbose != CAPO_POLICY_ONLY_INGRESS)
++	vec_foreach (rule_id, policy->rule_ids[VLIB_TX])
++	  {
++	    rule = capo_rule_get_if_exists (*rule_id);
++	    s = format (s, "%Uegress :%U\n", format_white_space, indent + 2,
++			format_capo_rule, rule);
++	  }
++      if (verbose != CAPO_POLICY_ONLY_EGRESS)
++	vec_foreach (rule_id, policy->rule_ids[VLIB_RX])
++	  {
++	    rule = capo_rule_get_if_exists (*rule_id);
++	    s = format (s, "%Uingress:%U\n", format_white_space, indent + 2,
++			format_capo_rule, rule);
++	  }
++    }
++  else
++    {
++      s = format (s, "[policy#%u] rx-rules:%d tx-rules:%d\n",
++		  policy - capo_policies, vec_len (policy->rule_ids[VLIB_RX]),
++		  vec_len (policy->rule_ids[VLIB_TX]));
++    }
++
++  return (s);
++}
++
++static clib_error_t *
++capo_policies_show_cmd_fn (vlib_main_t *vm, unformat_input_t *input,
++			   vlib_cli_command_t *cmd)
++{
++  unformat_input_t _line_input, *line_input = &_line_input;
++  clib_error_t *error = 0;
++  capo_policy_t *policy;
++  u8 verbose = 0, has_input = 0;
++
++  if (unformat_user (input, unformat_line_input, line_input))
++    {
++      has_input = 1;
++      while (unformat_check_input (line_input) != UNFORMAT_END_OF_INPUT)
++	{
++	  if (unformat (line_input, "verbose"))
++	    verbose = 1;
++	  else
++	    {
++	      error = clib_error_return (0, "unknown input '%U'",
++					 format_unformat_error, line_input);
++	      goto done;
++	    }
++	}
++    }
++
++  pool_foreach (policy, capo_policies)
++    vlib_cli_output (vm, "%U", format_capo_policy, policy, 0 /* indent */,
++		     verbose);
++
++done:
++  if (has_input)
++    unformat_free (line_input);
++  return error;
++}
++
++VLIB_CLI_COMMAND (capo_policies_show_cmd, static) = {
++  .path = "show capo policies",
++  .function = capo_policies_show_cmd_fn,
++  .short_help = "show capo policies [verbose]",
++};
++
++static clib_error_t *
++capo_policies_add_cmd_fn (vlib_main_t *vm, unformat_input_t *input,
++			  vlib_cli_command_t *cmd)
++{
++  unformat_input_t _line_input, *line_input = &_line_input;
++  clib_error_t *error = 0;
++  u32 id = CAPO_INVALID_INDEX, rule_id;
++  capo_policy_rule_t *policy_rules = 0, *policy_rule;
++  int direction = VLIB_RX;
++  int rv;
++
++  if (!unformat_user (input, unformat_line_input, line_input))
++    return clib_error_return (0, "missing parameters");
++
++  while (unformat_check_input (line_input) != UNFORMAT_END_OF_INPUT)
++    {
++      if (unformat (line_input, "update %u", &id))
++	;
++      else if (unformat (line_input, "%U", unformat_vlib_rx_tx, &direction))
++	;
++      else if (unformat (line_input, "%u", &rule_id))
++	{
++	  vec_add2 (policy_rules, policy_rule, 1);
++	  policy_rule->rule_id = rule_id;
++	  policy_rule->direction = direction;
++	}
++      else
++	{
++	  error = clib_error_return (0, "unknown input '%U'",
++				     format_unformat_error, line_input);
++	  goto done;
++	}
++    }
++
++  rv = capo_policy_update (&id, policy_rules);
++  if (rv)
++    error = clib_error_return (0, "capo_policy_delete errored with %d", rv);
++  else
++    vlib_cli_output (vm, "capo policy %d added", id);
++
++done:
++  vec_free (policy_rules);
++  unformat_free (line_input);
++  return error;
++}
++
++VLIB_CLI_COMMAND (capo_policies_add_cmd, static) = {
++  .path = "capo policy add",
++  .function = capo_policies_add_cmd_fn,
++  .short_help = "capo policy add [rx rule_id rule_id ...] [tx rule_id rule_id "
++		"...] [update [id]]",
++};
++
++static clib_error_t *
++capo_policies_del_cmd_fn (vlib_main_t *vm, unformat_input_t *input,
++			  vlib_cli_command_t *cmd)
++{
++  unformat_input_t _line_input, *line_input = &_line_input;
++  clib_error_t *error = 0;
++  u32 id = CAPO_INVALID_INDEX;
++  int rv;
++
++  if (!unformat_user (input, unformat_line_input, line_input))
++    return clib_error_return (0, "missing policy id");
++
++  while (unformat_check_input (line_input) != UNFORMAT_END_OF_INPUT)
++    {
++      if (unformat (line_input, "%u", &id))
++	;
++      else
++	{
++	  error = clib_error_return (0, "unknown input '%U'",
++				     format_unformat_error, line_input);
++	  goto done;
++	}
++    }
++
++  if (CAPO_INVALID_INDEX == id)
++    {
++      error = clib_error_return (0, "missing policy id");
++      goto done;
++    }
++
++  rv = capo_policy_delete (id);
++  if (rv)
++    error = clib_error_return (0, "capo_policy_delete errored with %d", rv);
++
++done:
++  unformat_free (line_input);
++  return error;
++}
++
++VLIB_CLI_COMMAND (capo_policies_del_cmd, static) = {
++  .path = "capo policy del",
++  .function = capo_policies_del_cmd_fn,
++  .short_help = "capo policy del [id]",
++};
++
++/*
++ * fd.io coding-style-patch-verification: ON
++ *
++ * Local Variables:
++ * eval: (c-set-style "gnu")
++ * End:
++ */
+diff --git a/src/plugins/capo/capo_policy.h b/src/plugins/capo/capo_policy.h
+new file mode 100644
+index 000000000..a98799929
+--- /dev/null
++++ b/src/plugins/capo/capo_policy.h
+@@ -0,0 +1,58 @@
++/*
++ * Copyright (c) 2020 Cisco and/or its affiliates.
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at:
++ *
++ *     http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ */
++
++#ifndef included_capo_policy_h
++#define included_capo_policy_h
++
++#include <capo/capo.h>
++
++typedef struct
++{
++  /* VLIB_RX for inbound
++     VLIB_TX for outbound */
++  u32 *rule_ids[VLIB_N_RX_TX];
++} capo_policy_t;
++
++typedef struct
++{
++  u32 rule_id;
++  /* VLIB_RX or VLIB_TX */
++  u8 direction;
++} capo_policy_rule_t;
++
++typedef enum
++{
++  CAPO_POLICY_QUIET,
++  CAPO_POLICY_VERBOSE,
++  CAPO_POLICY_ONLY_INGRESS,
++  CAPO_POLICY_ONLY_EGRESS,
++} capo_policy_format_type_t;
++
++extern capo_policy_t *capo_policies;
++
++int capo_policy_update (u32 *id, capo_policy_rule_t *rules);
++int capo_policy_delete (u32 id);
++u8 *format_capo_policy (u8 *s, va_list *args);
++capo_policy_t *capo_policy_get_if_exists (u32 index);
++
++#endif
++
++/*
++ * fd.io coding-style-patch-verification: ON
++ *
++ * Local Variables:
++ * eval: (c-set-style "gnu")
++ * End:
++ */
+diff --git a/src/plugins/capo/capo_rule.c b/src/plugins/capo/capo_rule.c
+new file mode 100644
+index 000000000..c672f29bd
+--- /dev/null
++++ b/src/plugins/capo/capo_rule.c
+@@ -0,0 +1,509 @@
++/*
++ * Copyright (c) 2020 Cisco and/or its affiliates.
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at:
++ *
++ *     http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ */
++
++#include <capo/capo.h>
++#include <capo/capo_rule.h>
++#include <capo/capo_ipset.h>
++
++capo_rule_t *capo_rules;
++
++u8 *
++format_capo_rule_action (u8 *s, va_list *args)
++{
++  capo_rule_action_t action = va_arg (*args, int);
++  switch (action)
++    {
++    case CAPO_ALLOW:
++      return format (s, "allow");
++    case CAPO_DENY:
++      return format (s, "deny");
++    case CAPO_LOG:
++      return format (s, "log");
++    case CAPO_PASS:
++      return format (s, "pass");
++    default:
++      return format (s, "unknownaction");
++    }
++}
++
++uword
++unformat_capo_rule_action (unformat_input_t *input, va_list *args)
++{
++  capo_rule_action_t *action = va_arg (*args, capo_rule_action_t *);
++  if (unformat (input, "allow"))
++    *action = CAPO_ALLOW;
++  else if (unformat (input, "deny"))
++    *action = CAPO_DENY;
++  else if (unformat (input, "log"))
++    *action = CAPO_LOG;
++  else if (unformat (input, "pass"))
++    *action = CAPO_PASS;
++  else
++    return 0;
++  return 1;
++}
++
++u8 *
++format_capo_rule_port_range (u8 *s, va_list *args)
++{
++  capo_port_range_t *port_range = va_arg (*args, capo_port_range_t *);
++
++  if (port_range->start != port_range->end)
++    s = format (s, "[%u-%u]", port_range->start, port_range->end);
++  else
++    s = format (s, "%u", port_range->start);
++
++  return (s);
++}
++
++u8 *
++format_capo_rule_entry (u8 *s, va_list *args)
++{
++  capo_rule_entry_t *entry = va_arg (*args, capo_rule_entry_t *);
++  capo_ipset_t *ipset;
++
++  s = format (s, "%s", entry->flags & CAPO_IS_SRC ? "src" : "dst");
++  s = format (s, "%s", entry->flags & CAPO_IS_NOT ? "!=" : "==");
++  switch (entry->type)
++    {
++    case CAPO_CIDR:
++      s = format (s, "%U", format_ip_prefix, &entry->data.cidr);
++      break;
++    case CAPO_PORT_RANGE:
++      s =
++	format (s, "%U", format_capo_rule_port_range, &entry->data.port_range);
++      break;
++    case CAPO_IP_SET:
++      ipset = capo_ipsets_get_if_exists (entry->data.set_id);
++      s = format (s, "%U", format_capo_ipset, ipset);
++      break;
++    case CAPO_PORT_IP_SET:
++      ipset = capo_ipsets_get_if_exists (entry->data.set_id);
++      s = format (s, "%U", format_capo_ipset, ipset);
++      break;
++    default:
++      s = format (s, "unknown");
++      break;
++    }
++  return (s);
++}
++
++uword
++unformat_rule_key_flag (unformat_input_t *input, va_list *args)
++{
++  capo_rule_key_flag_t *flags = va_arg (*args, capo_rule_key_flag_t *);
++  if (unformat (input, "src=="))
++    *flags = CAPO_IS_SRC;
++  else if (unformat (input, "src!="))
++    *flags = CAPO_IS_SRC | CAPO_IS_NOT;
++  else if (unformat (input, "dst!="))
++    *flags = CAPO_IS_NOT;
++  else if (unformat (input, "dst=="))
++    *flags = 0;
++  else
++    return 0;
++  return 1;
++}
++
++uword
++unformat_capo_port_range (unformat_input_t *input, va_list *args)
++{
++  capo_port_range_t *port_range = va_arg (*args, capo_port_range_t *);
++  u32 start, end;
++  if (unformat (input, "[%d-%d]", &start, &end))
++    {
++      port_range->start = (u16) start;
++      port_range->end = (u16) end;
++    }
++  else
++    return 0;
++  return 1;
++}
++
++uword
++unformat_capo_rule_entry (unformat_input_t *input, va_list *args)
++{
++  capo_rule_entry_t *entry = va_arg (*args, capo_rule_entry_t *);
++  if (unformat (input, "%U %U", unformat_rule_key_flag, &entry->flags,
++		unformat_ip_prefix, &entry->data.cidr))
++    entry->type = CAPO_CIDR;
++  else if (unformat (input, "%U %U", unformat_rule_key_flag, &entry->flags,
++		     unformat_capo_port_range, &entry->data.port_range))
++    entry->type = CAPO_PORT_RANGE;
++  else if (unformat (input, "%Uset %u", unformat_rule_key_flag, &entry->flags,
++		     &entry->data.set_id))
++    entry->type = CAPO_PORT_IP_SET;
++  else
++    return 0;
++  return 1;
++}
++
++u8 *
++format_capo_rule_filter (u8 *s, va_list *args)
++{
++  capo_rule_filter_t *filter = va_arg (*args, capo_rule_filter_t *);
++  switch (filter->type)
++    {
++    case CAPO_RULE_FILTER_NONE_TYPE:
++      return format (s, "<no filter>");
++    case CAPO_RULE_FILTER_ICMP_TYPE:
++      return format (s, "icmp-type%s=%d", filter->should_match ? "=" : "!",
++		     filter->value);
++    case CAPO_RULE_FILTER_ICMP_CODE:
++      return format (s, "icmp-code%s=%d", filter->should_match ? "=" : "!",
++		     filter->value);
++    case CAPO_RULE_FILTER_L4_PROTO:
++      return format (s, "proto%s=%U", filter->should_match ? "=" : "!",
++		     format_ip_protocol, filter->value);
++    default:
++      return format (s, "unknown");
++    }
++}
++
++uword
++unformat_capo_should_match (unformat_input_t *input, va_list *args)
++{
++  u8 *should_match = va_arg (*args, u8 *);
++  if (unformat (input, "=="))
++    *should_match = 1;
++  else if (unformat (input, "!="))
++    *should_match = 0;
++  else
++    return 0;
++  return 1;
++}
++
++uword
++unformat_capo_rule_filter (unformat_input_t *input, va_list *args)
++{
++  u8 tmp_value;
++  capo_rule_filter_t *filter = va_arg (*args, capo_rule_filter_t *);
++  if (unformat (input, "icmp-type%U%d", unformat_capo_should_match,
++		&filter->should_match, &filter->value))
++    filter->type = CAPO_RULE_FILTER_ICMP_TYPE;
++  else if (unformat (input, "icmp-code%U%d", unformat_capo_should_match,
++		     &filter->should_match, &filter->value))
++    filter->type = CAPO_RULE_FILTER_ICMP_CODE;
++  else if (unformat (input, "proto%U%U", unformat_capo_should_match,
++		     &filter->should_match, unformat_ip_protocol, &tmp_value))
++    {
++      filter->value = tmp_value;
++      filter->type = CAPO_RULE_FILTER_L4_PROTO;
++    }
++  else
++    return 0;
++  return 1;
++}
++
++static capo_rule_entry_t *
++capo_rule_get_entries (capo_rule_t *rule)
++{
++  capo_rule_entry_t *entries = NULL, *entry;
++  capo_port_range_t *pr;
++  ip_prefix_t *pfx;
++  u32 *set_id;
++  for (int i = 0; i < CAPO_RULE_MAX_FLAGS; i++)
++    {
++      vec_foreach (pfx, rule->prefixes[i])
++	{
++	  vec_add2 (entries, entry, 1);
++	  entry->type = CAPO_CIDR;
++	  entry->flags = i;
++	  clib_memcpy (&entry->data.cidr, pfx, sizeof (*pfx));
++	}
++      vec_foreach (pr, rule->port_ranges[i])
++	{
++	  vec_add2 (entries, entry, 1);
++	  entry->type = CAPO_PORT_RANGE;
++	  entry->flags = i;
++	  clib_memcpy (&entry->data.port_range, pr, sizeof (*pr));
++	}
++      vec_foreach (set_id, rule->ip_ipsets[i])
++	{
++	  vec_add2 (entries, entry, 1);
++	  entry->type = CAPO_IP_SET;
++	  entry->flags = i;
++	  entry->data.set_id = *set_id;
++	}
++      vec_foreach (set_id, rule->ipport_ipsets[i])
++	{
++	  vec_add2 (entries, entry, 1);
++	  entry->type = CAPO_PORT_IP_SET;
++	  entry->flags = i;
++	  entry->data.set_id = *set_id;
++	}
++    }
++  return entries;
++}
++
++u8 *
++format_capo_rule (u8 *s, va_list *args)
++{
++  capo_rule_t *rule = va_arg (*args, capo_rule_t *);
++  capo_rule_filter_t *filter;
++  capo_rule_entry_t *entry, *entries;
++
++  if (rule == NULL)
++    return format (s, "deleted rule");
++
++  s = format (s, "[rule#%d;%U][", rule - capo_rules, format_capo_rule_action,
++	      rule->action);
++
++  /* filters */
++  vec_foreach (filter, rule->filters)
++    {
++      if (filter->type != CAPO_RULE_FILTER_NONE_TYPE)
++	s = format (s, "%U,", format_capo_rule_filter, filter);
++    }
++
++  entries = capo_rule_get_entries (rule);
++  vec_foreach (entry, entries)
++    s = format (s, "%U,", format_capo_rule_entry, entry);
++  vec_free (entries);
++  s = format (s, "]");
++
++  return (s);
++}
++
++capo_rule_t *
++capo_rule_alloc ()
++{
++  capo_rule_t *rule;
++  pool_get_zero (capo_rules, rule);
++  return rule;
++}
++
++capo_rule_t *
++capo_rule_get_if_exists (u32 index)
++{
++  if (pool_is_free_index (capo_rules, index))
++    return (NULL);
++  return pool_elt_at_index (capo_rules, index);
++}
++
++static void
++capo_rule_cleanup (capo_rule_t *rule)
++{
++  int i;
++  vec_free (rule->filters);
++  for (i = 0; i < CAPO_RULE_MAX_FLAGS; i++)
++    {
++      vec_free (rule->prefixes[i]);
++      vec_free (rule->port_ranges[i]);
++      vec_free (rule->ip_ipsets[i]);
++      vec_free (rule->ipport_ipsets[i]);
++    }
++}
++
++int
++capo_rule_update (u32 *id, capo_rule_action_t action, ip_address_family_t af,
++		  capo_rule_filter_t *filters, capo_rule_entry_t *entries)
++{
++  capo_rule_filter_t *filter;
++  capo_rule_entry_t *entry;
++  capo_rule_t *rule;
++  int rv;
++
++  rule = capo_rule_get_if_exists (*id);
++  if (rule)
++    capo_rule_cleanup (rule);
++  else
++    rule = capo_rule_alloc ();
++
++  rule->af = -1;
++  rule->action = action;
++  vec_foreach (filter, filters)
++    vec_add1 (rule->filters, *filter);
++
++  vec_foreach (entry, entries)
++    {
++      u8 flags = entry->flags;
++      switch (entry->type)
++	{
++	case CAPO_CIDR:
++	  vec_add1 (rule->prefixes[flags], entry->data.cidr);
++	  break;
++	case CAPO_PORT_RANGE:
++	  vec_add1 (rule->port_ranges[flags], entry->data.port_range);
++	  break;
++	case CAPO_PORT_IP_SET:
++	  vec_add1 (rule->ipport_ipsets[flags], entry->data.set_id);
++	  break;
++	case CAPO_IP_SET:
++	  vec_add1 (rule->ip_ipsets[flags], entry->data.set_id);
++	  break;
++	default:
++	  rv = 1;
++	  goto error;
++	}
++    }
++  *id = rule - capo_rules;
++  return 0;
++error:
++  capo_rule_cleanup (rule);
++  pool_put (capo_rules, rule);
++  return rv;
++}
++
++int
++capo_rule_delete (u32 id)
++{
++  capo_rule_t *rule;
++  rule = capo_rule_get_if_exists (id);
++  if (NULL == rule)
++    return VNET_API_ERROR_NO_SUCH_ENTRY;
++
++  capo_rule_cleanup (rule);
++  pool_put (capo_rules, rule);
++
++  return 0;
++}
++
++static clib_error_t *
++capo_rules_show_cmd_fn (vlib_main_t *vm, unformat_input_t *input,
++			vlib_cli_command_t *cmd)
++{
++  capo_rule_t *rule;
++
++  pool_foreach (rule, capo_rules)
++    {
++      vlib_cli_output (vm, "%U", format_capo_rule, rule);
++    }
++
++  return 0;
++}
++
++VLIB_CLI_COMMAND (capo_rules_show_cmd, static) = {
++  .path = "show capo rules",
++  .function = capo_rules_show_cmd_fn,
++  .short_help = "show capo rules",
++};
++
++static clib_error_t *
++capo_rules_add_cmd_fn (vlib_main_t *vm, unformat_input_t *input,
++		       vlib_cli_command_t *cmd)
++{
++  unformat_input_t _line_input, *line_input = &_line_input;
++  capo_rule_filter_t tmp_filter, *filters = 0;
++  capo_rule_entry_t tmp_entry, *entries = 0;
++  clib_error_t *error = 0;
++  capo_rule_action_t action;
++  ip_address_family_t af = AF_IP4;
++  u32 id = CAPO_INVALID_INDEX;
++  int rv;
++
++  if (!unformat_user (input, unformat_line_input, line_input))
++    return 0;
++
++  while (unformat_check_input (line_input) != UNFORMAT_END_OF_INPUT)
++    {
++      if (unformat (line_input, "update %u", &id))
++	;
++      else if (unformat_user (line_input, unformat_ip_address_family, &af))
++	;
++      else if (unformat_user (line_input, unformat_capo_rule_action, &action))
++	;
++      else if (unformat_user (line_input, unformat_capo_rule_entry,
++			      &tmp_entry))
++	vec_add1 (entries, tmp_entry);
++      else if (unformat_user (line_input, unformat_capo_rule_filter,
++			      &tmp_filter))
++	{
++	  vec_add1 (filters, tmp_filter);
++	  vlib_cli_output (vm, "%U", format_capo_rule_filter, &tmp_filter);
++	}
++      else
++	{
++	  error = clib_error_return (0, "unknown input '%U'",
++				     format_unformat_error, line_input);
++	  goto done;
++	}
++    }
++
++  rv = capo_rule_update (&id, action, af, filters, entries);
++  if (rv)
++    error = clib_error_return (0, "capo_rule_update error %d", rv);
++  else
++    vlib_cli_output (vm, "capo rule %d added", id);
++
++done:
++  vec_free (filters);
++  vec_free (entries);
++  unformat_free (line_input);
++  return error;
++}
++
++VLIB_CLI_COMMAND (capo_rules_add_cmd, static) = {
++  .path = "capo rule add",
++  .function = capo_rules_add_cmd_fn,
++  .short_help = "capo rule add [ip4|ip6] [allow|deny|log|pass]"
++		"[filter[==|!=]value]"
++		"[[src|dst][==|!=][prefix|set ID|[port-port]]]",
++  .long_help = "Add a rule, with given filters and entries\n"
++	       "filters can be `icmp-type`, `icmp-code` and `proto`",
++};
++
++static clib_error_t *
++capo_rules_del_cmd_fn (vlib_main_t *vm, unformat_input_t *input,
++		       vlib_cli_command_t *cmd)
++{
++  unformat_input_t _line_input, *line_input = &_line_input;
++  clib_error_t *error = 0;
++  u32 id = CAPO_INVALID_INDEX;
++  int rv;
++
++  if (!unformat_user (input, unformat_line_input, line_input))
++    return clib_error_return (0, "missing rule id");
++
++  while (unformat_check_input (line_input) != UNFORMAT_END_OF_INPUT)
++    {
++      if (unformat (line_input, "%u", &id))
++	;
++      else
++	{
++	  error = clib_error_return (0, "unknown input '%U'",
++				     format_unformat_error, line_input);
++	  goto done;
++	}
++    }
++
++  if (CAPO_INVALID_INDEX == id)
++    {
++      error = clib_error_return (0, "missing rule id");
++      goto done;
++    }
++
++  rv = capo_rule_delete (id);
++  if (rv)
++    error = clib_error_return (0, "capo_rule_delete errored with %d", rv);
++
++done:
++  unformat_free (line_input);
++  return error;
++}
++
++VLIB_CLI_COMMAND (capo_rules_del_cmd, static) = {
++  .path = "capo rule del",
++  .function = capo_rules_del_cmd_fn,
++  .short_help = "capo rule del [id]",
++};
++
++/*
++ * fd.io coding-style-patch-verification: ON
++ *
++ * Local Variables:
++ * eval: (c-set-style "gnu")
++ * End:
++ */
+diff --git a/src/plugins/capo/capo_rule.h b/src/plugins/capo/capo_rule.h
+new file mode 100644
+index 000000000..0875a45c5
+--- /dev/null
++++ b/src/plugins/capo/capo_rule.h
+@@ -0,0 +1,91 @@
++/*
++ * Copyright (c) 2020 Cisco and/or its affiliates.
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at:
++ *
++ *     http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ */
++
++#ifndef included_capo_rule_h
++#define included_capo_rule_h
++
++#include <capo/capo.h>
++
++typedef vl_api_capo_rule_action_t capo_rule_action_t;
++typedef vl_api_capo_entry_type_t capo_entry_type_t;
++typedef vl_api_capo_rule_filter_type_t capo_rule_filter_type_t;
++
++typedef struct capo_rule_filter_
++{
++  capo_rule_filter_type_t type;
++  /* Content to filter against */
++  u32 value;
++  /* If true match packet.property == opaque, else packet.property != opaque */
++  u8 should_match;
++} capo_rule_filter_t;
++
++typedef union capo_entry_data_t_
++{
++  ip_prefix_t cidr;
++  capo_port_range_t port_range;
++  u32 set_id;
++} capo_entry_data_t;
++
++typedef enum capo_rule_key_flag_
++{
++  CAPO_IS_SRC = 1 << 0,
++  CAPO_IS_NOT = 1 << 1,
++  CAPO_RULE_MAX_FLAGS = 1 << 2,
++} capo_rule_key_flag_t;
++
++#define CAPO_SRC     CAPO_IS_SRC
++#define CAPO_NOT_SRC (CAPO_IS_SRC | CAPO_IS_NOT)
++#define CAPO_DST     0
++#define CAPO_NOT_DST CAPO_IS_NOT
++
++typedef struct capo_rule_entry_t_
++{
++  capo_entry_type_t type;
++  capo_entry_data_t data;
++  capo_rule_key_flag_t flags;
++} capo_rule_entry_t;
++
++typedef struct capo_rule_
++{
++  ip_address_family_t af;
++  capo_rule_action_t action;
++
++  capo_rule_filter_t *filters;
++
++  /* Indexed by capo_rule_key_flag_t */
++  ip_prefix_t *prefixes[CAPO_RULE_MAX_FLAGS];
++  u32 *ip_ipsets[CAPO_RULE_MAX_FLAGS];
++  capo_port_range_t *port_ranges[CAPO_RULE_MAX_FLAGS];
++  u32 *ipport_ipsets[CAPO_RULE_MAX_FLAGS];
++} capo_rule_t;
++
++extern capo_rule_t *capo_rules;
++
++int capo_rule_delete (u32 id);
++int capo_rule_update (u32 *id, capo_rule_action_t action,
++		      ip_address_family_t af, capo_rule_filter_t *filters,
++		      capo_rule_entry_t *entries);
++u8 *format_capo_rule (u8 *s, va_list *args);
++capo_rule_t *capo_rule_get_if_exists (u32 index);
++
++#endif
++
++/*
++ * fd.io coding-style-patch-verification: ON
++ *
++ * Local Variables:
++ * eval: (c-set-style "gnu")
++ * End:
++ */
+diff --git a/src/plugins/capo/capo_test.c b/src/plugins/capo/capo_test.c
+new file mode 100644
+index 000000000..8bfa4ae29
+--- /dev/null
++++ b/src/plugins/capo/capo_test.c
+@@ -0,0 +1,490 @@
++/*
++ * Copyright (c) 2015 Cisco and/or its affiliates.
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at:
++ *
++ *     http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ */
++/*
++ *------------------------------------------------------------------
++ * acl_test.c - test harness plugin
++ *------------------------------------------------------------------
++ */
++
++#include <vat/vat.h>
++#include <vlibapi/api.h>
++#include <vlibmemory/api.h>
++#include <vppinfra/error.h>
++#include <vnet/ip/ip.h>
++#include <arpa/inet.h>
++
++#include <vnet/ip/ip_format_fns.h>
++#include <vnet/ethernet/ethernet_format_fns.h>
++
++#define __plugin_msg_base capo_test_main.msg_id_base
++#include <vlibapi/vat_helper_macros.h>
++
++uword unformat_sw_if_index (unformat_input_t *input, va_list *args);
++
++/* Declare message IDs */
++#include <capo/capo.api_enum.h>
++#include <capo/capo.api_types.h>
++#define vl_endianfun /* define message structures */
++#include <capo/capo.api.h>
++#undef vl_endianfun
++
++typedef struct
++{
++  /* API message ID base */
++  u16 msg_id_base;
++  vat_main_t *vat_main;
++} capo_test_main_t;
++
++capo_test_main_t capo_test_main;
++
++/* NAME: capo_get_version_reply */
++static void
++vl_api_capo_get_version_reply_t_handler (vl_api_capo_get_version_reply_t *mp)
++{
++  vat_main_t *vam = capo_test_main.vat_main;
++  clib_warning ("Calico Policy plugin version: %d.%d", ntohl (mp->major),
++		ntohl (mp->minor));
++  vam->result_ready = 1;
++}
++
++/* NAME: capo_control_ping_reply */
++static void
++vl_api_capo_control_ping_reply_t_handler (vl_api_capo_control_ping_reply_t *mp)
++{
++  vat_main_t *vam = capo_test_main.vat_main;
++  i32 retval = ntohl (mp->retval);
++  if (vam->async_mode)
++    {
++      vam->async_errors += (retval < 0);
++    }
++  else
++    {
++      vam->retval = retval;
++      vam->result_ready = 1;
++    }
++}
++
++/* NAME: ipset_create_reply */
++static void
++vl_api_capo_ipset_create_reply_t_handler (vl_api_capo_ipset_create_reply_t *mp)
++{
++  vat_main_t *vam = capo_test_main.vat_main;
++  clib_warning ("Got ipset_create_reply...");
++  vam->result_ready = 1;
++}
++
++/* NAME: rule_create_reply */
++static void
++vl_api_capo_rule_create_reply_t_handler (vl_api_capo_rule_create_reply_t *mp)
++{
++  vat_main_t *vam = capo_test_main.vat_main;
++  clib_warning ("Got rule_create_reply...");
++  vam->result_ready = 1;
++}
++
++/* NAME: policy_create_reply */
++static void
++vl_api_capo_policy_create_reply_t_handler (
++  vl_api_capo_policy_create_reply_t *mp)
++{
++  vat_main_t *vam = capo_test_main.vat_main;
++  clib_warning ("Got policy_create_reply...");
++  vam->result_ready = 1;
++}
++
++/* NAME: capo_get_version */
++
++static int
++api_capo_get_version (vat_main_t *vam)
++{
++  capo_test_main_t *cptm = &capo_test_main;
++  unformat_input_t *i = vam->input;
++  vl_api_capo_get_version_t *mp;
++  u32 msg_size = sizeof (*mp);
++  int ret;
++
++  vam->result_ready = 0;
++  mp = vl_msg_api_alloc_as_if_client (msg_size);
++  memset (mp, 0, msg_size);
++  mp->_vl_msg_id = ntohs (VL_API_CAPO_GET_VERSION + cptm->msg_id_base);
++  mp->client_index = vam->my_client_index;
++
++  /* FIXME: do something here */
++
++  while (unformat_check_input (i) != UNFORMAT_END_OF_INPUT)
++    {
++    }
++
++  /* send it... */
++  S (mp);
++
++  /* Wait for a reply... */
++  W (ret);
++  return ret;
++}
++
++/* NAME: capo_control_ping */
++
++static int
++api_capo_control_ping (vat_main_t *vam)
++{
++  capo_test_main_t *cptm = &capo_test_main;
++  unformat_input_t *i = vam->input;
++  vl_api_capo_control_ping_t *mp;
++  u32 msg_size = sizeof (*mp);
++  int ret;
++
++  vam->result_ready = 0;
++  mp = vl_msg_api_alloc_as_if_client (msg_size);
++  memset (mp, 0, msg_size);
++  mp->_vl_msg_id = ntohs (VL_API_CAPO_CONTROL_PING + cptm->msg_id_base);
++  mp->client_index = vam->my_client_index;
++
++  /* FIXME: do something here */
++
++  while (unformat_check_input (i) != UNFORMAT_END_OF_INPUT)
++    {
++    }
++
++  /* send it... */
++  S (mp);
++
++  /* Wait for a reply... */
++  W (ret);
++  return ret;
++}
++
++/* NAME: ipset_create */
++
++static int
++api_capo_ipset_create (vat_main_t *vam)
++{
++  capo_test_main_t *cptm = &capo_test_main;
++  unformat_input_t *i = vam->input;
++  vl_api_capo_ipset_create_t *mp;
++  u32 msg_size = sizeof (*mp);
++  int ret;
++
++  vam->result_ready = 0;
++  mp = vl_msg_api_alloc_as_if_client (msg_size);
++  memset (mp, 0, msg_size);
++  mp->_vl_msg_id = ntohs (VL_API_CAPO_IPSET_CREATE + cptm->msg_id_base);
++  mp->client_index = vam->my_client_index;
++
++  /* FIXME: do something here */
++
++  while (unformat_check_input (i) != UNFORMAT_END_OF_INPUT)
++    {
++    }
++
++  /* send it... */
++  S (mp);
++
++  /* Wait for a reply... */
++  W (ret);
++  return ret;
++}
++
++/* NAME: ipset_add_del_members */
++
++static int
++api_capo_ipset_add_del_members (vat_main_t *vam)
++{
++  capo_test_main_t *cptm = &capo_test_main;
++  unformat_input_t *i = vam->input;
++  vl_api_capo_ipset_add_del_members_t *mp;
++  u32 msg_size = sizeof (*mp);
++  int ret;
++
++  vam->result_ready = 0;
++  mp = vl_msg_api_alloc_as_if_client (msg_size);
++  memset (mp, 0, msg_size);
++  mp->_vl_msg_id =
++    ntohs (VL_API_CAPO_IPSET_ADD_DEL_MEMBERS + cptm->msg_id_base);
++  mp->client_index = vam->my_client_index;
++
++  /* FIXME: do something here */
++
++  while (unformat_check_input (i) != UNFORMAT_END_OF_INPUT)
++    {
++    }
++
++  /* send it... */
++  S (mp);
++
++  /* Wait for a reply... */
++  W (ret);
++  return ret;
++}
++
++/* NAME: ipset_delete */
++
++static int
++api_capo_ipset_delete (vat_main_t *vam)
++{
++  capo_test_main_t *cptm = &capo_test_main;
++  unformat_input_t *i = vam->input;
++  vl_api_capo_ipset_delete_t *mp;
++  u32 msg_size = sizeof (*mp);
++  int ret;
++
++  vam->result_ready = 0;
++  mp = vl_msg_api_alloc_as_if_client (msg_size);
++  memset (mp, 0, msg_size);
++  mp->_vl_msg_id = ntohs (VL_API_CAPO_IPSET_DELETE + cptm->msg_id_base);
++  mp->client_index = vam->my_client_index;
++
++  /* FIXME: do something here */
++
++  while (unformat_check_input (i) != UNFORMAT_END_OF_INPUT)
++    {
++    }
++
++  /* send it... */
++  S (mp);
++
++  /* Wait for a reply... */
++  W (ret);
++  return ret;
++}
++
++/* NAME: rule_create */
++
++static int
++api_capo_rule_create (vat_main_t *vam)
++{
++  capo_test_main_t *cptm = &capo_test_main;
++  unformat_input_t *i = vam->input;
++  vl_api_capo_rule_create_t *mp;
++  u32 msg_size = sizeof (*mp);
++  int ret;
++
++  vam->result_ready = 0;
++  mp = vl_msg_api_alloc_as_if_client (msg_size);
++  memset (mp, 0, msg_size);
++  mp->_vl_msg_id = ntohs (VL_API_CAPO_RULE_CREATE + cptm->msg_id_base);
++  mp->client_index = vam->my_client_index;
++
++  /* FIXME: do something here */
++
++  while (unformat_check_input (i) != UNFORMAT_END_OF_INPUT)
++    {
++    }
++
++  /* send it... */
++  S (mp);
++
++  /* Wait for a reply... */
++  W (ret);
++  return ret;
++}
++
++/* NAME: rule_update */
++
++static int
++api_capo_rule_update (vat_main_t *vam)
++{
++  capo_test_main_t *cptm = &capo_test_main;
++  unformat_input_t *i = vam->input;
++  vl_api_capo_rule_update_t *mp;
++  u32 msg_size = sizeof (*mp);
++  int ret;
++
++  vam->result_ready = 0;
++  mp = vl_msg_api_alloc_as_if_client (msg_size);
++  memset (mp, 0, msg_size);
++  mp->_vl_msg_id = ntohs (VL_API_CAPO_RULE_UPDATE + cptm->msg_id_base);
++  mp->client_index = vam->my_client_index;
++
++  /* FIXME: do something here */
++
++  while (unformat_check_input (i) != UNFORMAT_END_OF_INPUT)
++    {
++    }
++
++  /* send it... */
++  S (mp);
++
++  /* Wait for a reply... */
++  W (ret);
++  return ret;
++}
++
++/* NAME: rule_delete */
++
++static int
++api_capo_rule_delete (vat_main_t *vam)
++{
++  capo_test_main_t *cptm = &capo_test_main;
++  unformat_input_t *i = vam->input;
++  vl_api_capo_rule_delete_t *mp;
++  u32 msg_size = sizeof (*mp);
++  int ret;
++
++  vam->result_ready = 0;
++  mp = vl_msg_api_alloc_as_if_client (msg_size);
++  memset (mp, 0, msg_size);
++  mp->_vl_msg_id = ntohs (VL_API_CAPO_RULE_DELETE + cptm->msg_id_base);
++  mp->client_index = vam->my_client_index;
++
++  /* FIXME: do something here */
++
++  while (unformat_check_input (i) != UNFORMAT_END_OF_INPUT)
++    {
++    }
++
++  /* send it... */
++  S (mp);
++
++  /* Wait for a reply... */
++  W (ret);
++  return ret;
++}
++
++/* NAME: policy_create */
++
++static int
++api_capo_policy_create (vat_main_t *vam)
++{
++  capo_test_main_t *cptm = &capo_test_main;
++  unformat_input_t *i = vam->input;
++  vl_api_capo_policy_create_t *mp;
++  u32 msg_size = sizeof (*mp);
++  int ret;
++
++  vam->result_ready = 0;
++  mp = vl_msg_api_alloc_as_if_client (msg_size);
++  memset (mp, 0, msg_size);
++  mp->_vl_msg_id = ntohs (VL_API_CAPO_POLICY_CREATE + cptm->msg_id_base);
++  mp->client_index = vam->my_client_index;
++
++  /* FIXME: do something here */
++
++  while (unformat_check_input (i) != UNFORMAT_END_OF_INPUT)
++    {
++    }
++
++  /* send it... */
++  S (mp);
++
++  /* Wait for a reply... */
++  W (ret);
++  return ret;
++}
++
++/* NAME: policy_update */
++
++static int
++api_capo_policy_update (vat_main_t *vam)
++{
++  capo_test_main_t *cptm = &capo_test_main;
++  unformat_input_t *i = vam->input;
++  vl_api_capo_policy_update_t *mp;
++  u32 msg_size = sizeof (*mp);
++  int ret;
++
++  vam->result_ready = 0;
++  mp = vl_msg_api_alloc_as_if_client (msg_size);
++  memset (mp, 0, msg_size);
++  mp->_vl_msg_id = ntohs (VL_API_CAPO_POLICY_UPDATE + cptm->msg_id_base);
++  mp->client_index = vam->my_client_index;
++
++  /* FIXME: do something here */
++
++  while (unformat_check_input (i) != UNFORMAT_END_OF_INPUT)
++    {
++    }
++
++  /* send it... */
++  S (mp);
++
++  /* Wait for a reply... */
++  W (ret);
++  return ret;
++}
++
++/* NAME: policy_delete */
++
++static int
++api_capo_policy_delete (vat_main_t *vam)
++{
++  capo_test_main_t *cptm = &capo_test_main;
++  unformat_input_t *i = vam->input;
++  vl_api_capo_policy_delete_t *mp;
++  u32 msg_size = sizeof (*mp);
++  int ret;
++
++  vam->result_ready = 0;
++  mp = vl_msg_api_alloc_as_if_client (msg_size);
++  memset (mp, 0, msg_size);
++  mp->_vl_msg_id = ntohs (VL_API_CAPO_POLICY_DELETE + cptm->msg_id_base);
++  mp->client_index = vam->my_client_index;
++
++  /* FIXME: do something here */
++
++  while (unformat_check_input (i) != UNFORMAT_END_OF_INPUT)
++    {
++    }
++
++  /* send it... */
++  S (mp);
++
++  /* Wait for a reply... */
++  W (ret);
++  return ret;
++}
++
++/* NAME: configure_policies */
++
++static int
++api_capo_configure_policies (vat_main_t *vam)
++{
++  capo_test_main_t *cptm = &capo_test_main;
++  unformat_input_t *i = vam->input;
++  vl_api_capo_configure_policies_t *mp;
++  u32 msg_size = sizeof (*mp);
++  int ret;
++
++  vam->result_ready = 0;
++  mp = vl_msg_api_alloc_as_if_client (msg_size);
++  memset (mp, 0, msg_size);
++  mp->_vl_msg_id = ntohs (VL_API_CAPO_CONFIGURE_POLICIES + cptm->msg_id_base);
++  mp->client_index = vam->my_client_index;
++
++  /* FIXME: do something here */
++
++  while (unformat_check_input (i) != UNFORMAT_END_OF_INPUT)
++    {
++    }
++
++  /* send it... */
++  S (mp);
++
++  /* Wait for a reply... */
++  W (ret);
++  return ret;
++}
++
++#define VL_API_LOCAL_SETUP_MESSAGE_ID_TABLE local_setup_message_id_table
++static void
++local_setup_message_id_table (vat_main_t *vam)
++{
++  // hash_set_mem (vam->function_by_name, "acl_add_replace_from_file",
++  // api_capo_acl_add_replace_from_file); hash_set_mem (vam->help_by_name,
++  // "acl_add_replace_from_file", "filename <file> [permit]
++  // [append-default-permit]");
++}
++
++#include <capo/capo.api_test.c>
+diff --git a/src/plugins/capo/test/test_capo.py b/src/plugins/capo/test/test_capo.py
+new file mode 100644
+index 000000000..dec9c56f7
+--- /dev/null
++++ b/src/plugins/capo/test/test_capo.py
+@@ -0,0 +1,806 @@
++#!/usr/bin/env python3
++
++import random
++import unittest
++from ipaddress import (IPv4Address, IPv4Network, IPv6Address, IPv6Network,
++                       ip_address, ip_network)
++from itertools import product
++
++from framework import VppTestCase, VppTestRunner
++from scapy.layers.inet import (ICMP, IP, TCP, UDP, ICMPerror, IPerror,
++                               TCPerror, UDPerror)
++from scapy.layers.inet6 import (ICMPv6DestUnreach, ICMPv6EchoReply,
++                                ICMPv6EchoRequest, IPerror6, IPv6)
++from scapy.layers.l2 import Ether
++from scapy.packet import Raw
++from vpp_ip import INVALID_INDEX, DpoProto
++from vpp_object import VppObject
++from vpp_papi import VppEnum
++
++icmp4_type = 8  # echo request
++icmp4_code = 3
++icmp6_type = 128  # echo request
++icmp6_code = 3
++tcp_protocol = 6
++icmp_protocol = 1
++icmp6_protocol = 58
++udp_protocol = 17
++src_l4 = 1234
++dst_l4 = 4321
++
++
++def random_payload():
++    return Raw(load=bytearray(random.getrandbits(8) for _ in range(20)))
++
++
++class VppCapoPolicyItem():
++    def __init__(self, is_inbound, rule_id):
++        self._is_inbound = is_inbound
++        self._rule_id = rule_id
++
++    def encode(self):
++        return {'rule_id': self._rule_id, 'is_inbound': self._is_inbound}
++
++
++class VppCapoPolicy(VppObject):
++    def __init__(self, test, rules):
++        self._test = test
++        self._rules = rules
++        self.encoded_rules = []
++        self.init_rules()
++
++    def init_rules(self):
++        self.encoded_rules = []
++        for rule in self._rules:
++            self.encoded_rules.append(rule.encode())
++
++    def add_vpp_config(self):
++        r = self._test.vapi.capo_policy_create(
++            len(self.encoded_rules),
++            self.encoded_rules)
++        self._test.assertEqual(0, r.retval)
++        self._test.registry.register(self, self._test.logger)
++        self._test.logger.info("capo_policy_create retval=" + str(r.retval))
++        self._policy_id = r.policy_id
++        self._test.logger.info(self._test.vapi.cli("show capo policies verbose"))
++
++    def capo_policy_update(self, rules):
++        self._rules = rules
++        self.init_rules()
++        r = self._test.vapi.capo_policy_update(
++            self._policy_id,
++            len(self.encoded_rules),
++            self.encoded_rules)
++        self._test.assertEqual(0, r.retval)
++
++    def capo_policy_delete(self):
++        r = self._test.vapi.capo_policy_delete(self._policy_id)
++        self._test.assertEqual(0, r.retval)
++        self._test.logger.info(self._test.vapi.cli("show capo policies"))
++
++    def remove_vpp_config(self):
++        self.capo_policy_delete()
++
++    def query_vpp_config(self):
++        self._test.logger.info("query vpp config")
++        self._test.logger.info(self._test.vapi.cli("show capo policies verbose"))
++
++
++class VppCapoFilter:
++    def __init__(self, type=None, value=0, should_match=0):
++        self._filter_type = type if type != None else FILTER_TYPE_NONE
++        self._filter_value = value
++        self._should_match = should_match
++
++    def encode(self):
++        return {'type': self._filter_type,
++            'value': self._filter_value,
++            'should_match': self._should_match}
++
++
++class VppCapoRule(VppObject):
++    def __init__(self, test, is_v6, action, filters=[], matches=[]):
++        self._test = test
++        # This is actually unused
++        self._af = 255
++        self.init_rule(action, filters, matches)
++
++    def vpp_id(self):
++        return self._rule_id
++
++    def init_rule(self, action, filters=[], matches=[]):
++        self._action = action
++        self._filters = filters
++        self._matches = matches
++        self.encoded_filters = []
++        for filter in self._filters:
++            self.encoded_filters.append(filter.encode())
++        while len(self.encoded_filters) < 3:
++            self.encoded_filters.append(VppCapoFilter().encode())
++        self._test.assertEqual(len(self.encoded_filters), 3)
++
++    def add_vpp_config(self):
++        r = self._test.vapi.capo_rule_create(
++            {'af': self._af,
++             'action': self._action,
++             'filters': self.encoded_filters,
++             'num_entries': len(self._matches),
++             'matches': self._matches
++            })
++        self._test.assertEqual(0, r.retval)
++        self._test.registry.register(self, self._test.logger)
++        self._test.logger.info("capo_rule_create retval=" + str(r.retval))
++        self._rule_id = r.rule_id
++        self._test.logger.info("rules id : " + str(self._rule_id))
++        self._test.logger.info(self._test.vapi.cli("show capo rules"))
++
++    def capo_rule_update(self, filters, matches):
++        self.init_rule(self._action, filters, matches)
++        r = self._test.vapi.capo_rule_update(
++            self._rule_id,
++            {'af': self._af,
++             'action': self._action,
++             'filters': self.encoded_filters,
++             'num_entries': len(self._matches),
++             'matches': self._matches
++            })
++        self._test.assertEqual(0, r.retval)
++        self._test.registry.register(self, self._test.logger)
++        self._test.logger.info("capo rule update")
++        self._test.logger.info(self._test.vapi.cli("show capo rules"))
++
++    def capo_rule_delete(self):
++        r = self._test.vapi.capo_rule_delete(self._rule_id)
++        self._test.assertEqual(0, r.retval)
++        self._test.logger.info(self._test.vapi.cli("show capo rules"))
++
++    def remove_vpp_config(self):
++        self.capo_rule_delete()
++
++    def query_vpp_config(self):
++        self._test.logger.info("query vpp config")
++        self._test.logger.info(self._test.vapi.cli("show capo rules"))
++
++
++class VppCapoIpset(VppObject):
++    def __init__(self, test, type, members):
++        self.test = test
++        self.type = type
++        self.members = members
++
++    def add_vpp_config(self):
++        r = self.test.vapi.capo_ipset_create(self.type)
++        self.test.assertEqual(0, r.retval)
++        self.vpp_id = r.set_id
++        encoded_members = []
++        for m in self.members:
++            if self.type == IPSET_TYPE_IP:
++                encoded_members.append({"val":{"address": m}})
++            elif self.type == IPSET_TYPE_IP_PORT:
++                encoded_members.append({"val":{"tuple": m}})
++            elif self.type == IPSET_TYPE_NET:
++                encoded_members.append({"val":{"prefix": m}})
++        r = self.test.vapi.capo_ipset_add_del_members(
++            set_id=self.vpp_id,
++            is_add=True,
++            len=len(encoded_members),
++            members=encoded_members,
++        )
++        self.test.assertEqual(0, r.retval)
++
++    def query_vpp_config(self):
++        pass
++
++    def remove_vpp_config(self):
++        r = self.test.vapi.capo_ipset_delete(set_id=self.vpp_id)
++        self.test.assertEqual(0, r.retval)
++
++
++
++class BaseCapoTest(VppTestCase):
++    @classmethod
++    def setUpClass(self):
++        super(BaseCapoTest, self).setUpClass()
++        # We can't define these before the API is loaded, so here they are...
++        global ACTION_ALLOW, ACTION_DENY, ACTION_PASS, ACTION_LOG
++        ACTION_ALLOW = VppEnum.vl_api_capo_rule_action_t.CAPO_ALLOW
++        ACTION_DENY = VppEnum.vl_api_capo_rule_action_t.CAPO_DENY
++        ACTION_PASS = VppEnum.vl_api_capo_rule_action_t.CAPO_PASS
++        ACTION_LOG = VppEnum.vl_api_capo_rule_action_t.CAPO_LOG
++        global FILTER_TYPE_NONE, FILTER_TYPE_L4_PROTO, FILTER_TYPE_ICMP_CODE, FILTER_TYPE_ICMP_TYPE
++        FILTER_TYPE_NONE = VppEnum.vl_api_capo_rule_filter_type_t.CAPO_RULE_FILTER_NONE_TYPE
++        FILTER_TYPE_L4_PROTO = VppEnum.vl_api_capo_rule_filter_type_t.CAPO_RULE_FILTER_L4_PROTO
++        FILTER_TYPE_ICMP_CODE = VppEnum.vl_api_capo_rule_filter_type_t.CAPO_RULE_FILTER_ICMP_CODE
++        FILTER_TYPE_ICMP_TYPE = VppEnum.vl_api_capo_rule_filter_type_t.CAPO_RULE_FILTER_ICMP_TYPE
++        global ENTRY_CIDR, ENTRY_PORT_RANGE, ENTRY_PORT_IP_SET, ENTRY_IP_SET
++        ENTRY_CIDR = VppEnum.vl_api_capo_entry_type_t.CAPO_CIDR
++        ENTRY_PORT_RANGE = VppEnum.vl_api_capo_entry_type_t.CAPO_PORT_RANGE
++        ENTRY_PORT_IP_SET = VppEnum.vl_api_capo_entry_type_t.CAPO_PORT_IP_SET
++        ENTRY_IP_SET = VppEnum.vl_api_capo_entry_type_t.CAPO_IP_SET
++        global IPSET_TYPE_IP, IPSET_TYPE_IP_PORT, IPSET_TYPE_NET
++        IPSET_TYPE_IP = VppEnum.vl_api_capo_ipset_type_t.CAPO_IP
++        IPSET_TYPE_IP_PORT = VppEnum.vl_api_capo_ipset_type_t.CAPO_IP_AND_PORT
++        IPSET_TYPE_NET = VppEnum.vl_api_capo_ipset_type_t.CAPO_NET
++
++        self.create_pg_interfaces(range(2))
++        for i in self.pg_interfaces:
++            i.admin_up()
++            # Add one additional neighbor on each side for tests with different addresses
++            i.generate_remote_hosts(2)
++            i.config_ip4()
++            i.configure_ipv4_neighbors()
++            i.config_ip6()
++            i.configure_ipv6_neighbors()
++
++    @classmethod
++    def tearDownClass(self):
++        for i in self.pg_interfaces:
++            i.unconfig_ip4()
++            i.unconfig_ip6()
++            i.admin_down()
++        super(BaseCapoTest, self).tearDownClass()
++
++
++    def setUp(self):
++        super(BaseCapoTest, self).setUp()
++
++    def tearDown(self):
++        super(BaseCapoTest, self).tearDown()
++
++    def configure_policies(self, interface, ingress, egress, profiles):
++        id_list = []
++        for policy in ingress + egress + profiles:
++            id_list.append(policy._policy_id)
++
++        r = self.vapi.capo_configure_policies(
++             interface.sw_if_index,
++             len(ingress),
++             len(egress),
++             len(ingress) + len(egress) + len(profiles),
++             id_list)
++        self.assertEqual(0, r.retval)
++
++    def base_ip_packet(self, is_v6=False, second_src_ip=False, second_dst_ip=False):
++        IP46 = IPv6 if is_v6 else IP
++        src_host = self.pg0.remote_hosts[1 if second_src_ip else 0]
++        dst_host = self.pg1.remote_hosts[1 if second_dst_ip else 0]
++        src_addr = src_host.ip6 if is_v6 else src_host.ip4
++        dst_addr = dst_host.ip6 if is_v6 else dst_host.ip4
++        return Ether(src=src_host.mac, dst=self.pg0.local_mac) / IP46(src=src_addr,
++                dst=dst_addr)
++
++    def do_test_one_rule(self, filters, matches, matching_packets, not_matching_packets):
++        # Caution: because of how vpp works, packets may be reordered (v4 first, v6 next)
++        # which may break the check on received packets
++        # Therefore, in matching packets, all v4 packets must be before all v6 packets
++        self.rule.capo_rule_update(filters, matches)
++        self.send_test_packets(self.pg0, self.pg1, matching_packets, not_matching_packets)
++
++    def send_test_packets(self, from_if, to_if, passing_packets, dropped_packets):
++        if len(passing_packets) > 0:
++            rxl = self.send_and_expect(from_if, passing_packets, to_if)
++            self.assertEqual(len(rxl), len(passing_packets))
++            for i in range(len(passing_packets)):
++                rx = rxl[i].payload
++                tx = passing_packets[i].payload
++                tx = tx.__class__(bytes(tx)) # Compute all fields
++                # Remove IP[v6] TTL / checksum that are changed on forwarding
++                if IP in tx:
++                    del tx.chksum, tx.ttl, rx.chksum, rx.ttl
++                elif IPv6 in tx:
++                    del tx.hlim, rx.hlim
++                self.assertEqual(rx, tx)
++        if len(dropped_packets) > 0:
++            self.send_and_assert_no_replies(from_if, dropped_packets, to_if, timeout=0.1)
++        self.vapi.cli("clear acl-plugin sessions")
++
++
++class TestCapoMatches(BaseCapoTest):
++    """ Calico Policies rule matching tests  """
++    @classmethod
++    def setUpClass(self):
++        super(TestCapoMatches, self).setUpClass()
++
++    @classmethod
++    def tearDownClass(self):
++        super(TestCapoMatches, self).tearDownClass()
++
++    def setUp(self):
++        super(TestCapoMatches, self).setUp()
++        self.rule = VppCapoRule(self, is_v6=False, action=ACTION_ALLOW)
++        self.rule.add_vpp_config()
++        self.policy = VppCapoPolicy(self, [VppCapoPolicyItem(is_inbound=1, rule_id=self.rule.vpp_id())])
++        self.policy.add_vpp_config()
++        self.configure_policies(self.pg1, [self.policy], [], [])
++        self.src_ip_ipset = VppCapoIpset(self, IPSET_TYPE_IP, [self.pg0.remote_ip4, self.pg0.remote_ip6])
++        self.src_ip_ipset.add_vpp_config()
++        self.dst_ip_ipset = VppCapoIpset(self, IPSET_TYPE_IP, [self.pg1.remote_ip4, self.pg1.remote_ip6])
++        self.dst_ip_ipset.add_vpp_config()
++        self.src_net_ipset = VppCapoIpset(self, IPSET_TYPE_NET, [self.pg0.remote_ip4+"/32", self.pg0.remote_ip6+"/128"])
++        self.src_net_ipset.add_vpp_config()
++        self.dst_net_ipset = VppCapoIpset(self, IPSET_TYPE_NET, [self.pg1.remote_ip4+"/32", self.pg1.remote_ip6+"/128"])
++        self.dst_net_ipset.add_vpp_config()
++        self.src_ipport_ipset = VppCapoIpset(self, IPSET_TYPE_IP_PORT, [
++            {"address":self.pg0.remote_ip4, "l4_proto": tcp_protocol, "port": src_l4},
++            {"address":self.pg0.remote_ip6, "l4_proto": tcp_protocol, "port": src_l4}
++        ])
++        self.src_ipport_ipset.add_vpp_config()
++        self.dst_ipport_ipset = VppCapoIpset(self, IPSET_TYPE_IP_PORT, [
++            {"address":self.pg1.remote_ip4, "l4_proto": tcp_protocol, "port": dst_l4},
++            {"address":self.pg1.remote_ip6, "l4_proto": tcp_protocol, "port": dst_l4}
++        ])
++        self.dst_ipport_ipset.add_vpp_config()
++
++    def tearDown(self):
++        self.vapi.cli("clear acl-plugin sessions")
++        self.configure_policies(self.pg1, [], [], [])
++        self.policy.capo_policy_delete()
++        self.rule.capo_rule_delete()
++        super(TestCapoMatches, self).tearDown()
++
++    def test_empty_rule(self):
++        # Empty rule matches everything
++        valid = [
++            self.base_ip_packet(False) / TCP(sport=src_l4, dport=dst_l4) / random_payload(),
++            self.base_ip_packet(False) / UDP(sport=src_l4, dport=dst_l4) / random_payload(),
++            self.base_ip_packet(False) / ICMP(type=icmp4_type, code=icmp4_code) / random_payload(),
++            self.base_ip_packet(True) / TCP(sport=src_l4, dport=dst_l4) / random_payload(),
++            self.base_ip_packet(True) / UDP(sport=src_l4, dport=dst_l4) / random_payload(),
++            self.base_ip_packet(True) / ICMPv6EchoRequest(type=icmp6_type, code=icmp6_code) / random_payload(),
++        ]
++        self.do_test_one_rule([], [], valid, [])
++
++    def capo_test_icmp(self, is_v6):
++        ICMP46 = ICMPv6EchoRequest if is_v6 else ICMP
++        icmp_type = icmp6_type if is_v6 else icmp4_type
++        icmp_code = icmp6_code if is_v6 else icmp4_code
++
++        # Define filter on ICMP type
++        filters = [VppCapoFilter(FILTER_TYPE_ICMP_TYPE, value=icmp_type, should_match=1)]
++        valid = self.base_ip_packet(is_v6) / ICMP46(type=icmp_type, code=icmp_code) / random_payload()
++        invalid = self.base_ip_packet(is_v6) / ICMP46(type=11, code=22) / random_payload()
++        self.do_test_one_rule(filters, [], [valid], [invalid])
++
++        # Define filter on ICMP type  / should match = 0
++        filters = [VppCapoFilter(FILTER_TYPE_ICMP_TYPE, value=11, should_match=0)]
++        invalid = self.base_ip_packet(is_v6) / ICMP46(type=11, code=icmp_code) / random_payload()
++        valid = self.base_ip_packet(is_v6) / ICMP46(type=icmp_type, code=icmp_code) / random_payload()
++        self.do_test_one_rule(filters, [], [valid], [invalid])
++
++    def test_icmp4_type(self):
++        self.capo_test_icmp(is_v6=False)
++
++    def test_icmp6_type(self):
++        self.capo_test_icmp(is_v6=True)
++
++    def capo_test_icmp_code(self, is_v6):
++        ICMP46 = ICMPv6EchoRequest if is_v6 else ICMP
++        icmp_type = 1 if is_v6 else 3   # Destination unreachable
++        icmp_code = 9 # admin prohibited
++
++        # Define filter on ICMP type
++        filters = [VppCapoFilter(FILTER_TYPE_ICMP_CODE, value=icmp_code, should_match=1)]
++        valid = self.base_ip_packet(is_v6) / ICMP46(type=icmp_type, code=icmp_code) / random_payload()
++        invalid = self.base_ip_packet(is_v6) / ICMP46(type=icmp_type, code=icmp_code-1) / random_payload()
++        self.do_test_one_rule(filters, [], [valid], [invalid])
++
++        # Define filter on ICMP type  / should match = 0
++        filters = [VppCapoFilter(FILTER_TYPE_ICMP_CODE, value=icmp_code, should_match=0)]
++        valid = self.base_ip_packet(is_v6) / ICMP46(type=icmp_type, code=icmp_code+1) / random_payload()
++        invalid = self.base_ip_packet(is_v6) / ICMP46(type=icmp_type, code=icmp_code) / random_payload()
++        self.do_test_one_rule(filters, [], [valid], [invalid])
++
++    def test_icmp4_code(self):
++        self.capo_test_icmp(is_v6=False)
++
++    def test_icmp6_code(self):
++        self.capo_test_icmp(is_v6=True)
++
++    def capo_test_l4proto(self, is_v6, l4proto):
++        filter_value = 0
++        if l4proto == TCP:
++            filter_value = tcp_protocol
++        elif l4proto == UDP:
++            filter_value = udp_protocol
++
++        # Define filter on l4proto type
++        filters = [VppCapoFilter(FILTER_TYPE_L4_PROTO, value=filter_value, should_match=1)]
++
++        # Send tcp pg0 -> pg1
++        valid = self.base_ip_packet(is_v6) / l4proto(sport=src_l4, dport=dst_l4) / random_payload()
++        # send icmp packet (different l4proto) and expect packet is filtered
++        invalid = self.base_ip_packet(is_v6) / ICMP(type=8, code=3) / random_payload()
++        self.do_test_one_rule(filters, [], [valid], [invalid])
++
++        # Define filter on l4proto / should match = 0
++        filters = [VppCapoFilter(FILTER_TYPE_L4_PROTO, value=filter_value, should_match=0)]
++        # send l4proto packet and expect it is filtered
++        invalid = self.base_ip_packet(is_v6) / l4proto(sport=src_l4, dport=dst_l4) / random_payload()
++        # send icmp packet (different l4proto) and expect it is not filtered
++        valid = self.base_ip_packet(is_v6) / ICMP(type=8, code=3) / random_payload()
++        self.do_test_one_rule(filters, [], [valid], [invalid])
++
++    def test_l4proto_tcp4(self):
++        self.capo_test_l4proto(False, TCP)
++
++    def test_l4proto_tcp6(self):
++        self.capo_test_l4proto(True, TCP)
++
++    def test_l4proto_udp4(self):
++        self.capo_test_l4proto(False, UDP)
++
++    def test_l4proto_udp6(self):
++        self.capo_test_l4proto(True, UDP)
++
++    def test_prefixes_ip6(self):
++        self.test_prefixes(True)
++
++    def test_prefixes(self, is_ip6=False):
++        pload = lambda : TCP(sport=src_l4, dport=dst_l4) / random_payload()
++        dst_ip_match = self.pg1.remote_ip6 + "/128" if is_ip6 else self.pg1.remote_ip4 + "/32"
++        match = {"is_src": False, "is_not": False, "type": ENTRY_CIDR, "data": {"cidr": dst_ip_match}}
++        valid = self.base_ip_packet(is_ip6) / pload()
++        invalid = self.base_ip_packet(is_ip6, second_dst_ip=True) / pload()
++        self.do_test_one_rule([], [match], [valid], [invalid])
++
++        match['is_not'] = True
++        self.do_test_one_rule([], [match], [invalid], [valid])
++
++        src_ip_match = self.pg0.remote_ip6 + "/128" if is_ip6 else self.pg0.remote_ip4 + "/32"
++        match = {"is_src": True, "is_not": False, "type": ENTRY_CIDR, "data": {"cidr": src_ip_match}}
++        valid = self.base_ip_packet(is_ip6) / pload()
++        invalid = self.base_ip_packet(is_ip6, second_src_ip=True) / pload()
++        self.do_test_one_rule([], [match], [valid], [invalid])
++
++        match['is_not'] = True
++        self.do_test_one_rule([], [match], [invalid], [valid])
++
++    def test_port_ranges_ip6(self):
++        self.test_prefixes(True)
++
++    def test_port_ranges(self, is_ip6=False):
++        base = self.base_ip_packet(is_ip6)
++        test_port = 5123
++        # Test all match kinds
++        match = {"is_src": False, "is_not": False, "type": ENTRY_PORT_RANGE,
++                 "data": {"port_range": {"start": test_port, "end": test_port}}}
++        valid = base / TCP(sport=test_port, dport=test_port) / random_payload()
++        invalid = [
++            base / TCP(sport=test_port, dport=test_port+1) / random_payload(),
++            base / TCP(sport=test_port, dport=test_port-1) / random_payload(),
++        ]
++        self.do_test_one_rule([], [match], [valid], invalid)
++
++        match['is_not'] = True
++        self.do_test_one_rule([], [match], invalid, [valid])
++
++        match = {"is_src": True, "is_not": False, "type": ENTRY_PORT_RANGE,
++                 "data": {"port_range": {"start": test_port, "end": test_port}}}
++        valid = base / TCP(sport=test_port, dport=test_port) / random_payload()
++        invalid = [
++            base / TCP(sport=test_port+1, dport=test_port) / random_payload(),
++            base / TCP(sport=test_port-1, dport=test_port) / random_payload(),
++        ]
++        self.do_test_one_rule([], [match], [valid], invalid)
++
++        match['is_not'] = True
++        self.do_test_one_rule([], [match], invalid, [valid])
++
++        # Test port ranges with several ports & UDP
++        match = {"is_src": False, "is_not": False, "type": ENTRY_PORT_RANGE,
++                 "data": {"port_range": {"start": test_port, "end": test_port+10}}}
++        valid = [
++            base / TCP(sport=test_port, dport=test_port) / random_payload(),
++            base / TCP(sport=test_port, dport=test_port+5) / random_payload(),
++            base / TCP(sport=test_port, dport=test_port+10) / random_payload(),
++            base / UDP(sport=test_port, dport=test_port) / random_payload(),
++            base / UDP(sport=test_port, dport=test_port+5) / random_payload(),
++            base / UDP(sport=test_port, dport=test_port+10) / random_payload(),
++        ]
++        invalid = [
++            base / TCP(sport=test_port, dport=test_port-1) / random_payload(),
++            base / TCP(sport=test_port, dport=test_port+11) / random_payload(),
++        ]
++        self.do_test_one_rule([], [match], valid, invalid)
++
++
++    def test_ip_ipset_ip6(self):
++        self.test_ip_ipset(True)
++
++    def test_ip_ipset(self, is_ip6=False):
++        pload = lambda : TCP(sport=src_l4, dport=dst_l4) / random_payload()
++        dst_ip_match = self.pg1.remote_ip6 + "/128" if is_ip6 else self.pg1.remote_ip4 + "/32"
++        match = {"is_src": False, "is_not": False, "type": ENTRY_IP_SET,
++                 "data": {"set_id": {"set_id": self.dst_ip_ipset.vpp_id}}}
++        valid = self.base_ip_packet(is_ip6) / pload()
++        invalid = self.base_ip_packet(is_ip6, second_dst_ip=True) / pload()
++        self.do_test_one_rule([], [match], [valid], [invalid])
++
++        match['is_not'] = True
++        self.do_test_one_rule([], [match], [invalid], [valid])
++
++        src_ip_match = self.pg0.remote_ip6 + "/128" if is_ip6 else self.pg0.remote_ip4 + "/32"
++        match = {"is_src": True, "is_not": False, "type": ENTRY_IP_SET,
++                 "data": {"set_id": {"set_id": self.src_ip_ipset.vpp_id}}}
++        valid = self.base_ip_packet(is_ip6) / pload()
++        invalid = self.base_ip_packet(is_ip6, second_src_ip=True) / pload()
++        self.do_test_one_rule([], [match], [valid], [invalid])
++
++        match['is_not'] = True
++        self.do_test_one_rule([], [match], [invalid], [valid])
++
++    def test_net_ipset_ip6(self):
++        self.test_net_ipset(True)
++
++    def test_net_ipset(self, is_ip6=False):
++        pload = lambda : TCP(sport=src_l4, dport=dst_l4) / random_payload()
++        dst_ip_match = self.pg1.remote_ip6 + "/128" if is_ip6 else self.pg1.remote_ip4 + "/32"
++        match = {"is_src": False, "is_not": False, "type": ENTRY_IP_SET,
++                 "data": {"set_id": {"set_id": self.dst_net_ipset.vpp_id}}}
++        valid = self.base_ip_packet(is_ip6) / pload()
++        invalid = self.base_ip_packet(is_ip6, second_dst_ip=True) / pload()
++        self.do_test_one_rule([], [match], [valid], [invalid])
++
++        match['is_not'] = True
++        self.do_test_one_rule([], [match], [invalid], [valid])
++
++        src_ip_match = self.pg0.remote_ip6 + "/128" if is_ip6 else self.pg0.remote_ip4 + "/32"
++        match = {"is_src": True, "is_not": False, "type": ENTRY_IP_SET,
++                 "data": {"set_id": {"set_id": self.src_net_ipset.vpp_id}}}
++        valid = self.base_ip_packet(is_ip6) / pload()
++        invalid = self.base_ip_packet(is_ip6, second_src_ip=True) / pload()
++        self.do_test_one_rule([], [match], [valid], [invalid])
++
++        match['is_not'] = True
++        self.do_test_one_rule([], [match], [invalid], [valid])
++
++    def test_ipport_ipset_ip6(self):
++        self.test_ipport_ipset(True)
++
++    def test_ipport_ipset(self, is_ip6=False):
++        match = {"is_src": False, "is_not": False, "type": ENTRY_PORT_IP_SET,
++                 "data": {"set_id": {"set_id": self.dst_ipport_ipset.vpp_id}}}
++        valid = self.base_ip_packet(is_ip6) / TCP(sport=src_l4, dport=dst_l4) / random_payload()
++        invalid = [ # Change all criteria: address, proto, port
++            self.base_ip_packet(is_ip6, second_dst_ip=True) / TCP(sport=src_l4, dport=dst_l4) / random_payload(),
++            self.base_ip_packet(is_ip6) / UDP(sport=src_l4, dport=dst_l4) / random_payload(),
++            self.base_ip_packet(is_ip6) / TCP(sport=src_l4, dport=dst_l4+1) / random_payload(),
++        ]
++        self.do_test_one_rule([], [match], [valid], invalid)
++
++        match['is_not'] = True
++        self.do_test_one_rule([], [match], invalid, [valid])
++
++        match = {"is_src": True, "is_not": False, "type": ENTRY_PORT_IP_SET,
++                 "data": {"set_id": {"set_id": self.src_ipport_ipset.vpp_id}}}
++        valid = self.base_ip_packet(is_ip6) / TCP(sport=src_l4, dport=dst_l4) / random_payload()
++        invalid = [ # Change all criteria: address, proto, port
++            self.base_ip_packet(is_ip6, second_src_ip=True) / TCP(sport=src_l4, dport=dst_l4) / random_payload(),
++            self.base_ip_packet(is_ip6) / UDP(sport=src_l4, dport=dst_l4) / random_payload(),
++            self.base_ip_packet(is_ip6) / TCP(sport=src_l4+1, dport=dst_l4) / random_payload(),
++        ]
++        self.do_test_one_rule([], [match], [valid], invalid)
++
++        match['is_not'] = True
++        self.do_test_one_rule([], [match], invalid, [valid])
++
++    # Calico specificity: if a rule has port ranges and ipport ipsets, a packet matches
++    # the rule if it matches either category
++    def test_port_range_and_ipport_ipset_ip6(self):
++            self.test_port_range_and_ipport_ipset(True)
++
++    def test_port_range_and_ipport_ipset(self, is_ip6=False):
++        # Test all match types to exercies all code (but not all combinations)
++        test_port=4569
++        matches = [
++            {"is_src": False, "is_not": False, "type": ENTRY_PORT_IP_SET,
++                "data": {"set_id": {"set_id": self.dst_ipport_ipset.vpp_id}}},
++            {"is_src": False, "is_not": False, "type": ENTRY_PORT_RANGE,
++                "data": {"port_range": {"start": test_port, "end": test_port}}},
++        ]
++        valid = [
++            self.base_ip_packet(is_ip6) / TCP(sport=src_l4, dport=dst_l4) / random_payload(),
++            self.base_ip_packet(is_ip6) / TCP(sport=src_l4, dport=test_port) / random_payload(),
++            self.base_ip_packet(is_ip6) / UDP(sport=src_l4, dport=test_port) / random_payload(),
++            self.base_ip_packet(is_ip6, second_src_ip=True) / TCP(sport=src_l4, dport=test_port) / random_payload(),
++            self.base_ip_packet(is_ip6, second_dst_ip=True) / TCP(sport=src_l4, dport=test_port) / random_payload(),
++        ]
++        invalid = [
++            self.base_ip_packet(is_ip6, second_dst_ip=True) / TCP(sport=src_l4, dport=dst_l4) / random_payload(),
++            self.base_ip_packet(is_ip6) / UDP(sport=src_l4, dport=dst_l4) / random_payload(),
++            self.base_ip_packet(is_ip6) / TCP(sport=src_l4, dport=(dst_l4+test_port)//2) / random_payload(),
++        ]
++        self.do_test_one_rule([], matches, valid, invalid)
++
++        for match in matches:
++            match['is_not'] = True
++        self.do_test_one_rule([], matches, invalid, valid)
++
++        matches = [
++            {"is_src": True, "is_not": False, "type": ENTRY_PORT_IP_SET,
++                "data": {"set_id": {"set_id": self.src_ipport_ipset.vpp_id}}},
++            {"is_src": True, "is_not": False, "type": ENTRY_PORT_RANGE,
++                "data": {"port_range": {"start": test_port, "end": test_port}}},
++        ]
++        valid = [
++            self.base_ip_packet(is_ip6) / TCP(sport=src_l4, dport=dst_l4) / random_payload(),
++            self.base_ip_packet(is_ip6) / TCP(sport=test_port, dport=dst_l4) / random_payload(),
++            self.base_ip_packet(is_ip6) / UDP(sport=test_port, dport=dst_l4) / random_payload(),
++            self.base_ip_packet(is_ip6, second_src_ip=True) / TCP(sport=test_port, dport=dst_l4) / random_payload(),
++            self.base_ip_packet(is_ip6, second_dst_ip=True) / TCP(sport=test_port, dport=dst_l4) / random_payload(),
++        ]
++        invalid = [
++            self.base_ip_packet(is_ip6, second_src_ip=True) / TCP(sport=src_l4, dport=dst_l4) / random_payload(),
++            self.base_ip_packet(is_ip6) / UDP(sport=src_l4, dport=dst_l4) / random_payload(),
++            self.base_ip_packet(is_ip6) / TCP(sport=(src_l4+test_port)//2, dport=dst_l4) / random_payload(),
++        ]
++        self.do_test_one_rule([], matches, valid, invalid)
++
++        for match in matches:
++            match['is_not'] = True
++        self.do_test_one_rule([], matches, invalid, valid)
++
++
++class TestCapoPolicies(BaseCapoTest):
++    """ Calico Policies tests """
++    @classmethod
++    def setUpClass(self):
++        super(TestCapoPolicies, self).setUpClass()
++
++    @classmethod
++    def tearDownClass(self):
++        super(TestCapoPolicies, self).tearDownClass()
++
++    def setUp(self):
++        super(TestCapoPolicies, self).setUp()
++
++    def tearDown(self):
++        super(TestCapoPolicies, self).tearDown()
++
++    def tcp_dport_rule(self, port, action):
++        return VppCapoRule(self, is_v6=False, action=action,
++            filters=[VppCapoFilter(FILTER_TYPE_L4_PROTO, tcp_protocol, True)],
++            matches=[{"is_src": False, "is_not": False, "type": ENTRY_PORT_RANGE,
++                        "data": {"port_range": {"start": port, "end": port}}}]
++        )
++
++    def test_inbound_outbound(self):
++        r = self.tcp_dport_rule(1000, ACTION_ALLOW)
++        r.add_vpp_config()
++        pin = VppCapoPolicy(self, [VppCapoPolicyItem(is_inbound=1, rule_id=r.vpp_id())])
++        pout = VppCapoPolicy(self, [VppCapoPolicyItem(is_inbound=0, rule_id=r.vpp_id())])
++        pin.add_vpp_config()
++        pout.add_vpp_config()
++
++        matching = self.base_ip_packet() / TCP(sport=1, dport=1000) / random_payload()
++        not_matching = self.base_ip_packet() / TCP(sport=1, dport=2000) / random_payload()
++
++        # out policy at src
++        self.configure_policies(self.pg0, [], [pout], [])
++        self.send_test_packets(self.pg0, self.pg1, [matching], [not_matching])
++
++        # policies configured at src + dst
++        self.configure_policies(self.pg1, [pin], [], [])
++        self.send_test_packets(self.pg0, self.pg1, [matching], [not_matching])
++
++        # policies configured at dst
++        self.configure_policies(self.pg0, [], [], [])
++        self.send_test_packets(self.pg0, self.pg1, [matching], [not_matching])
++
++        # no policies
++        self.configure_policies(self.pg1, [], [], [])
++        self.send_test_packets(self.pg0, self.pg1, [matching, not_matching], [])
++
++    def test_default_verdict(self):
++        # If profiles only are configured (pass_id = 0), default is deny
++        # If there are policies + profiles (pass_id > 0), then default is to deny before
++        # evaluating profiles, unless a rule with a PASS target matches
++        rule1 = self.tcp_dport_rule(1000, ACTION_ALLOW)
++        rule2 = self.tcp_dport_rule(2000, ACTION_ALLOW)
++        rule3 = self.tcp_dport_rule(1000, ACTION_DENY)
++        rule4 = self.tcp_dport_rule(1000, ACTION_PASS)
++        rule1.add_vpp_config()
++        rule2.add_vpp_config()
++        rule3.add_vpp_config()
++        rule4.add_vpp_config()
++        policy1 = VppCapoPolicy(self, [VppCapoPolicyItem(is_inbound=1, rule_id=rule1.vpp_id())])
++        policy2 = VppCapoPolicy(self, [VppCapoPolicyItem(is_inbound=1, rule_id=rule2.vpp_id())])
++        policy3 = VppCapoPolicy(self, [VppCapoPolicyItem(is_inbound=1, rule_id=rule3.vpp_id())])
++        policy4 = VppCapoPolicy(self, [VppCapoPolicyItem(is_inbound=1, rule_id=rule4.vpp_id())])
++        policy5 = VppCapoPolicy(self, [
++            VppCapoPolicyItem(is_inbound=1, rule_id=rule4.vpp_id()),
++            VppCapoPolicyItem(is_inbound=1, rule_id=rule3.vpp_id()),
++        ])
++        policy1.add_vpp_config()
++        policy2.add_vpp_config()
++        policy3.add_vpp_config()
++        policy4.add_vpp_config()
++        policy5.add_vpp_config()
++
++        # Test profile default deny: 1 allow rule, pass_id=0
++        self.configure_policies(self.pg1, [], [], [policy1])
++        passing = [self.base_ip_packet() / TCP(sport=1, dport=1000) / random_payload()]
++        dropped = [self.base_ip_packet() / TCP(sport=1, dport=2000) / random_payload()]
++        self.send_test_packets(self.pg0, self.pg1, passing, dropped)
++
++        # Test policy default deny: 1 allow rule, pass_id=1
++        self.configure_policies(self.pg1, [policy1], [], [])
++        self.send_test_packets(self.pg0, self.pg1, passing, dropped)
++
++        # Test that profiles are not executed when policies are configured
++        # 1 allow policy, 1 allow profile, pass_id=1
++        self.configure_policies(self.pg1, [policy1], [], [policy2])
++        self.send_test_packets(self.pg0, self.pg1, passing, dropped)
++
++        # Test that pass target does not evaluate further policies and jumps to profiles
++        # 1 pass policy, 1 deny policy, 1 allow profile, pass_id=2
++        self.configure_policies(self.pg1, [policy4, policy3], [], [policy1])
++        self.send_test_packets(self.pg0, self.pg1, passing, dropped)
++
++        # Test that pass target does not evaluate further rules in the policy and jumps to profiles
++        # 1 policy w/ 1 pass rule & 1 deny rule, 1 deny profile, pass_id=1
++        self.configure_policies(self.pg1, [policy5], [], [policy1])
++        self.send_test_packets(self.pg0, self.pg1, passing, dropped)
++
++        policy1.remove_vpp_config()
++        policy2.remove_vpp_config()
++        policy3.remove_vpp_config()
++        policy4.remove_vpp_config()
++        policy5.remove_vpp_config()
++        rule1.remove_vpp_config()
++        rule2.remove_vpp_config()
++        rule3.remove_vpp_config()
++        rule4.remove_vpp_config()
++
++    def test_realistic_policy(self):
++        # Rule 1 allows ping from everywhere
++        rule1 = VppCapoRule(self, is_v6=False, action=ACTION_ALLOW,
++            filters = [
++                VppCapoFilter(FILTER_TYPE_L4_PROTO, icmp_protocol, True),
++                VppCapoFilter(FILTER_TYPE_ICMP_TYPE, 8, True),
++                VppCapoFilter(FILTER_TYPE_ICMP_CODE, 0, True),
++            ],
++            matches = [],
++        )
++        rule1.add_vpp_config()
++        # Rule 2 allows tcp dport 8080 from a single container
++        src_ipset = VppCapoIpset(self, IPSET_TYPE_NET,
++                [self.pg0.remote_ip4 + "/32", self.pg0.remote_ip6 + "/128"])
++        src_ipset.add_vpp_config()
++        rule2 = VppCapoRule(self, is_v6=False, action=ACTION_ALLOW,
++            filters=[
++                VppCapoFilter(FILTER_TYPE_L4_PROTO, tcp_protocol, True),
++            ],
++            matches = [
++                {"is_src": True, "is_not": False, "type": ENTRY_IP_SET,
++                        "data": {"set_id": {"set_id": src_ipset.vpp_id}}},
++                {"is_src": False, "is_not": False, "type": ENTRY_PORT_RANGE,
++                        "data": {"port_range": {"start": 8080, "end": 8080}}},
++            ],
++        )
++        rule2.add_vpp_config()
++        policy = VppCapoPolicy(self, [
++            VppCapoPolicyItem(is_inbound=1, rule_id=rule1.vpp_id()),
++            VppCapoPolicyItem(is_inbound=1, rule_id=rule2.vpp_id()),
++        ])
++        policy.add_vpp_config()
++        self.configure_policies(self.pg1, [policy], [], [])
++
++        passing = [
++            self.base_ip_packet() / ICMP(type=8),
++            self.base_ip_packet(second_src_ip=True) / ICMP(type=8),
++            self.base_ip_packet() / TCP(sport=1, dport=8080) / random_payload(),
++        ]
++        dropped = [
++            self.base_ip_packet() / ICMP(type=3),
++            self.base_ip_packet(second_src_ip=True) / TCP(sport=1, dport=8080) / random_payload(),
++            self.base_ip_packet() / UDP(sport=1, dport=8080) / random_payload(),
++            self.base_ip_packet() / TCP(sport=1, dport=8081) / random_payload(),
++        ]
++        self.send_test_packets(self.pg0, self.pg1, passing, dropped)
++        # Cleanup
++        self.configure_policies(self.pg1, [], [], [])
++        policy.remove_vpp_config()
++        rule1.remove_vpp_config()
++        rule2.remove_vpp_config()
++        src_ipset.remove_vpp_config()
+-- 
+2.38.0
+

--- a/vpplink/binapi/patches/0004-capo-Calico-Policies-plugin.patch
+++ b/vpplink/binapi/patches/0004-capo-Calico-Policies-plugin.patch
@@ -18,12 +18,12 @@ Signed-off-by: MathiasRaoul <mathias.raoul@gmail.com>
  src/plugins/capo/bihash_8_24.h     | 107 ++++
  src/plugins/capo/capo.api          | 260 ++++++++++
  src/plugins/capo/capo.h            |  58 +++
- src/plugins/capo/capo_api.c        | 444 ++++++++++++++++
- src/plugins/capo/capo_interface.c  | 340 ++++++++++++
- src/plugins/capo/capo_interface.h  |  40 ++
+ src/plugins/capo/capo_api.c        | 443 ++++++++++++++++
+ src/plugins/capo/capo_interface.c  | 339 ++++++++++++
+ src/plugins/capo/capo_interface.h  |  41 ++
  src/plugins/capo/capo_ipset.c      | 472 +++++++++++++++++
  src/plugins/capo/capo_ipset.h      |  68 +++
- src/plugins/capo/capo_match.c      | 736 ++++++++++++++++++++++++++
+ src/plugins/capo/capo_match.c      | 734 ++++++++++++++++++++++++++
  src/plugins/capo/capo_match.h      |  49 ++
  src/plugins/capo/capo_policy.c     | 263 ++++++++++
  src/plugins/capo/capo_policy.h     |  58 +++
@@ -31,7 +31,7 @@ Signed-off-by: MathiasRaoul <mathias.raoul@gmail.com>
  src/plugins/capo/capo_rule.h       |  91 ++++
  src/plugins/capo/capo_test.c       | 490 ++++++++++++++++++
  src/plugins/capo/test/test_capo.py | 806 +++++++++++++++++++++++++++++
- 18 files changed, 4824 insertions(+)
+ 18 files changed, 4821 insertions(+)
  create mode 100644 src/plugins/capo/CMakeLists.txt
  create mode 100644 src/plugins/capo/bihash_8_24.h
  create mode 100644 src/plugins/capo/capo.api
@@ -215,7 +215,7 @@ index 000000000..79d1005bc
 + */
 diff --git a/src/plugins/capo/capo.api b/src/plugins/capo/capo.api
 new file mode 100644
-index 000000000..48732828e
+index 000000000..f29925e1d
 --- /dev/null
 +++ b/src/plugins/capo/capo.api
 @@ -0,0 +1,260 @@
@@ -474,10 +474,10 @@ index 000000000..48732828e
 +  u32 client_index;
 +  u32 context;
 +  u32 sw_if_index;
-+  u32 num_ingress_policies;
-+  u32 num_egress_policies;
++  u32 num_rx_policies;
++  u32 num_tx_policies;
 +  u32 total_ids;
-+  u32 policy_ids[total_ids]; // ingress, then egress, then profiles
++  u32 policy_ids[total_ids]; // rx_policies, then tx_policies, then profiles
 +};
 diff --git a/src/plugins/capo/capo.h b/src/plugins/capo/capo.h
 new file mode 100644
@@ -545,10 +545,10 @@ index 000000000..812d14831
 + */
 diff --git a/src/plugins/capo/capo_api.c b/src/plugins/capo/capo_api.c
 new file mode 100644
-index 000000000..c44b77eda
+index 000000000..335ed79cc
 --- /dev/null
 +++ b/src/plugins/capo/capo_api.c
-@@ -0,0 +1,444 @@
+@@ -0,0 +1,443 @@
 +/*
 + * Copyright (c) 2020 Cisco and/or its affiliates.
 + * Licensed under the Apache License, Version 2.0 (the "License");
@@ -916,18 +916,17 @@ index 000000000..c44b77eda
 +  int i = 0;
 +
 +  mp->sw_if_index = clib_net_to_host_u32 (mp->sw_if_index);
-+  mp->num_ingress_policies = clib_net_to_host_u32 (mp->num_ingress_policies);
-+  mp->num_egress_policies = clib_net_to_host_u32 (mp->num_egress_policies);
++  mp->num_rx_policies = clib_net_to_host_u32 (mp->num_rx_policies);
++  mp->num_tx_policies = clib_net_to_host_u32 (mp->num_tx_policies);
 +  mp->total_ids = clib_net_to_host_u32 (mp->total_ids);
-+  num_profiles =
-+    mp->total_ids - mp->num_ingress_policies - mp->num_egress_policies;
++  num_profiles = mp->total_ids - mp->num_rx_policies - mp->num_tx_policies;
 +  for (i = 0; i < mp->total_ids; i++)
 +    {
 +      mp->policy_ids[i] = clib_net_to_host_u32 (mp->policy_ids[i]);
 +    }
 +
-+  rv = capo_configure_policies (mp->sw_if_index, mp->num_ingress_policies,
-+				mp->num_egress_policies, num_profiles,
++  rv = capo_configure_policies (mp->sw_if_index, mp->num_rx_policies,
++				mp->num_tx_policies, num_profiles,
 +				mp->policy_ids);
 +
 +  REPLY_MACRO (VL_API_CAPO_CONFIGURE_POLICIES_REPLY);
@@ -995,10 +994,10 @@ index 000000000..c44b77eda
 + */
 diff --git a/src/plugins/capo/capo_interface.c b/src/plugins/capo/capo_interface.c
 new file mode 100644
-index 000000000..d13d58ff4
+index 000000000..6f9289383
 --- /dev/null
 +++ b/src/plugins/capo/capo_interface.c
-@@ -0,0 +1,340 @@
+@@ -0,0 +1,339 @@
 +/*
 + * Copyright (c) 2020 Cisco and/or its affiliates.
 + * Licensed under the Apache License, Version 2.0 (the "License");
@@ -1041,8 +1040,9 @@ index 000000000..d13d58ff4
 +}
 +
 +int
-+capo_configure_policies (u32 sw_if_index, u32 num_ingress, u32 num_egress,
-+			 u32 num_profiles, u32 *policy_ids)
++capo_configure_policies (u32 sw_if_index, u32 num_rx_policies,
++			 u32 num_tx_policies, u32 num_profiles,
++			 u32 *policy_ids)
 +{
 +  clib_bihash_kv_8_24_t kv = { sw_if_index, { 0 } };
 +  capo_interface_config_t *conf = (capo_interface_config_t *) &kv.value;
@@ -1061,27 +1061,25 @@ index 000000000..d13d58ff4
 +  if (clib_bihash_search_8_24 (&capo_main.if_config, &kv, &kv) >= 0)
 +    {
 +      old_conf = (capo_interface_config_t *) &kv.value;
-+      vec_free (old_conf->ingress_policies);
-+      vec_free (old_conf->egress_policies);
++      vec_free (old_conf->rx_policies);
++      vec_free (old_conf->tx_policies);
 +      vec_free (old_conf->profiles);
 +      found = 1;
 +    }
 +
-+  clib_warning ("configuring policies for if %u", sw_if_index);
-+
-+  for (i = 0; i < num_ingress + num_egress + num_profiles; i++)
++  for (i = 0; i < num_rx_policies + num_tx_policies + num_profiles; i++)
 +    if (pool_is_free_index (capo_policies, policy_ids[i]))
 +      goto error;
 +
-+  vec_resize (conf->ingress_policies, num_ingress);
-+  for (i = 0; i < num_ingress; i++)
-+    conf->ingress_policies[i] = policy_ids[i];
-+  vec_resize (conf->egress_policies, num_egress);
-+  for (i = 0; i < num_egress; i++)
-+    conf->egress_policies[i] = policy_ids[num_ingress + i];
++  vec_resize (conf->rx_policies, num_rx_policies);
++  for (i = 0; i < num_rx_policies; i++)
++    conf->rx_policies[i] = policy_ids[i];
++  vec_resize (conf->tx_policies, num_tx_policies);
++  for (i = 0; i < num_tx_policies; i++)
++    conf->tx_policies[i] = policy_ids[num_rx_policies + i];
 +  vec_resize (conf->profiles, num_profiles);
 +  for (i = 0; i < num_profiles; i++)
-+    conf->profiles[i] = policy_ids[num_ingress + num_egress + i];
++    conf->profiles[i] = policy_ids[num_rx_policies + num_tx_policies + i];
 +
 +  clib_bihash_add_del_8_24 (&capo_main.if_config, &kv, 1 /* is_add */);
 +
@@ -1098,8 +1096,8 @@ index 000000000..d13d58ff4
 +
 +error:
 +  clib_warning ("error configuring policies for %u", sw_if_index);
-+  vec_resize (conf->ingress_policies, 0);
-+  vec_resize (conf->egress_policies, 0);
++  vec_resize (conf->rx_policies, 0);
++  vec_resize (conf->tx_policies, 0);
 +  vec_resize (conf->profiles, 0);
 +  return 1;
 +}
@@ -1117,8 +1115,8 @@ index 000000000..d13d58ff4
 +  if (clib_bihash_search_8_24 (&capo_main.if_config, &kv, &kv) >= 0)
 +    {
 +      conf = (capo_interface_config_t *) &kv.value;
-+      vec_free (conf->ingress_policies);
-+      vec_free (conf->egress_policies);
++      vec_free (conf->rx_policies);
++      vec_free (conf->tx_policies);
 +      vec_free (conf->profiles);
 +    }
 +
@@ -1157,21 +1155,21 @@ index 000000000..d13d58ff4
 +  if (ip4)
 +    s = format (s, "%U", format_ip4_address, ip4);
 +  s = format (s, "]\n");
-+  if (vec_len (conf->ingress_policies))
-+    s = format (s, "  ingress:\n");
-+  vec_foreach_index (i, conf->ingress_policies)
++  if (vec_len (conf->rx_policies))
++    s = format (s, "  rx:\n");
++  vec_foreach_index (i, conf->rx_policies)
 +    {
-+      policy = capo_policy_get_if_exists (conf->ingress_policies[i]);
++      policy = capo_policy_get_if_exists (conf->rx_policies[i]);
 +      s = format (s, "    %U", format_capo_policy, policy, 4 /* indent */,
-+		  CAPO_POLICY_ONLY_INGRESS);
++		  CAPO_POLICY_ONLY_RX);
 +    }
-+  if (vec_len (conf->egress_policies))
-+    s = format (s, "  egress:\n");
-+  vec_foreach_index (i, conf->egress_policies)
++  if (vec_len (conf->tx_policies))
++    s = format (s, "  tx:\n");
++  vec_foreach_index (i, conf->tx_policies)
 +    {
-+      policy = capo_policy_get_if_exists (conf->egress_policies[i]);
++      policy = capo_policy_get_if_exists (conf->tx_policies[i]);
 +      s = format (s, "    %U", format_capo_policy, policy, 4 /* indent */,
-+		  CAPO_POLICY_ONLY_EGRESS);
++		  CAPO_POLICY_ONLY_TX);
 +    }
 +  if (vec_len (conf->profiles))
 +    s = format (s, "  profiles:\n");
@@ -1268,8 +1266,8 @@ index 000000000..d13d58ff4
 +  unformat_input_t _line_input, *line_input = &_line_input;
 +  clib_error_t *error = 0;
 +  u32 sw_if_index = CAPO_INVALID_INDEX;
-+  u32 num_ingress = 0;
-+  u32 num_egress = 0;
++  u32 num_rx_policies = 0;
++  u32 num_tx_policies = 0;
 +  u32 policy_id;
 +  u32 *policy_list = NULL;
 +  int rv;
@@ -1284,9 +1282,9 @@ index 000000000..d13d58ff4
 +	;
 +      else if (unformat (line_input, "sw_if_index %d", &sw_if_index))
 +	;
-+      else if (unformat (line_input, "in %d", &num_ingress))
++      else if (unformat (line_input, "rx %d", &num_rx_policies))
 +	;
-+      else if (unformat (line_input, "out %d", &num_egress))
++      else if (unformat (line_input, "tx %d", &num_tx_policies))
 +	;
 +      else if (unformat (line_input, "%d", &policy_id))
 +	vec_add1 (policy_list, policy_id);
@@ -1310,8 +1308,8 @@ index 000000000..d13d58ff4
 +    }
 +
 +  rv = capo_configure_policies (
-+    sw_if_index, num_ingress, num_egress,
-+    vec_len (policy_list) - num_ingress - num_egress, policy_list);
++    sw_if_index, num_rx_policies, num_tx_policies,
++    vec_len (policy_list) - num_rx_policies - num_tx_policies, policy_list);
 +
 +  if (rv)
 +    error =
@@ -1328,8 +1326,8 @@ index 000000000..d13d58ff4
 +VLIB_CLI_COMMAND (capo_interface_configure_cmd, static) = {
 +  .path = "capo interface configure",
 +  .function = capo_interface_configure_cmd_fn,
-+  .short_help = "capo interface configure [interface | sw_if_index N] in "
-+		"<num_ingress> out <num_egress> <policy_id> ...",
++  .short_help = "capo interface configure [interface | sw_if_index N] rx "
++		"<num_rx> tx <num_tx> <policy_id> ...",
 +};
 +
 +/*
@@ -1341,10 +1339,10 @@ index 000000000..d13d58ff4
 + */
 diff --git a/src/plugins/capo/capo_interface.h b/src/plugins/capo/capo_interface.h
 new file mode 100644
-index 000000000..f02c608a8
+index 000000000..b87bbcb4d
 --- /dev/null
 +++ b/src/plugins/capo/capo_interface.h
-@@ -0,0 +1,40 @@
+@@ -0,0 +1,41 @@
 +/*
 + * Copyright (c) 2020 Cisco and/or its affiliates.
 + * Licensed under the Apache License, Version 2.0 (the "License");
@@ -1367,13 +1365,14 @@ index 000000000..f02c608a8
 +
 +typedef struct
 +{
-+  u32 *ingress_policies;
-+  u32 *egress_policies;
++  u32 *rx_policies;
++  u32 *tx_policies;
 +  u32 *profiles;
 +} capo_interface_config_t;
 +
-+int capo_configure_policies (u32 sw_if_index, u32 num_ingress, u32 num_egress,
-+			     u32 num_profiles, u32 *policy_ids);
++int capo_configure_policies (u32 sw_if_index, u32 num_rx_policies,
++			     u32 num_tx_policies, u32 num_profiles,
++			     u32 *policy_ids);
 +u8 *format_capo_interface (u8 *s, va_list *args);
 +
 +#endif
@@ -1939,10 +1938,10 @@ index 000000000..56bb0f466
 + */
 diff --git a/src/plugins/capo/capo_match.c b/src/plugins/capo/capo_match.c
 new file mode 100644
-index 000000000..eed0cb233
+index 000000000..59dfe826e
 --- /dev/null
 +++ b/src/plugins/capo/capo_match.c
-@@ -0,0 +1,736 @@
+@@ -0,0 +1,734 @@
 +/*
 + * Copyright (c) 2020 Cisco and/or its affiliates.
 + * Licensed under the Apache License, Version 2.0 (the "License");
@@ -1987,8 +1986,7 @@ index 000000000..eed0cb233
 +      return 0;
 +    }
 +  if_config = (capo_interface_config_t *) conf_kv.value;
-+  policies =
-+    is_inbound ? if_config->egress_policies : if_config->ingress_policies;
++  policies = is_inbound ? if_config->rx_policies : if_config->tx_policies;
 +
 +  if (vec_len (policies) == 0)
 +    goto profiles; /* no policies, jump to profiles */
@@ -2054,10 +2052,9 @@ index 000000000..eed0cb233
 +capo_match_policy (capo_policy_t *policy, u32 is_inbound, u32 is_ip6,
 +		   fa_5tuple_t *pkt_5tuple)
 +{
-+  /* inbound packet from VPP pov is outbound from container pov - need to match
-+     it against TX policies */
++  /* packets RX/TX from VPP perspective */
 +  u32 *rules =
-+    is_inbound ? policy->rule_ids[VLIB_TX] : policy->rule_ids[VLIB_RX];
++    is_inbound ? policy->rule_ids[VLIB_RX] : policy->rule_ids[VLIB_TX];
 +  u32 *rule_id;
 +  capo_rule_t *rule;
 +  int r;
@@ -2736,7 +2733,7 @@ index 000000000..fe1907485
 + */
 diff --git a/src/plugins/capo/capo_policy.c b/src/plugins/capo/capo_policy.c
 new file mode 100644
-index 000000000..86c61b8cc
+index 000000000..0e94400c3
 --- /dev/null
 +++ b/src/plugins/capo/capo_policy.c
 @@ -0,0 +1,263 @@
@@ -2832,18 +2829,18 @@ index 000000000..86c61b8cc
 +    {
 +      s = format (s, "[policy#%u]\n", policy - capo_policies);
 +      capo_rule_t *rule;
-+      if (verbose != CAPO_POLICY_ONLY_INGRESS)
++      if (verbose != CAPO_POLICY_ONLY_RX)
 +	vec_foreach (rule_id, policy->rule_ids[VLIB_TX])
 +	  {
 +	    rule = capo_rule_get_if_exists (*rule_id);
-+	    s = format (s, "%Uegress :%U\n", format_white_space, indent + 2,
++	    s = format (s, "%Utx:%U\n", format_white_space, indent + 2,
 +			format_capo_rule, rule);
 +	  }
-+      if (verbose != CAPO_POLICY_ONLY_EGRESS)
++      if (verbose != CAPO_POLICY_ONLY_TX)
 +	vec_foreach (rule_id, policy->rule_ids[VLIB_RX])
 +	  {
 +	    rule = capo_rule_get_if_exists (*rule_id);
-+	    s = format (s, "%Uingress:%U\n", format_white_space, indent + 2,
++	    s = format (s, "%Urx:%U\n", format_white_space, indent + 2,
 +			format_capo_rule, rule);
 +	  }
 +    }
@@ -3005,7 +3002,7 @@ index 000000000..86c61b8cc
 + */
 diff --git a/src/plugins/capo/capo_policy.h b/src/plugins/capo/capo_policy.h
 new file mode 100644
-index 000000000..a98799929
+index 000000000..c598f9ade
 --- /dev/null
 +++ b/src/plugins/capo/capo_policy.h
 @@ -0,0 +1,58 @@
@@ -3047,8 +3044,8 @@ index 000000000..a98799929
 +{
 +  CAPO_POLICY_QUIET,
 +  CAPO_POLICY_VERBOSE,
-+  CAPO_POLICY_ONLY_INGRESS,
-+  CAPO_POLICY_ONLY_EGRESS,
++  CAPO_POLICY_ONLY_RX,
++  CAPO_POLICY_ONLY_TX,
 +} capo_policy_format_type_t;
 +
 +extern capo_policy_t *capo_policies;

--- a/vpplink/binapi/vpp_clone_current.sh
+++ b/vpplink/binapi/vpp_clone_current.sh
@@ -48,6 +48,14 @@ function git_cherry_pick ()
 	git commit --amend -m "gerrit:${refs#refs/changes/*/} $(git log -1 --pretty=%B)"
 }
 
+function git_apply_private ()
+{
+	refs=$1
+    blue "Applying $refs..."
+    git am < $SCRIPTDIR/patches/$refs
+}
+
+
 function git_revert ()
 {
 	refs=$1
@@ -92,9 +100,10 @@ git_cherry_pick refs/changes/34/34734/3 # 34734: memif: autogenerate socket_ids 
 git_cherry_pick refs/changes/26/34726/1 # 34726: interface: add buffer stats api | https://gerrit.fd.io/r/c/vpp/+/34726
 git_cherry_pick refs/changes/05/35805/2 # 35805: dpdk: add intf tag to dev{} subinput | https://gerrit.fd.io/r/c/vpp/+/35805
 
-# --------------- Dedicated plugins ---------------
-git_cherry_pick refs/changes/64/33264/7 # 33264: pbl: Port based balancer | https://gerrit.fd.io/r/c/vpp/+/33264
-git_cherry_pick refs/changes/88/31588/4 # 31588: cnat: [WIP] no k8s maglev from pods | https://gerrit.fd.io/r/c/vpp/+/31588
-git_cherry_pick refs/changes/83/28083/21 # 28083: acl: acl-plugin custom policies |  https://gerrit.fd.io/r/c/vpp/+/28083
-git_cherry_pick refs/changes/13/28513/28 # 25813: capo: Calico Policies plugin | https://gerrit.fd.io/r/c/vpp/+/28513
-# --------------- Dedicated plugins ---------------
+# --------------- private plugins ---------------
+# Generated with 'git format-patch --zero-commit -o ./patches/ HEAD^'
+git_apply_private 0001-pbl-Port-based-balancer.patch
+git_apply_private 0002-cnat-WIP-no-k8s-maglev-from-pods.patch
+git_apply_private 0003-acl-acl-plugin-custom-policies.patch
+git_apply_private 0004-capo-Calico-Policies-plugin.patch
+

--- a/vpplink/binapi/vppapi/capo/capo.ba.go
+++ b/vpplink/binapi/vppapi/capo/capo.ba.go
@@ -28,7 +28,7 @@ const _ = api.GoVppAPIPackageIsVersion2
 const (
 	APIFile    = "capo"
 	APIVersion = "0.1.0"
-	VersionCrc = 0xf7ab3600
+	VersionCrc = 0x48be6241
 )
 
 // CapoEntryType defines enum 'capo_entry_type'.
@@ -336,16 +336,16 @@ func (u *CapoIpsetMemberValUnion) GetTuple() (a CapoThreeTuple) {
 // CapoConfigurePolicies defines message 'capo_configure_policies'.
 // InProgress: the message form may change in the future versions
 type CapoConfigurePolicies struct {
-	SwIfIndex          uint32   `binapi:"u32,name=sw_if_index" json:"sw_if_index,omitempty"`
-	NumIngressPolicies uint32   `binapi:"u32,name=num_ingress_policies" json:"num_ingress_policies,omitempty"`
-	NumEgressPolicies  uint32   `binapi:"u32,name=num_egress_policies" json:"num_egress_policies,omitempty"`
-	TotalIds           uint32   `binapi:"u32,name=total_ids" json:"-"`
-	PolicyIds          []uint32 `binapi:"u32[total_ids],name=policy_ids" json:"policy_ids,omitempty"`
+	SwIfIndex     uint32   `binapi:"u32,name=sw_if_index" json:"sw_if_index,omitempty"`
+	NumRxPolicies uint32   `binapi:"u32,name=num_rx_policies" json:"num_rx_policies,omitempty"`
+	NumTxPolicies uint32   `binapi:"u32,name=num_tx_policies" json:"num_tx_policies,omitempty"`
+	TotalIds      uint32   `binapi:"u32,name=total_ids" json:"-"`
+	PolicyIds     []uint32 `binapi:"u32[total_ids],name=policy_ids" json:"policy_ids,omitempty"`
 }
 
 func (m *CapoConfigurePolicies) Reset()               { *m = CapoConfigurePolicies{} }
 func (*CapoConfigurePolicies) GetMessageName() string { return "capo_configure_policies" }
-func (*CapoConfigurePolicies) GetCrcString() string   { return "3ca1772c" }
+func (*CapoConfigurePolicies) GetCrcString() string   { return "318ba2a5" }
 func (*CapoConfigurePolicies) GetMessageType() api.MessageType {
 	return api.RequestMessage
 }
@@ -355,8 +355,8 @@ func (m *CapoConfigurePolicies) Size() (size int) {
 		return 0
 	}
 	size += 4                    // m.SwIfIndex
-	size += 4                    // m.NumIngressPolicies
-	size += 4                    // m.NumEgressPolicies
+	size += 4                    // m.NumRxPolicies
+	size += 4                    // m.NumTxPolicies
 	size += 4                    // m.TotalIds
 	size += 4 * len(m.PolicyIds) // m.PolicyIds
 	return size
@@ -367,8 +367,8 @@ func (m *CapoConfigurePolicies) Marshal(b []byte) ([]byte, error) {
 	}
 	buf := codec.NewBuffer(b)
 	buf.EncodeUint32(m.SwIfIndex)
-	buf.EncodeUint32(m.NumIngressPolicies)
-	buf.EncodeUint32(m.NumEgressPolicies)
+	buf.EncodeUint32(m.NumRxPolicies)
+	buf.EncodeUint32(m.NumTxPolicies)
 	buf.EncodeUint32(uint32(len(m.PolicyIds)))
 	for i := 0; i < len(m.PolicyIds); i++ {
 		var x uint32
@@ -382,8 +382,8 @@ func (m *CapoConfigurePolicies) Marshal(b []byte) ([]byte, error) {
 func (m *CapoConfigurePolicies) Unmarshal(b []byte) error {
 	buf := codec.NewBuffer(b)
 	m.SwIfIndex = buf.DecodeUint32()
-	m.NumIngressPolicies = buf.DecodeUint32()
-	m.NumEgressPolicies = buf.DecodeUint32()
+	m.NumRxPolicies = buf.DecodeUint32()
+	m.NumTxPolicies = buf.DecodeUint32()
 	m.TotalIds = buf.DecodeUint32()
 	m.PolicyIds = make([]uint32, m.TotalIds)
 	for i := 0; i < len(m.PolicyIds); i++ {
@@ -1370,7 +1370,7 @@ func (m *CapoRuleUpdateReply) Unmarshal(b []byte) error {
 
 func init() { file_capo_binapi_init() }
 func file_capo_binapi_init() {
-	api.RegisterMessage((*CapoConfigurePolicies)(nil), "capo_configure_policies_3ca1772c")
+	api.RegisterMessage((*CapoConfigurePolicies)(nil), "capo_configure_policies_318ba2a5")
 	api.RegisterMessage((*CapoConfigurePoliciesReply)(nil), "capo_configure_policies_reply_e8d4e804")
 	api.RegisterMessage((*CapoControlPing)(nil), "capo_control_ping_51077d14")
 	api.RegisterMessage((*CapoControlPingReply)(nil), "capo_control_ping_reply_f6b0b8ca")

--- a/vpplink/binapi/vppapi/generate.log
+++ b/vpplink/binapi/vppapi/generate.log
@@ -1,11 +1,11 @@
-VPP Version                 : 23.02-rc0~185-g77488ae02
+VPP Version                 : 23.02-rc0~185-g631edff89
 Binapi-generator version    : govpp v0.6.0-dev
 VPP Base commit             : e416893a5 tests: tapv2, tunv2 and af_packet interface tests for vpp
 ------------------ Cherry picked commits --------------------
-gerrit:28513/28 capo: Calico Policies plugin
-gerrit:28083/21 acl: acl-plugin custom policies
-gerrit:31588/4 cnat: [WIP] no k8s maglev from pods
-gerrit:33264/7 pbl: Port based balancer
+capo: Calico Policies plugin
+acl: acl-plugin custom policies
+cnat: [WIP] no k8s maglev from pods
+pbl: Port based balancer
 gerrit:35805/2 dpdk: add intf tag to dev{} subinput
 gerrit:34726/1 interface: add buffer stats api
 gerrit:34734/3 memif: autogenerate socket_ids

--- a/vpplink/binapi/vppapi/generate.log
+++ b/vpplink/binapi/vppapi/generate.log
@@ -1,4 +1,4 @@
-VPP Version                 : 23.02-rc0~185-g631edff89
+VPP Version                 : 23.02-rc0~185-g8991b1fdc
 Binapi-generator version    : govpp v0.6.0-dev
 VPP Base commit             : e416893a5 tests: tapv2, tunv2 and af_packet interface tests for vpp
 ------------------ Cherry picked commits --------------------

--- a/vpplink/types/capo.go
+++ b/vpplink/types/capo.go
@@ -469,14 +469,16 @@ func ToCapoPolicy(p *Policy) (items []capo.CapoPolicyItem) {
 	items = make([]capo.CapoPolicyItem, 0, len(p.InboundRuleIDs)+len(p.OutboundRuleIDs))
 	for _, rid := range p.InboundRuleIDs {
 		items = append(items, capo.CapoPolicyItem{
-			IsInbound: true,
-			RuleID:    rid,
+			IsInbound: false, // Calico policies are expressed from the point of view of PODs
+			// in VPP this is reversed
+			RuleID: rid,
 		})
 	}
 	for _, rid := range p.OutboundRuleIDs {
 		items = append(items, capo.CapoPolicyItem{
-			IsInbound: false,
-			RuleID:    rid,
+			IsInbound: true, // Calico policies are expressed from the point of view of PODs
+			// in VPP this is reversed
+			RuleID: rid,
 		})
 	}
 	return items


### PR DESCRIPTION
This patch changes the semantics for capo policies and rules,
it makes it so that VPP debug CLI & code uses rx/tx when refering
to packets comming into VPP (rx) or out of VPP (tx).

In Calio, the semantic is the opposite, the point of view taken by
the implementation is that of a container. Hence the traffic
coming out of VPP will be (ingress), and that coming into VPP
will be (egress).
