### PR TITLE
agent: endpointtohostaction should have priority and empty hep should…

### DIFF
--- a/calico-vpp-agent/policy/host_endpoint.go
+++ b/calico-vpp-agent/policy/host_endpoint.go
@@ -177,12 +177,18 @@ func (h *HostEndpoint) getTapPolicies(state *PolicyState) (conf *types.Interface
 		return nil, errors.Wrap(err, "cannot create host policies for TapConf")
 	}
 	if len(conf.IngressPolicyIDs) > 0 {
-		conf.IngressPolicyIDs = append(conf.IngressPolicyIDs, h.server.workloadsToHostPolicy.VppID)
 		conf.IngressPolicyIDs = append([]uint32{h.server.failSafePolicy.VppID}, conf.IngressPolicyIDs...)
+		conf.IngressPolicyIDs = append([]uint32{h.server.workloadsToHostPolicy.VppID}, conf.IngressPolicyIDs...)
+	} else {
+		conf.IngressPolicyIDs = []uint32{h.server.workloadsToHostPolicy.VppID, h.server.failSafePolicy.VppID}
+		/* automatically deny the rest because host endpoint is empty on ingress */
 	}
 	if len(conf.EgressPolicyIDs) > 0 {
-		conf.EgressPolicyIDs = append([]uint32{h.server.AllowFromHostPolicy.VppID}, conf.EgressPolicyIDs...)
 		conf.EgressPolicyIDs = append([]uint32{h.server.failSafePolicy.VppID}, conf.EgressPolicyIDs...)
+		conf.EgressPolicyIDs = append([]uint32{h.server.AllowFromHostPolicy.VppID}, conf.EgressPolicyIDs...)
+	} else {
+		conf.EgressPolicyIDs = []uint32{h.server.AllowFromHostPolicy.VppID, h.server.failSafePolicy.VppID}
+		/* automatically deny the rest because host endpoint is empty on egress */
 	}
 	return conf, nil
 }


### PR DESCRIPTION
… deny all

in calico documentation for policies, an empty hep (no policies) should drop traffic
except failsafe, endpoint to host action, and allow from host to local pods.

and endpointtohostaction has actually priority over everything, so should be in first order.