### PR TITLE
agent: add startup watchdog logging missing components

### DIFF
--- a/calico-vpp-agent/cmd/calico_vpp_dataplane.go
+++ b/calico-vpp-agent/cmd/calico_vpp_dataplane.go
@@ -151,22 +151,18 @@ func main() {
 	routingServer.SetBGPConf(bgpConf)
 	serviceServer.SetBGPConf(bgpConf)
 
+	watchDog := NewWatchDog(log.WithFields(logrus.Fields{"component": "watchDog"}))
+	Go(watchDog.watch)
 	Go(policyServer.ServePolicy)
-	log.Infof("Waiting for our node's BGP spec...")
 	felixConfig := policyServer.WaitForFelixConfig()
+	felixConfigReceived = true
 	ourBGPSpec := policyServer.WaitForOurBGPSpec()
-
+	bgpSpecReceived = true
 	prefixWatcher.SetOurBGPSpec(ourBGPSpec)
 	connectivityServer.SetOurBGPSpec(ourBGPSpec)
 	routingServer.SetOurBGPSpec(ourBGPSpec)
 	serviceServer.SetOurBGPSpec(ourBGPSpec)
 	localSIDWatcher.SetOurBGPSpec(ourBGPSpec)
-
-	/**
-	 * This should be done in a separated location, but till then, we
-	 * still have to wait on the policy server starting
-	 */
-	log.Infof("Waiting for felix config being present...")
 
 	if *config.GetCalicoVppFeatureGates().MultinetEnabled {
 		Go(netWatcher.WatchNetworks)

--- a/calico-vpp-agent/cmd/watch_dog.go
+++ b/calico-vpp-agent/cmd/watch_dog.go
@@ -1,0 +1,56 @@
+// Copyright (C) 2019 Cisco Systems Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"gopkg.in/tomb.v2"
+)
+
+var (
+	felixConfigReceived bool
+	bgpSpecReceived     bool
+	agentStarted        bool
+)
+
+type WatchDog struct {
+	log *logrus.Entry
+}
+
+func NewWatchDog(log *logrus.Entry) *WatchDog {
+	return &WatchDog{
+		log: log,
+	}
+}
+
+func (wd *WatchDog) watch(t *tomb.Tomb) error {
+	for !agentStarted {
+		time.Sleep(time.Second * 5)
+		if !felixConfigReceived {
+			wd.log.Info("Felix Config not received, still waiting...")
+		}
+		if !bgpSpecReceived {
+			wd.log.Info("BGP Spec not received, still waiting...")
+		}
+		if felixConfigReceived && bgpSpecReceived {
+			wd.log.Info("AGENT STARTING...")
+			agentStarted = true
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
adding a startup watchdog that logs every 5 seconds what we are missing for agent to start (felixconfig, bgpspec)