### PR TITLE
vpp: foward mcast traffic to calico-pods-46

### DIFF
--- a/calico-vpp-agent/cni/network_vpp_routes.go
+++ b/calico-vpp-agent/cni/network_vpp_routes.go
@@ -194,6 +194,13 @@ func (s *Server) CreatePodVRF(podSpec *storage.LocalPodSpec, stack *vpplink.Clea
 		} else {
 			stack.Push(s.vpp.DelDefaultRouteViaTable, vrfId, vrfIndex, ipFamily.IsIp6)
 		}
+
+		err = s.vpp.AddDefaultMRouteViaTable(vrfId, vrfIndex, ipFamily.IsIp6)
+		if err != nil {
+			return errors.Wrapf(err, "error adding VRF %d %s default Mroute via VRF %d", vrfId, ipFamily.Str, vrfIndex)
+		} else {
+			stack.Push(s.vpp.DelDefaultMRouteViaTable, vrfId, vrfIndex, ipFamily.IsIp6)
+		}
 	}
 	return nil
 }
@@ -352,7 +359,11 @@ func (s *Server) DeletePodVRF(podSpec *storage.LocalPodSpec) {
 		s.log.Infof("pod(del) VRF %d %s default route via VRF %d", vrfId, ipFamily.Str, vrfIndex)
 		err = s.vpp.DelDefaultRouteViaTable(vrfId, vrfIndex, ipFamily.IsIp6)
 		if err != nil {
-			s.log.Errorf("Error  VRF %d %s default route via VRF %d : %s", vrfId, ipFamily.Str, vrfIndex, err)
+			s.log.Errorf("Error deleting VRF %d %s default route via VRF %d : %s", vrfId, ipFamily.Str, vrfIndex, err)
+		}
+		err = s.vpp.DelDefaultMRouteViaTable(vrfId, vrfIndex, ipFamily.IsIp6)
+		if err != nil {
+			s.log.Errorf("Error deleting VRF %d %s default mroute via VRF %d : %s", vrfId, ipFamily.Str, vrfIndex, err)
 		}
 	}
 

--- a/calico-vpp-agent/common/common.go
+++ b/calico-vpp-agent/common/common.go
@@ -88,7 +88,6 @@ func CreateVppLinkInRetryLoop(socket string, log *logrus.Entry, timeout time.Dur
 			} else {
 				log.Warnf("Waiting for VPP... [%d/%d] %v", i, maxRetry, err)
 			}
