### PR TITLE
vpp-manager: Only warn if setting the DPDK mac in VPP is unsupported

### DIFF
--- a/vpp-manager/uplink/dpdk.go
+++ b/vpp-manager/uplink/dpdk.go
@@ -16,6 +16,7 @@
 package uplink
 
 import (
+	gerrors "errors"
 	"fmt"
 	"regexp"
 	"time"
@@ -24,6 +25,7 @@ import (
 	"github.com/projectcalico/vpp-dataplane/config"
 	"github.com/projectcalico/vpp-dataplane/vpp-manager/utils"
 	"github.com/projectcalico/vpp-dataplane/vpplink"
+	"github.com/projectcalico/vpp-dataplane/vpplink/types"
 	log "github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 )
@@ -167,7 +169,9 @@ func (d *DPDKDriver) CreateMainVppInterface(vpp *vpplink.VppLink, vppPid int, up
 	}
 	d.spec.SwIfIndex = swIfIndex
 	err = vpp.SetInterfaceMacAddress(swIfIndex, &d.conf.HardwareAddr)
-	if err != nil {
+	if err != nil && gerrors.Is(err, types.VppErrorUnimplemented) {
+		log.Warn("Setting dpdk interface mac address in vpp unsupported")
+	} else if err != nil {
 		return errors.Wrap(err, "could not set dpdk interface mac address in vpp")
 	}
 	return nil

--- a/vpplink/types/errors.go
+++ b/vpplink/types/errors.go
@@ -1,0 +1,24 @@
+// Copyright (C) 2023 Cisco Systems Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"go.fd.io/govpp/api"
+)
+
+var (
+	VppErrorUnimplemented = api.UNIMPLEMENTED
+)

--- a/vpplink/types/errors_test.go
+++ b/vpplink/types/errors_test.go
@@ -1,0 +1,41 @@
+// Copyright (C) 2023 Cisco Systems Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	gerrors "errors"
+	"github.com/pkg/errors"
+	"go.fd.io/govpp/api"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestCommonConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "vpplink types tests")
+}
+
+var _ = Describe("Test Vpplink types", func() {
+	It("Vpplink errors comparisons testing", func() {
+		err := api.RetvalToVPPApiError(int32(api.UNIMPLEMENTED))
+		err = errors.Wrapf(err, "Something else")
+		Expect(gerrors.Is(err, VppErrorUnimplemented)).To(BeTrue())
+		err = api.RetvalToVPPApiError(int32(api.SYSCALL_ERROR_1))
+		Expect(gerrors.Is(err, VppErrorUnimplemented)).To(BeFalse())
+	})
+})


### PR DESCRIPTION
Signed-off-by: Nathan Skrzypczak <nathan.skrzypczak@gmail.com>