### PR TITLE
Fix manifest yamls

### DIFF
--- a/yaml/base/calico-vpp-daemonset.yaml
+++ b/yaml/base/calico-vpp-daemonset.yaml
@@ -171,7 +171,8 @@ data:
       },
       "uplinkInterfaces": [
         {
-          "interfaceName": "eth1"
+          "interfaceName": "eth1",
+          "vppDriver": "af_packet"
         }
       ]
     }

--- a/yaml/generated/calico-vpp-dpdk.yaml
+++ b/yaml/generated/calico-vpp-dpdk.yaml
@@ -178,11 +178,11 @@ data:
       },
       "uplinkInterfaces": [
         {
-          "interfaceName": "eth1"
+          "interfaceName": "eth1",
+          "vppDriver": "dpdk"
         }
       ]
     }
-  CALICOVPP_NATIVE_DRIVER: dpdk
   SERVICE_PREFIX: 10.96.0.0/12
 kind: ConfigMap
 metadata:
@@ -256,6 +256,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         envFrom:
         - configMapRef:
             name: calico-vpp-config

--- a/yaml/generated/calico-vpp-eks-dpdk.yaml
+++ b/yaml/generated/calico-vpp-eks-dpdk.yaml
@@ -167,6 +167,15 @@ data:
     }
   CALICOVPP_INTERFACES: |-
     {
+      "maxPodIfSpec": {
+        "rx": 10, "tx": 10, "rxqsz": 1024, "txqsz": 1024
+      },
+      "defaultPodIfSpec": {
+        "rx": 1, "tx":1, "isl3": true
+      },
+      "vppHostTapSpec": {
+        "rx": 1, "tx":1, "rxqsz": 1024, "txqsz": 1024, "isl3": false
+      },
       "uplinkInterfaces": [
         {
           "interfaceName": "eth0",
@@ -258,6 +267,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         envFrom:
         - configMapRef:
             name: calico-vpp-config

--- a/yaml/generated/calico-vpp-eks.yaml
+++ b/yaml/generated/calico-vpp-eks.yaml
@@ -167,6 +167,15 @@ data:
     }
   CALICOVPP_INTERFACES: |-
     {
+      "maxPodIfSpec": {
+        "rx": 10, "tx": 10, "rxqsz": 1024, "txqsz": 1024
+      },
+      "defaultPodIfSpec": {
+        "rx": 1, "tx":1, "isl3": true
+      },
+      "vppHostTapSpec": {
+        "rx": 1, "tx":1, "rxqsz": 1024, "txqsz": 1024, "isl3": false
+      },
       "uplinkInterfaces": [
         {
           "interfaceName": "eth0",
@@ -256,6 +265,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         envFrom:
         - configMapRef:
             name: calico-vpp-config

--- a/yaml/generated/calico-vpp-kind.yaml
+++ b/yaml/generated/calico-vpp-kind.yaml
@@ -206,6 +206,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         envFrom:
         - configMapRef:
             name: calico-vpp-config

--- a/yaml/generated/calico-vpp-nohuge.yaml
+++ b/yaml/generated/calico-vpp-nohuge.yaml
@@ -178,7 +178,8 @@ data:
       },
       "uplinkInterfaces": [
         {
-          "interfaceName": "eth1"
+          "interfaceName": "eth1",
+          "vppDriver": "af_packet"
         }
       ]
     }
@@ -214,6 +215,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         envFrom:
         - configMapRef:
             name: calico-vpp-config

--- a/yaml/generated/calico-vpp.yaml
+++ b/yaml/generated/calico-vpp.yaml
@@ -178,7 +178,8 @@ data:
       },
       "uplinkInterfaces": [
         {
-          "interfaceName": "eth1"
+          "interfaceName": "eth1",
+          "vppDriver": ""
         }
       ]
     }
@@ -255,6 +256,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         envFrom:
         - configMapRef:
             name: calico-vpp-config

--- a/yaml/overlays/default-huge/default-huge.yaml
+++ b/yaml/overlays/default-huge/default-huge.yaml
@@ -1,3 +1,27 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: calico-vpp-config
+  namespace: calico-vpp-dataplane
+data:
+  CALICOVPP_INTERFACES: |-
+    {
+      "maxPodIfSpec": {
+        "rx": 10, "tx": 10, "rxqsz": 1024, "txqsz": 1024
+      },
+      "defaultPodIfSpec": {
+        "rx": 1, "tx":1, "isl3": true
+      },
+      "vppHostTapSpec": {
+        "rx": 1, "tx":1, "rxqsz": 1024, "txqsz": 1024, "isl3": false
+      },
+      "uplinkInterfaces": [
+        {
+          "interfaceName": "eth1",
+          "vppDriver": ""
+        }
+      ]
+    }
 ---
 kind: DaemonSet
 apiVersion: apps/v1

--- a/yaml/overlays/dpdk/dpdk.yaml
+++ b/yaml/overlays/dpdk/dpdk.yaml
@@ -4,7 +4,24 @@ metadata:
   name: calico-vpp-config
   namespace: calico-vpp-dataplane
 data:
-  CALICOVPP_NATIVE_DRIVER: "dpdk"
+  CALICOVPP_INTERFACES: |-
+    {
+      "maxPodIfSpec": {
+        "rx": 10, "tx": 10, "rxqsz": 1024, "txqsz": 1024
+      },
+      "defaultPodIfSpec": {
+        "rx": 1, "tx":1, "isl3": true
+      },
+      "vppHostTapSpec": {
+        "rx": 1, "tx":1, "rxqsz": 1024, "txqsz": 1024, "isl3": false
+      },
+      "uplinkInterfaces": [
+        {
+          "interfaceName": "eth1",
+          "vppDriver": "dpdk"
+        }
+      ]
+    }
 ---
 kind: DaemonSet
 apiVersion: apps/v1

--- a/yaml/overlays/eks-dpdk/eks-config.yaml
+++ b/yaml/overlays/eks-dpdk/eks-config.yaml
@@ -6,6 +6,15 @@ metadata:
 data:  # Configuration template for VPP in EKS
   CALICOVPP_INTERFACES: |-
     {
+      "maxPodIfSpec": {
+        "rx": 10, "tx": 10, "rxqsz": 1024, "txqsz": 1024
+      },
+      "defaultPodIfSpec": {
+        "rx": 1, "tx":1, "isl3": true
+      },
+      "vppHostTapSpec": {
+        "rx": 1, "tx":1, "rxqsz": 1024, "txqsz": 1024, "isl3": false
+      },
       "uplinkInterfaces": [
         {
           "interfaceName": "eth0",

--- a/yaml/overlays/eks/eks-config.yaml
+++ b/yaml/overlays/eks/eks-config.yaml
@@ -7,6 +7,15 @@ data:  # Configuration template for VPP in EKS
   SERVICE_PREFIX: 10.100.0.0/16
   CALICOVPP_INTERFACES: |-
     {
+      "maxPodIfSpec": {
+        "rx": 10, "tx": 10, "rxqsz": 1024, "txqsz": 1024
+      },
+      "defaultPodIfSpec": {
+        "rx": 1, "tx":1, "isl3": true
+      },
+      "vppHostTapSpec": {
+        "rx": 1, "tx":1, "rxqsz": 1024, "txqsz": 1024, "isl3": false
+      },
       "uplinkInterfaces": [
         {
           "interfaceName": "eth0",
@@ -14,7 +23,6 @@ data:  # Configuration template for VPP in EKS
         }
       ]
     }
-
 ---
 kind: DaemonSet
 apiVersion: apps/v1


### PR DESCRIPTION
Fix the yamls which got messed up post the config changes.

1. Add back the missing fields for eks
2. Set vppDriver explicitly per individual manifests