-			err = nil
 			time.Sleep(retry)
 		} else {
 			// Try a simple API message to verify everything is up and running

--- a/vpp-manager/utils/utils.go
+++ b/vpp-manager/utils/utils.go
@@ -192,7 +192,6 @@ func CreateVppLink() (vpp *vpplink.VppLink, err error) {
 			} else {
 				log.Warnf("Waiting for VPP... [%d/10] %v", i, err)
 			}
-			err = nil
 			time.Sleep(2 * time.Second)
 		} else {
 			return vpp, nil

--- a/vpplink/routes.go
+++ b/vpplink/routes.go
@@ -25,6 +25,7 @@ import (
 	vppip "github.com/projectcalico/vpp-dataplane/vpplink/binapi/vppapi/ip"
 	"github.com/projectcalico/vpp-dataplane/vpplink/binapi/vppapi/ip_neighbor"
 	"github.com/projectcalico/vpp-dataplane/vpplink/binapi/vppapi/ip_types"
+	"github.com/projectcalico/vpp-dataplane/vpplink/binapi/vppapi/mfib_types"
 	"github.com/projectcalico/vpp-dataplane/vpplink/types"
 )
 
@@ -208,4 +209,88 @@ func (v *VppLink) SetIPFlowHash(ipFlowHash types.IPFlowHash, vrfID uint32, isIPv
 	}
 	v.log.Debugf("updated flow hash algo for vrf %d", vrfID)
 	return nil
+}
+
+func (v *VppLink) MRouteAdd(route *types.Route, flags mfib_types.MfibEntryFlags) error {
+	return v.addDelIPMRoute(route, flags, true)
+}
+
+func (v *VppLink) MRouteDel(route *types.Route, flags mfib_types.MfibEntryFlags) error {
+	return v.addDelIPMRoute(route, flags, false)
+}
+
+func (v *VppLink) addDelIPMRoute(route *types.Route, flags mfib_types.MfibEntryFlags, isAdd bool) error {
+	v.lock.Lock()
+	defer v.lock.Unlock()
+
+	isIP6 := route.IsIP6()
+	ones, _ := route.Dst.Mask.Size()
+	prefix := ip_types.Mprefix{
+		Af:               types.ToVppAddressFamily(isIP6),
+		GrpAddressLength: uint16(ones),
+		GrpAddress:       types.ToVppAddress(route.Dst.IP).Un,
+		// we do not expose SrcAddress yet
+	}
+
+	paths := make([]mfib_types.MfibPath, 0, len(route.Paths))
+	for _, routePath := range route.Paths {
+		paths = append(paths, mfib_types.MfibPath{
+			ItfFlags: mfib_types.MFIB_API_ITF_FLAG_FORWARD,
+			Path:     routePath.ToFibPath(isIP6),
+		})
+
+	}
+
+	vppRoute := vppip.IPMroute{
+		TableID:    uint32(route.Table),
+		Prefix:     prefix,
+		EntryFlags: flags,
+		Paths:      paths,
+		RpfID:      route.RpfID,
+	}
+
+	request := &vppip.IPMrouteAddDel{
+		IsAdd: isAdd,
+		Route: vppRoute,
+	}
+
+	response := &vppip.IPMrouteAddDelReply{}
+	err := v.ch.SendRequest(request).ReceiveReply(response)
+	if err != nil {
+		return errors.Wrapf(err, "failed to %s mroute from VPP", IsAddToStr(isAdd))
+	} else if response.Retval != 0 {
+		return fmt.Errorf("failed to %s mroute from VPP (retval %d)", IsAddToStr(isAdd), response.Retval)
+	}
+	v.log.Debugf("%sed route %+v", IsAddToStr(isAdd), route)
+	return nil
+}
+
+func (v *VppLink) addDelDefaultMRouteViaTable(srcTable, dstTable uint32, isIP6 bool, isAdd bool) error {
+	route := &types.Route{
+		Paths: []types.RoutePath{{
+			Table:     dstTable,
+			SwIfIndex: types.InvalidID,
+			// we add a RpfID matching the srcTable so that we lookup in the multicast table
+			RpfID: srcTable,
+		}},
+		Table: srcTable,
+		RpfID: 0,
+	}
+	// Use the mcast CIDRs of the ip family
+	if isIP6 {
+		_, c, _ := net.ParseCIDR("ff00::/8")
+		route.Dst = c
+	} else {
+		_, c, _ := net.ParseCIDR("224.0.0.0/4")
+		route.Dst = c
+	}
+	return v.addDelIPMRoute(route, mfib_types.MFIB_API_ENTRY_FLAG_ACCEPT_ALL_ITF, isAdd /*isAdd*/)
+}
+
+func (v *VppLink) AddDefaultMRouteViaTable(sourceTable, dstTable uint32, isIP6 bool) error {
+	return v.addDelDefaultMRouteViaTable(sourceTable, dstTable, isIP6, true /*isAdd*/)
+}
+
+func (v *VppLink) DelDefaultMRouteViaTable(sourceTable, dstTable uint32, isIP6 bool) error {
+	return v.addDelDefaultMRouteViaTable(sourceTable, dstTable, isIP6, false /*isAdd*/)
 }

--- a/vpplink/types/route.go
+++ b/vpplink/types/route.go
@@ -29,12 +29,14 @@ type RoutePath struct {
 	Table      uint32
 	IsAttached bool
 	Preference uint8
+	RpfID      uint32
 }
 
 type Route struct {
 	Dst   *net.IPNet
 	Paths []RoutePath
 	Table uint32
+	RpfID uint32
 }
 
 func (p *RoutePath) tableString() string {
@@ -79,7 +81,7 @@ func (p *RoutePath) ToFibPath(isIP6 bool) fib_types.FibPath {
 	fibPath := fib_types.FibPath{
 		SwIfIndex:  p.SwIfIndex,
 		TableID:    p.Table,
-		RpfID:      0,
+		RpfID:      p.RpfID,
 		Weight:     1,
 		Preference: p.Preference,
 		Type:       fib_types.FIB_API_PATH_TYPE_NORMAL,


### PR DESCRIPTION
This patch forwards the multicast traffic originiating from the pods to the calico-pods-46 VRF, so that this traffic might be configured by users without knowleged of the pod's VRF table_id.

Signed-off-by: Nathan Skrzypczak <nathan.skrzypczak@gmail.com>