### PR TITLE
agent: remove leaking policies in system policies

### DIFF
--- a/calico-vpp-agent/cni/cni_pod_test.go
+++ b/calico-vpp-agent/cni/cni_pod_test.go
@@ -235,7 +235,7 @@ var _ = Describe("Pod-related functionality of CNI", func() {
 					socket, err := vpp.MemifsocketByID(memifs[0].SocketId)
 					Expect(err).ToNot(HaveOccurred(), "failed to get memif socket")
 					Expect(socket.SocketFilename).To(Equal(
-						fmt.Sprintf("@netns:%s%s", newPod.Netns, newPod.InterfaceName)),
+						fmt.Sprintf("@netns:%s@vpp/memif-%s", newPod.Netns, newPod.InterfaceName)),
 						"memif socket file is not configured correctly")
 
 					By("Checking PBL (packet punting) to redirect some traffic into memif (secondary interface)")

--- a/calico-vpp-agent/cni/pod_interface/memif.go
+++ b/calico-vpp-agent/cni/pod_interface/memif.go
@@ -56,7 +56,7 @@ func (i *MemifPodInterfaceDriver) CreateInterface(podSpec *storage.LocalPodSpec,
 	memifName := "@" + podSpec.InterfaceName
 	// if we are in main network (PBL case)
 	if podSpec.NetworkName == "" {
-		memifName = "@vpp/memif" + podSpec.InterfaceName
+		memifName = "@vpp/memif-" + podSpec.InterfaceName
 	}
 	socketId, err := i.vpp.AddMemifSocketFileName(fmt.Sprintf("@netns:%s%s", podSpec.NetnsName, memifName))
 	if err != nil {

--- a/calico-vpp-agent/policy/host_endpoint.go
+++ b/calico-vpp-agent/policy/host_endpoint.go
@@ -178,13 +178,13 @@ func (h *HostEndpoint) getTapPolicies(state *PolicyState) (conf *types.Interface
 	}
 	if len(conf.IngressPolicyIDs) > 0 {
 		conf.IngressPolicyIDs = append(conf.IngressPolicyIDs, h.server.workloadsToHostPolicy.VppID)
-		conf.IngressPolicyIDs = append([]uint32{h.server.failSafePolicyId}, conf.IngressPolicyIDs...)
+		conf.IngressPolicyIDs = append([]uint32{h.server.failSafePolicy.VppID}, conf.IngressPolicyIDs...)
 	} else {
 		conf.IngressPolicyIDs = h.server.defaultTap0IngressConf
 	}
 	if len(conf.EgressPolicyIDs) > 0 {
-		conf.EgressPolicyIDs = append([]uint32{h.server.AllowFromHostPolicyId}, conf.EgressPolicyIDs...)
-		conf.EgressPolicyIDs = append([]uint32{h.server.failSafePolicyId}, conf.EgressPolicyIDs...)
+		conf.EgressPolicyIDs = append([]uint32{h.server.AllowFromHostPolicy.VppID}, conf.EgressPolicyIDs...)
+		conf.EgressPolicyIDs = append([]uint32{h.server.failSafePolicy.VppID}, conf.EgressPolicyIDs...)
 	}
 	return conf, nil
 }
@@ -195,10 +195,10 @@ func (h *HostEndpoint) getForwardPolicies(state *PolicyState) (conf *types.Inter
 		return nil, errors.Wrap(err, "cannot create host policies for forwardConf")
 	}
 	if len(conf.EgressPolicyIDs) > 0 {
-		conf.EgressPolicyIDs = append([]uint32{h.server.allowToHostPolicyId}, conf.EgressPolicyIDs...)
+		conf.EgressPolicyIDs = append([]uint32{h.server.allowToHostPolicy.VppID}, conf.EgressPolicyIDs...)
 	}
 	if len(conf.IngressPolicyIDs) > 0 {
-		conf.IngressPolicyIDs = append([]uint32{h.server.allowToHostPolicyId}, conf.IngressPolicyIDs...)
+		conf.IngressPolicyIDs = append([]uint32{h.server.allowToHostPolicy.VppID}, conf.IngressPolicyIDs...)
 	}
 	return conf, nil
 }

--- a/calico-vpp-agent/policy/workload_endpoint.go
+++ b/calico-vpp-agent/policy/workload_endpoint.go
@@ -121,7 +121,7 @@ func (w *WorkloadEndpoint) getPolicies(state *PolicyState, network string) (conf
 		conf.ProfileIDs = append(conf.ProfileIDs, prof.VppID)
 	}
 	if len(conf.IngressPolicyIDs) > 0 {
-		conf.IngressPolicyIDs = append([]uint32{w.server.AllowFromHostPolicyId}, conf.IngressPolicyIDs...)
+		conf.IngressPolicyIDs = append([]uint32{w.server.AllowFromHostPolicy.VppID}, conf.IngressPolicyIDs...)
 	}
 	return conf, nil
 }


### PR DESCRIPTION
no need to remove leaking rules as they are automatically deleted when no policy uses them anymore.
However some policies we recreate are leaking so needed to remove them