### PR TITLE
config: also validate missing jsonEnvVars

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -66,12 +66,12 @@ var (
 
 	ServiceCIDRs           = PrefixListEnvVar("SERVICE_PREFIX")
 	IPSecIkev2Psk          = StringEnvVar("CALICOVPP_IPSEC_IKEV2_PSK", "")
-	CalicoVppDebug         = ValidableJsonEnvVar("CALICOVPP_DEBUG", &CalicoVppDebugConfigType{})
-	CalicoVppInterfaces    = ValidableJsonEnvVar("CALICOVPP_INTERFACES", &CalicoVppInterfacesConfigType{})
-	CalicoVppFeatureGates  = ValidableJsonEnvVar("CALICOVPP_FEATURE_GATES", &CalicoVppFeatureGatesConfigType{})
-	CalicoVppIpsec         = ValidableJsonEnvVar("CALICOVPP_IPSEC", &CalicoVppIpsecConfigType{})
-	CalicoVppSrv6          = ValidableJsonEnvVar("CALICOVPP_SRV6", &CalicoVppSrv6ConfigType{})
-	CalicoVppInitialConfig = ValidableJsonEnvVar("CALICOVPP_INITIAL_CONFIG", &CalicoVppInitialConfigConfigType{})
+	CalicoVppDebug         = JsonEnvVar("CALICOVPP_DEBUG", &CalicoVppDebugConfigType{})
+	CalicoVppInterfaces    = JsonEnvVar("CALICOVPP_INTERFACES", &CalicoVppInterfacesConfigType{})
+	CalicoVppFeatureGates  = JsonEnvVar("CALICOVPP_FEATURE_GATES", &CalicoVppFeatureGatesConfigType{})
+	CalicoVppIpsec         = JsonEnvVar("CALICOVPP_IPSEC", &CalicoVppIpsecConfigType{})
+	CalicoVppSrv6          = JsonEnvVar("CALICOVPP_SRV6", &CalicoVppSrv6ConfigType{})
+	CalicoVppInitialConfig = JsonEnvVar("CALICOVPP_INITIAL_CONFIG", &CalicoVppInitialConfigConfigType{})
 	LogFormat              = StringEnvVar("CALICOVPP_LOG_FORMAT", "")
 
 	/* Deprecated vars */

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -17,42 +17,83 @@ package config
 
 import (
 	"net"
+	"os"
 	"testing"
 
 	"github.com/vishvananda/netlink"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
+
+func TestCommonConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "common config tests")
+}
 
 func network(address string) *net.IPNet {
 	_, n, _ := net.ParseCIDR(address)
 	return n
 }
 
-var (
-	gw               = net.ParseIP("192.168.2.1")
-	net0             = network("192.168.2.1/32")
-	net2             = network("192.168.3.0/24")
-	net3             = network("10.8.0.0/16")
-	deflt *net.IPNet = nil
-)
-
-// LinkIndex is the target position of the route in sorted order
-var routesLists = [][]netlink.Route{
-	{
-		netlink.Route{LinkIndex: 3, Dst: deflt, Gw: gw},
-		netlink.Route{LinkIndex: 1, Dst: net2, Gw: gw},
-		netlink.Route{LinkIndex: 2, Dst: net3, Gw: gw},
-		netlink.Route{LinkIndex: 0, Dst: net0, Gw: nil},
-	},
+type SomeType struct {
+	A int
 }
 
-func TestRouteSort(t *testing.T) {
-	for _, rl := range routesLists {
-		c := LinuxInterfaceState{Routes: rl}
-		c.SortRoutes()
-		for i, r := range c.Routes {
-			if r.LinkIndex != i {
-				t.Errorf("Link %d should be at index %d", r.LinkIndex, i)
+type SomeValidableType struct {
+	A int
+}
+
+func (self *SomeValidableType) Validate() error {
+	self.A = 1234
+	return nil
+}
+
+var _ = Describe("Test Common Config", func() {
+	It("Test Routes Sorting", func() {
+
+		var (
+			gw               = net.ParseIP("192.168.2.1")
+			net0             = network("192.168.2.1/32")
+			net2             = network("192.168.3.0/24")
+			net3             = network("10.8.0.0/16")
+			deflt *net.IPNet = nil
+		)
+
+		// LinkIndex is the target position of the route in sorted order
+		var routesLists = [][]netlink.Route{
+			{
+				netlink.Route{LinkIndex: 3, Dst: deflt, Gw: gw},
+				netlink.Route{LinkIndex: 1, Dst: net2, Gw: gw},
+				netlink.Route{LinkIndex: 2, Dst: net3, Gw: gw},
+				netlink.Route{LinkIndex: 0, Dst: net0, Gw: nil},
+			},
+		}
+
+		for _, rl := range routesLists {
+			c := LinuxInterfaceState{Routes: rl}
+			c.SortRoutes()
+			for i, r := range c.Routes {
+				Expect(r.LinkIndex).To(Equal(i), "Link %d should be at index %d", r.LinkIndex, i)
 			}
 		}
-	}
-}
+	})
+
+	It("Test Routes Sorting", func() {
+		SomeParsedVar := JsonEnvVar("SOMEVAR", &SomeType{})
+		Expect(os.Setenv("SOMEVAR", "{\"A\":1}")).ToNot(HaveOccurred())
+		Expect(ParseEnvVars("SOMEVAR")).To(BeEmpty())
+		Expect((*SomeParsedVar).A).To(Equal(1))
+
+		SomeValidableParsedVar := JsonEnvVar("SOMEVAR2", &SomeValidableType{})
+		Expect(ParseEnvVars("SOMEVAR2")).To(BeEmpty())
+		Expect((*SomeValidableParsedVar).A).To(Equal(1234))
+
+		_ = RequiredStringEnvVar("SOMEVAR3")
+		Expect(os.Unsetenv("SOMEVAR3")).ToNot(HaveOccurred())
+		errs := ParseEnvVars("SOMEVAR3")
+		Expect(len(errs)).To(Equal(1))
+		Expect(errs[0]).To(HaveOccurred())
+
+	})
+})


### PR DESCRIPTION
This patch makes it so that JsonEnvVars implementing Validate() error will also have their method called even if the envvar is not defined. This allows to set defaults at the start of the program and avoid NPE when the propertie's type is a pointer.

Signed-off-by: Nathan Skrzypczak <nathan.skrzypczak@gmail.com>