### PR TITLE
vpp: upgrade to 8a0fd0669047c90d410d2ed5cb508bfe778b932a (19 jan 23)

### DIFF
--- a/vpplink/binapi/vpp_clone_current.sh
+++ b/vpplink/binapi/vpp_clone_current.sh
@@ -92,13 +92,14 @@ function git_clone_cd_and_reset ()
 
 # --------------- Things to cherry pick ---------------
 
-git_clone_cd_and_reset "$1" e416893a597959509c7f667c140c271c0bb78c14
+git_clone_cd_and_reset "$1" 8a0fd0669047c90d410d2ed5cb508bfe778b932a
 
 git_cherry_pick refs/changes/13/34713/4 # 34713: vppinfra: improve & test abstract socket | https://gerrit.fd.io/r/c/vpp/+/34713
 git_cherry_pick refs/changes/71/32271/16 # 32271: memif: add support for ns abstract sockets | https://gerrit.fd.io/r/c/vpp/+/32271
 git_cherry_pick refs/changes/34/34734/3 # 34734: memif: autogenerate socket_ids | https://gerrit.fd.io/r/c/vpp/+/34734
 git_cherry_pick refs/changes/26/34726/1 # 34726: interface: add buffer stats api | https://gerrit.fd.io/r/c/vpp/+/34726
 git_cherry_pick refs/changes/05/35805/2 # 35805: dpdk: add intf tag to dev{} subinput | https://gerrit.fd.io/r/c/vpp/+/35805
+git_cherry_pick refs/changes/31/37931/1 # 37931: ip: add the missing offload check | https://gerrit.fd.io/r/c/vpp/+/37931
 
 # --------------- private plugins ---------------
 # Generated with 'git format-patch --zero-commit -o ./patches/ HEAD^'

--- a/vpplink/binapi/vppapi/generate.log
+++ b/vpplink/binapi/vppapi/generate.log
@@ -1,11 +1,12 @@
-VPP Version                 : 23.02-rc0~185-g6f7711c7b
+VPP Version                 : 23.06-rc0~11-g50e4f4e80
 Binapi-generator version    : govpp v0.6.0-dev
-VPP Base commit             : e416893a5 tests: tapv2, tunv2 and af_packet interface tests for vpp
+VPP Base commit             : 8a0fd0669 af_packet: add the missing header-len for packets with checksum offload
 ------------------ Cherry picked commits --------------------
 capo: Calico Policies plugin
 acl: acl-plugin custom policies
 cnat: [WIP] no k8s maglev from pods
 pbl: Port based balancer
+gerrit:37931/1 ip: add the missing offload check
 gerrit:35805/2 dpdk: add intf tag to dev{} subinput
 gerrit:34726/1 interface: add buffer stats api
 gerrit:34734/3 memif: autogenerate socket_ids

--- a/vpplink/binapi/vppapi/ipsec/ipsec.ba.go
+++ b/vpplink/binapi/vppapi/ipsec/ipsec.ba.go
@@ -5,7 +5,7 @@
 // Contents:
 //
 //	 2 structs
