### PR TITLE
misc: dev env improvements

### DIFF
--- a/calico-vpp-agent/watchers/net_watcher.go
+++ b/calico-vpp-agent/watchers/net_watcher.go
@@ -79,25 +79,23 @@ func (w *NetWatcher) WatchNetworks(t *tomb.Tomb) error {
 	netList := &networkv3.NetworkList{}
 	err := w.client.List(context.Background(), netList, &client.ListOptions{})
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "Listing Networks failed")
 	}
 	nadList := &netv1.NetworkAttachmentDefinitionList{}
 	err = w.client.List(context.Background(), nadList, &client.ListOptions{})
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "Listing NetworkAttachmentDefinitions failed")
 	}
 	for _, net := range netList.Items {
 		err := w.OnNetAdded(&net)
 		if err != nil {
-			w.log.Error(err)
-			return err
+			return errors.Wrapf(err, "OnNetAdded failed for %v", net)
 		}
 	}
 	for _, nad := range nadList.Items {
 		err = w.onNadAdded(&nad)
 		if err != nil {
-			w.log.Error(err)
-			return err
+			return errors.Wrapf(err, "OnNadAdded failed for %v", nad)
 		}
 	}
 	w.InSync <- 1

--- a/vpp-manager/Makefile
+++ b/vpp-manager/Makefile
@@ -60,6 +60,15 @@ clean-vpp:
 	rm -f ./vpp_build/build-root/*.buildinfo
 	rm -f $(IMAGE_DIR)/*.deb
 
+rebuild-vpp: vpp-build-env
+	docker run --rm \
+		-e VPP_MGR_DIR=$(CURDIR) \
+		-v $(CURDIR):$(CURDIR):delegated \
+		--user $$(id -u):$$(id -g) \
+		--env NO_BUILD_DEBS=true \
+		--network=host \
+		calicovpp/vpp-build:latest
+
 vpp: clone-vpp clean-vpp vpp-build-env
 	docker run --rm \
 		-e VPP_MGR_DIR=$(CURDIR) \

--- a/vpp-manager/images/ubuntu-build/build_script.sh
+++ b/vpp-manager/images/ubuntu-build/build_script.sh
@@ -5,6 +5,8 @@ set -o errexit
 cd ${VPP_MGR_DIR}/vpp_build
 
 make build-release
-rm -f ./build-root/*.deb ./build-root/*.changes ./build-root/*.buildinfo
-make pkg-deb
+if [ "${NO_BUILD_DEBS}" != "true" ]; then
+	rm -f ./build-root/*.deb ./build-root/*.changes ./build-root/*.buildinfo
+	make pkg-deb
+fi
 

--- a/yaml/overlays/dev/kustomize.sh
+++ b/yaml/overlays/dev/kustomize.sh
@@ -119,10 +119,10 @@ function get_initial_config ()
 function get_feature_gates ()
 {
     echo "{
-      \"memifEnabled\": ${CALICOVPP_ENABLE_MEMIF:false},
-      \"vclEnabled\": ${CALICOVPP_ENABLE_VCL:false},
-      \"multinetEnabled\": ${CALICOVPP_ENABLE_MULTINET:false},
-      \"ipsecEnabled\": ${CALICOVPP_IPSEC_ENABLED:false}
+      \"memifEnabled\": ${CALICOVPP_ENABLE_MEMIF:-"false"},
+      \"vclEnabled\": ${CALICOVPP_ENABLE_VCL:-"false"},
+      \"multinetEnabled\": ${CALICOVPP_ENABLE_MULTINET:-"false"},
+      \"ipsecEnabled\": ${CALICOVPP_IPSEC_ENABLED:-"false"}
     }"
 }
 
@@ -251,7 +251,7 @@ calico_create_template ()
   export CALICOVPP_INITIAL_CONFIG="$(indent_variable "${CALICOVPP_INITIAL_CONFIG:-$(get_initial_config)}")"
   export CALICOVPP_INTERFACES="$(indent_variable "${CALICOVPP_INTERFACES:-$(get_interfaces)}")"
   export CALICOVPP_DEBUG="$(indent_variable "${CALICOVPP_DEBUG:-$(get_debug)}")"
-  export CALICOVPP_FEATURE_GATES="$(indent_variable "${CALICOVPP_FEATURE_GATES:-"{}"}")"
+  export CALICOVPP_FEATURE_GATES="$(indent_variable "${CALICOVPP_FEATURE_GATES:-$(get_feature_gates)}")"
   export CALICOVPP_IPSEC="$(indent_variable "${CALICOVPP_IPSEC:-"{}"}")"
   export CALICOVPP_SRV6="$(indent_variable "${CALICOVPP_SRV6:-"{}"}")"
   export DEBUG='"'${DEBUG}'"' # should we run VPP release or debug ?


### PR DESCRIPTION
This patch enables get_feature_gates which was missing in kustomize.sh

It also adds a make rebuild-vpp target in vpp-manager to do a local rebuild of VPP whithout the debs to shorten build iterations in dev

This also adds more context to the errors returned by the net_watcher.

Signed-off-by: Nathan Skrzypczak <nathan.skrzypczak@gmail.com>