### PR TITLE
build: Fix api-proxy build and dev build.

### DIFF
--- a/.ci/common.mk
+++ b/.ci/common.mk
@@ -24,12 +24,15 @@ ifdef CI_BUILD
 	GOFLAGS := -buildvcs=false
 
 	DOCKER_OPTS  = -e CI_BUILD=1 -e GOFLAGS=${GOFLAGS}
+	DOCKER_OPTS += -e CGO_ENABLED=${CGO_ENABLED}
 	DOCKER_OPTS += --user $$(id -u):$$(id -g)
 	DOCKER_OPTS += -w /vpp-dataplane/${SUB_DIR}
 	DOCKER_OPTS += -v ${PROJECT_DIR}:/vpp-dataplane
 	DOCKER_RUN = docker run -t --rm --name build_temp ${DOCKER_OPTS} calicovpp/ci-builder:latest
 	SQUASH :=
 	PUSH_DEP :=
+else
+	DOCKER_RUN = CGO_ENABLED=${CGO_ENABLED} GOFLAGS=${GOFLAGS}
 endif
 
 TAG = $(shell git rev-parse HEAD)

--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,9 @@ push:
 
 .PHONY: dev
 dev:
-	$(MAKE) -C calico-vpp-agent $@
-	$(MAKE) -C vpp-manager $@
-	$(MAKE) -C multinet-monitor $@
+	$(MAKE) -C calico-vpp-agent ALSO_LATEST=y $@
+	$(MAKE) -C vpp-manager ALSO_LATEST=y $@
+	$(MAKE) -C multinet-monitor ALSO_LATEST=y $@
 
 .PHONY: proto
 proto:

--- a/calico-vpp-agent/Makefile
+++ b/calico-vpp-agent/Makefile
@@ -11,9 +11,15 @@ all: build gobgp image
 
 export GOOS=linux
 
-build:
-	${DOCKER_RUN} go build -o ./cmd/calico-vpp-agent ./cmd
+# We make felix-api-proxy a static executable as it will run in the calico container
+# for which we have less control on the env and glibc version
+.PHONY: felix-api-proxy
+felix-api-proxy: CGO_ENABLED=0
+felix-api-proxy:
 	${DOCKER_RUN} go build -o ./cmd/felix-api-proxy ./cmd/api-proxy
+
+build: felix-api-proxy
+	${DOCKER_RUN} go build -o ./cmd/calico-vpp-agent ./cmd
 	${DOCKER_RUN} go build -o ./cmd/debug ./cmd/debug-state
 
 gobgp: GOBGP_DIR:=$(shell ${DOCKER_RUN} go list -f '{{.Dir}}' -m github.com/osrg/gobgp/v3)
@@ -35,11 +41,7 @@ push: ${PUSH_DEP}
 		docker push calicovpp/agent:latest; \
 	fi
 
-dev: build gobgp
-	@echo "Image tag                   : $(TAG)"                         > $(VERSION_FILE)
-	@echo "VPP-dataplane version       : $(shell git log -1 --oneline)" >> $(VERSION_FILE)
-	@cat $(GENERATE_LOG_FILE)                                           >> $(VERSION_FILE)
-	docker build -t calicovpp/agent:$(TAG) .
+dev: image
 
 proto:
 	$(MAKE) -C proto $@

--- a/calico-vpp-agent/cmd/api-proxy/Makefile
+++ b/calico-vpp-agent/cmd/api-proxy/Makefile
@@ -1,5 +1,0 @@
-export GOOS=linux
-
-.PHONY: build
-build:
-	go build 

--- a/multinet-monitor/Makefile
+++ b/multinet-monitor/Makefile
@@ -16,7 +16,7 @@ image: build
 	@cat $(GENERATE_LOG_FILE)                                           >> $(VERSION_FILE)
 	docker build --pull -t calicovpp/multinet-monitor:$(TAG) .
 	@if [ "${ALSO_LATEST}" = "y" ]; then \
-		docker tag calicovpp/agent:$(TAG) calicovpp/agent:latest; \
+		docker tag calicovpp/multinet-monitor:$(TAG) calicovpp/multinet-monitor:latest; \
 	fi
 
 .PHONY: dev

--- a/vpp-manager/Makefile
+++ b/vpp-manager/Makefile
@@ -116,3 +116,7 @@ dev: build
 	  --build-arg http_proxy=${DOCKER_BUILD_PROXY} \
 	  --build-arg WITH_GDB=${WITH_GDB} \
 	  -t calicovpp/vpp:$(TAG) $(DEV_IMAGE_DIR)
+	@if [ "${ALSO_LATEST}" = "y" ]; then \
+		docker tag calicovpp/vpp:$(TAG) calicovpp/vpp:latest; \
+	fi
+


### PR DESCRIPTION
This patch fixes the api-proxy build that could result in a mismatch between the glibc version used for linking when building and the one used in the run environment (i.e. the calico container where the image is run).

This also makes dev build produce :latest images in addition to the new :commit-hash tags, to maintain old behavior.