-//	48 messages
+//	50 messages
 package ipsec
 
 import (
@@ -26,7 +26,7 @@ const _ = api.GoVppAPIPackageIsVersion2
 const (
 	APIFile    = "ipsec"
 	APIVersion = "5.0.2"
-	VersionCrc = 0xd8d93805
+	VersionCrc = 0x9dfdcc71
 )
 
 // IpsecItf defines type 'ipsec_itf'.
@@ -1481,6 +1481,121 @@ func (m *IpsecSadEntryDelReply) Unmarshal(b []byte) error {
 	return nil
 }
 
+// IpsecSadEntryUpdate defines message 'ipsec_sad_entry_update'.
+type IpsecSadEntryUpdate struct {
+	SadID      uint32              `binapi:"u32,name=sad_id" json:"sad_id,omitempty"`
+	IsTun      bool                `binapi:"bool,name=is_tun" json:"is_tun,omitempty"`
+	Tunnel     tunnel_types.Tunnel `binapi:"tunnel,name=tunnel" json:"tunnel,omitempty"`
+	UDPSrcPort uint16              `binapi:"u16,name=udp_src_port,default=65535" json:"udp_src_port,omitempty"`
+	UDPDstPort uint16              `binapi:"u16,name=udp_dst_port,default=65535" json:"udp_dst_port,omitempty"`
+}
+
+func (m *IpsecSadEntryUpdate) Reset()               { *m = IpsecSadEntryUpdate{} }
+func (*IpsecSadEntryUpdate) GetMessageName() string { return "ipsec_sad_entry_update" }
+func (*IpsecSadEntryUpdate) GetCrcString() string   { return "1412af86" }
+func (*IpsecSadEntryUpdate) GetMessageType() api.MessageType {
+	return api.RequestMessage
+}
+
+func (m *IpsecSadEntryUpdate) Size() (size int) {
+	if m == nil {
+		return 0
+	}
+	size += 4      // m.SadID
+	size += 1      // m.IsTun
+	size += 4      // m.Tunnel.Instance
+	size += 1      // m.Tunnel.Src.Af
+	size += 1 * 16 // m.Tunnel.Src.Un
+	size += 1      // m.Tunnel.Dst.Af
+	size += 1 * 16 // m.Tunnel.Dst.Un
+	size += 4      // m.Tunnel.SwIfIndex
+	size += 4      // m.Tunnel.TableID
+	size += 1      // m.Tunnel.EncapDecapFlags
+	size += 1      // m.Tunnel.Mode
+	size += 1      // m.Tunnel.Flags
+	size += 1      // m.Tunnel.Dscp
+	size += 1      // m.Tunnel.HopLimit
+	size += 2      // m.UDPSrcPort
+	size += 2      // m.UDPDstPort
+	return size
+}
+func (m *IpsecSadEntryUpdate) Marshal(b []byte) ([]byte, error) {
+	if b == nil {
+		b = make([]byte, m.Size())
+	}
+	buf := codec.NewBuffer(b)
+	buf.EncodeUint32(m.SadID)
+	buf.EncodeBool(m.IsTun)
+	buf.EncodeUint32(m.Tunnel.Instance)
+	buf.EncodeUint8(uint8(m.Tunnel.Src.Af))
+	buf.EncodeBytes(m.Tunnel.Src.Un.XXX_UnionData[:], 16)
+	buf.EncodeUint8(uint8(m.Tunnel.Dst.Af))
+	buf.EncodeBytes(m.Tunnel.Dst.Un.XXX_UnionData[:], 16)
+	buf.EncodeUint32(uint32(m.Tunnel.SwIfIndex))
+	buf.EncodeUint32(m.Tunnel.TableID)
+	buf.EncodeUint8(uint8(m.Tunnel.EncapDecapFlags))
+	buf.EncodeUint8(uint8(m.Tunnel.Mode))
+	buf.EncodeUint8(uint8(m.Tunnel.Flags))
+	buf.EncodeUint8(uint8(m.Tunnel.Dscp))
+	buf.EncodeUint8(m.Tunnel.HopLimit)
+	buf.EncodeUint16(m.UDPSrcPort)
+	buf.EncodeUint16(m.UDPDstPort)
+	return buf.Bytes(), nil
+}
+func (m *IpsecSadEntryUpdate) Unmarshal(b []byte) error {
+	buf := codec.NewBuffer(b)
+	m.SadID = buf.DecodeUint32()
+	m.IsTun = buf.DecodeBool()
+	m.Tunnel.Instance = buf.DecodeUint32()
+	m.Tunnel.Src.Af = ip_types.AddressFamily(buf.DecodeUint8())
+	copy(m.Tunnel.Src.Un.XXX_UnionData[:], buf.DecodeBytes(16))
+	m.Tunnel.Dst.Af = ip_types.AddressFamily(buf.DecodeUint8())
+	copy(m.Tunnel.Dst.Un.XXX_UnionData[:], buf.DecodeBytes(16))
+	m.Tunnel.SwIfIndex = interface_types.InterfaceIndex(buf.DecodeUint32())
+	m.Tunnel.TableID = buf.DecodeUint32()
+	m.Tunnel.EncapDecapFlags = tunnel_types.TunnelEncapDecapFlags(buf.DecodeUint8())
+	m.Tunnel.Mode = tunnel_types.TunnelMode(buf.DecodeUint8())
+	m.Tunnel.Flags = tunnel_types.TunnelFlags(buf.DecodeUint8())
+	m.Tunnel.Dscp = ip_types.IPDscp(buf.DecodeUint8())
+	m.Tunnel.HopLimit = buf.DecodeUint8()
+	m.UDPSrcPort = buf.DecodeUint16()
+	m.UDPDstPort = buf.DecodeUint16()
+	return nil
+}
+
+// IpsecSadEntryUpdateReply defines message 'ipsec_sad_entry_update_reply'.
+type IpsecSadEntryUpdateReply struct {
+	Retval int32 `binapi:"i32,name=retval" json:"retval,omitempty"`
+}
+
+func (m *IpsecSadEntryUpdateReply) Reset()               { *m = IpsecSadEntryUpdateReply{} }
+func (*IpsecSadEntryUpdateReply) GetMessageName() string { return "ipsec_sad_entry_update_reply" }
+func (*IpsecSadEntryUpdateReply) GetCrcString() string   { return "e8d4e804" }
+func (*IpsecSadEntryUpdateReply) GetMessageType() api.MessageType {
+	return api.ReplyMessage
+}
+
+func (m *IpsecSadEntryUpdateReply) Size() (size int) {
+	if m == nil {
+		return 0
+	}
+	size += 4 // m.Retval
+	return size
+}
+func (m *IpsecSadEntryUpdateReply) Marshal(b []byte) ([]byte, error) {
+	if b == nil {
+		b = make([]byte, m.Size())
+	}
+	buf := codec.NewBuffer(b)
+	buf.EncodeInt32(m.Retval)
+	return buf.Bytes(), nil
+}
+func (m *IpsecSadEntryUpdateReply) Unmarshal(b []byte) error {
+	buf := codec.NewBuffer(b)
+	m.Retval = buf.DecodeInt32()
+	return nil
+}
+
 // IpsecSelectBackend defines message 'ipsec_select_backend'.
 type IpsecSelectBackend struct {
 	Protocol ipsec_types.IpsecProto `binapi:"ipsec_proto,name=protocol" json:"protocol,omitempty"`
@@ -2481,6 +2596,8 @@ func file_ipsec_binapi_init() {
 	api.RegisterMessage((*IpsecSadEntryAddReply)(nil), "ipsec_sad_entry_add_reply_9ffac24b")
 	api.RegisterMessage((*IpsecSadEntryDel)(nil), "ipsec_sad_entry_del_3a91bde5")
 	api.RegisterMessage((*IpsecSadEntryDelReply)(nil), "ipsec_sad_entry_del_reply_e8d4e804")
+	api.RegisterMessage((*IpsecSadEntryUpdate)(nil), "ipsec_sad_entry_update_1412af86")
+	api.RegisterMessage((*IpsecSadEntryUpdateReply)(nil), "ipsec_sad_entry_update_reply_e8d4e804")
 	api.RegisterMessage((*IpsecSelectBackend)(nil), "ipsec_select_backend_5bcfd3b7")
 	api.RegisterMessage((*IpsecSelectBackendReply)(nil), "ipsec_select_backend_reply_e8d4e804")
 	api.RegisterMessage((*IpsecSetAsyncMode)(nil), "ipsec_set_async_mode_a6465f7c")
@@ -2534,6 +2651,8 @@ func AllMessages() []api.Message {
 		(*IpsecSadEntryAddReply)(nil),
 		(*IpsecSadEntryDel)(nil),
 		(*IpsecSadEntryDelReply)(nil),
+		(*IpsecSadEntryUpdate)(nil),
+		(*IpsecSadEntryUpdateReply)(nil),
 		(*IpsecSelectBackend)(nil),
 		(*IpsecSelectBackendReply)(nil),
 		(*IpsecSetAsyncMode)(nil),

--- a/vpplink/binapi/vppapi/ipsec/ipsec_rpc.ba.go
+++ b/vpplink/binapi/vppapi/ipsec/ipsec_rpc.ba.go
@@ -26,6 +26,7 @@ type RPCService interface {
 	IpsecSadEntryAddDelV2(ctx context.Context, in *IpsecSadEntryAddDelV2) (*IpsecSadEntryAddDelV2Reply, error)
 	IpsecSadEntryAddDelV3(ctx context.Context, in *IpsecSadEntryAddDelV3) (*IpsecSadEntryAddDelV3Reply, error)
 	IpsecSadEntryDel(ctx context.Context, in *IpsecSadEntryDel) (*IpsecSadEntryDelReply, error)
+	IpsecSadEntryUpdate(ctx context.Context, in *IpsecSadEntryUpdate) (*IpsecSadEntryUpdateReply, error)
 	IpsecSelectBackend(ctx context.Context, in *IpsecSelectBackend) (*IpsecSelectBackendReply, error)
 	IpsecSetAsyncMode(ctx context.Context, in *IpsecSetAsyncMode) (*IpsecSetAsyncModeReply, error)
 	IpsecSpdAddDel(ctx context.Context, in *IpsecSpdAddDel) (*IpsecSpdAddDelReply, error)
@@ -327,6 +328,15 @@ func (c *serviceClient) IpsecSadEntryAddDelV3(ctx context.Context, in *IpsecSadE
 
 func (c *serviceClient) IpsecSadEntryDel(ctx context.Context, in *IpsecSadEntryDel) (*IpsecSadEntryDelReply, error) {
 	out := new(IpsecSadEntryDelReply)
+	err := c.conn.Invoke(ctx, in, out)
+	if err != nil {
+		return nil, err
+	}
+	return out, api.RetvalToVPPApiError(out.Retval)
+}
+
+func (c *serviceClient) IpsecSadEntryUpdate(ctx context.Context, in *IpsecSadEntryUpdate) (*IpsecSadEntryUpdateReply, error) {
+	out := new(IpsecSadEntryUpdateReply)
 	err := c.conn.Invoke(ctx, in, out)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This upgrade of VPP's version contains fixes for af_packet. Notable included fixes are : 8a0fd0669 - af_packet: add the missing header-len for packets with checksum offload 6a07348f4 - pci: add option to force uio binding
bca76580b - af_packet: move to plugin

And a cherry pick of a pending patch
git_cherry_pick refs/changes/31/37931/1 # 37931: ip: add the missing offload check | https://gerrit.fd.io/r/c/vpp/+/37931

Signed-off-by: Nathan Skrzypczak <nathan.skrzypczak@gmail.com>