### PR TITLE
vpp: memif, fix null termination of socket name

### DIFF
--- a/vpplink/binapi/patches/0001-pbl-Port-based-balancer.patch
+++ b/vpplink/binapi/patches/0001-pbl-Port-based-balancer.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Nathan Skrzypczak <nathan.skrzypczak@gmail.com>
 Date: Tue, 27 Jul 2021 09:41:55 +0200
-Subject: [PATCH 1/4] pbl: Port based balancer
+Subject: [PATCH 1/5] pbl: Port based balancer
 
 Type: feature
 
@@ -1357,5 +1357,5 @@ index 000000000..478584019
 + * End:
 + */
 -- 
-2.38.0
+2.39.2
 

--- a/vpplink/binapi/patches/0002-cnat-WIP-no-k8s-maglev-from-pods.patch
+++ b/vpplink/binapi/patches/0002-cnat-WIP-no-k8s-maglev-from-pods.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Nathan Skrzypczak <nathan.skrzypczak@gmail.com>
 Date: Mon, 8 Mar 2021 19:00:04 +0100
-Subject: [PATCH 2/4] cnat: [WIP] no k8s maglev from pods
+Subject: [PATCH 2/5] cnat: [WIP] no k8s maglev from pods
 
 Type: improvement
 
@@ -45,5 +45,5 @@ index 76aa89398..fd3b90a1a 100644
  	  const dpo_id_t *dpo0;
  	  const load_balance_t *lb1;
 -- 
-2.38.0
+2.39.2
 

--- a/vpplink/binapi/patches/0003-acl-acl-plugin-custom-policies.patch
+++ b/vpplink/binapi/patches/0003-acl-acl-plugin-custom-policies.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Andrew Yourtchenko <ayourtch@gmail.com>
 Date: Tue, 28 Jul 2020 10:23:06 +0000
-Subject: [PATCH 3/4] acl: acl-plugin custom policies
+Subject: [PATCH 3/5] acl: acl-plugin custom policies
 
 Type: feature
 Change-Id: I3117e84d9e822b68b12265e9261992e4d7f50f0f
@@ -806,5 +806,5 @@ index 8d1f3f20f..52641f9e7 100644
  void
  acl_plugin_show_lookup_user (u32 user_index)
 -- 
-2.38.0
+2.39.2
 

--- a/vpplink/binapi/patches/0004-capo-Calico-Policies-plugin.patch
+++ b/vpplink/binapi/patches/0004-capo-Calico-Policies-plugin.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Andrew Yourtchenko <ayourtch@gmail.com>
 Date: Wed, 18 Aug 2021 20:10:22 +0200
-Subject: [PATCH 4/4] capo: Calico Policies plugin
+Subject: [PATCH 4/5] capo: Calico Policies plugin
 
 New plugin that implements Calico policies and profiles in VPP.
 
@@ -5025,5 +5025,5 @@ index 000000000..401a7abd5
 +        rule2.remove_vpp_config()
 +        src_ipset.remove_vpp_config()
 -- 
-2.38.0
+2.39.2
 

--- a/vpplink/binapi/patches/0005-memif-fix-socket-name-null-termination.patch
+++ b/vpplink/binapi/patches/0005-memif-fix-socket-name-null-termination.patch
@@ -1,0 +1,41 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nathan Skrzypczak <nathan.skrzypczak@gmail.com>
+Date: Wed, 1 Mar 2023 18:51:22 +0100
+Subject: [PATCH 5/5] memif: fix socket name null termination
+
+Change-Id: I2bccc0c10c8ab2f2330cb8270cff3c10ff460280
+Signed-off-by: Nathan Skrzypczak <nathan.skrzypczak@gmail.com>
+---
+ src/plugins/memif/memif_api.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/plugins/memif/memif_api.c b/src/plugins/memif/memif_api.c
+index 5d32523de..e5ed3b6af 100644
+--- a/src/plugins/memif/memif_api.c
++++ b/src/plugins/memif/memif_api.c
+@@ -92,7 +92,7 @@ vl_api_memif_socket_filename_add_del_v2_t_handler (
+ {
+   vl_api_memif_socket_filename_add_del_v2_reply_t *rmp;
+   memif_main_t *mm = &memif_main;
+-  u8 *socket_filename = 0;
++  char *socket_filename = 0;
+   u32 socket_id;
+   int rv;
+ 
+@@ -105,11 +105,11 @@ vl_api_memif_socket_filename_add_del_v2_t_handler (
+     }
+ 
+   /* socket filename */
+-  socket_filename = vl_api_from_api_to_new_vec (mp, &mp->socket_filename);
++  socket_filename = vl_api_from_api_to_new_c_string (&mp->socket_filename);
+   if (mp->is_add && socket_id == (u32) ~0)
+     socket_id = memif_get_unused_socket_id ();
+ 
+-  rv = memif_socket_filename_add_del (mp->is_add, socket_id, socket_filename);
++  rv = memif_socket_filename_add_del (mp->is_add, socket_id, (u8*)socket_filename);
+ 
+   vec_free (socket_filename);
+ 
+-- 
+2.39.2
+

--- a/vpplink/binapi/vpp_clone_current.sh
+++ b/vpplink/binapi/vpp_clone_current.sh
@@ -107,4 +107,5 @@ git_apply_private 0001-pbl-Port-based-balancer.patch
 git_apply_private 0002-cnat-WIP-no-k8s-maglev-from-pods.patch
 git_apply_private 0003-acl-acl-plugin-custom-policies.patch
 git_apply_private 0004-capo-Calico-Policies-plugin.patch
+git_apply_private 0005-memif-fix-socket-name-null-termination.patch
 


### PR DESCRIPTION
The socket name was not properly null terminated when passed via the API. This should go away with the next rebase of VPP.