### PR TITLE
build: Fix api-proxy build and dev build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,9 @@ push:
 
 .PHONY: dev
 dev:
-	$(MAKE) -C calico-vpp-agent $@
-	$(MAKE) -C vpp-manager $@
-	$(MAKE) -C multinet-monitor $@
+	$(MAKE) -C calico-vpp-agent ALSO_LATEST=y $@
+	$(MAKE) -C vpp-manager ALSO_LATEST=y $@
+	$(MAKE) -C multinet-monitor ALSO_LATEST=y $@
 
 .PHONY: proto
 proto:

--- a/calico-vpp-agent/Makefile
+++ b/calico-vpp-agent/Makefile
@@ -10,9 +10,11 @@ all: build gobgp image
 export GOOS=linux
 GOBGP_DIR=$(shell go list -f '{{.Dir}}' -m github.com/osrg/gobgp/v3)
 
+# We make felix-api-proxy a static executable as it will run in the calico container
+# for which we have less control on the env and glibc version
 build:
 	go build -o ./cmd/calico-vpp-agent ./cmd
-	go build -o ./cmd/felix-api-proxy ./cmd/api-proxy
+	CGO_ENABLED=0 go build -o ./cmd/felix-api-proxy ./cmd/api-proxy
 	go build -o ./cmd/debug ./cmd/debug-state
 
 gobgp:
@@ -33,11 +35,7 @@ push: image
 		docker push calicovpp/agent:latest; \
 	fi
 
-dev: build gobgp
-	@echo "Image tag                   : $(TAG)"                         > $(VERSION_FILE)
-	@echo "VPP-dataplane version       : $(shell git log -1 --oneline)" >> $(VERSION_FILE)
-	@cat $(GENERATE_LOG_FILE)                                           >> $(VERSION_FILE)
-	docker build -t calicovpp/agent:$(TAG) .
+dev: image
 
 proto:
 	$(MAKE) -C proto $@

--- a/calico-vpp-agent/cmd/api-proxy/Makefile
+++ b/calico-vpp-agent/cmd/api-proxy/Makefile
@@ -1,5 +1,0 @@
-export GOOS=linux
-
-.PHONY: build
-build:
-	go build 

--- a/multinet-monitor/Makefile
+++ b/multinet-monitor/Makefile
@@ -14,7 +14,7 @@ image: build
 	@cat $(GENERATE_LOG_FILE)                                           >> $(VERSION_FILE)
 	docker build --pull -t calicovpp/multinet-monitor:$(TAG) .
 	@if [ "${ALSO_LATEST}" = "y" ]; then \
-		docker tag calicovpp/agent:$(TAG) calicovpp/agent:latest; \
+		docker tag calicovpp/multinet-monitor:$(TAG) calicovpp/multinet-monitor:latest; \
 	fi
 
 .PHONY: dev

--- a/vpp-manager/Makefile
+++ b/vpp-manager/Makefile
@@ -91,3 +91,7 @@ dev: build
 	  --build-arg http_proxy=${DOCKER_BUILD_PROXY} \
 	  --build-arg WITH_GDB=${WITH_GDB} \
 	  -t calicovpp/vpp:$(TAG) $(DEV_IMAGE_DIR)
+	@if [ "${ALSO_LATEST}" = "y" ]; then \
+		docker tag calicovpp/vpp:$(TAG) calicovpp/vpp:latest; \
+	fi
+


### PR DESCRIPTION
This patch fixes the api-proxy build that could result in a mismatch between the glibc version used for linking when building and the one used in the run environment (i.e. the calico container where the image is run).

This also makes dev build produce :latest images in addition to the new :commit-hash tags, to maintain old behavior.