### PR TITLE
build: pass TAG to integration tests & default to WITH_GDB=yes

### DIFF
--- a/.ci/common.mk
+++ b/.ci/common.mk
@@ -8,6 +8,8 @@ DEPEND_BASE = calicovpp/ci-builder
 
 VPP_BUCKET = calico-vpp-ci-artefacts
 
+WITH_GDB ?= yes
+
 # Docker option
 SQUASH := --squash
 # push dependency

--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,7 @@ release: check-TAG check-CALICO_TAG
 
 .PHONY: run-integration-tests
 run-integration-tests:
-	cd test/integration-tests;./run-tests.sh
+	cd test/integration-tests;TAG=${TAG} ./run-tests.sh
 
 .PHONY: test
 test: go-lint

--- a/test/integration-tests/run-tests.sh
+++ b/test/integration-tests/run-tests.sh
@@ -13,8 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VPP_IMAGE="calicovpp/vpp:latest"
-POD_MOCK_IMAGE="calicovpp/vpp-test-pod-mock:latest"
+TAG=${TAG:-latest}
+VPP_IMAGE=${VPP_IMAGE:-calicovpp/vpp:${TAG}}
+POD_MOCK_IMAGE=${POD_MOCK_IMAGE:-calicovpp/vpp-test-pod-mock:${TAG}}
 
 function prepageImageWithVPPBinary() {
   if ! docker image inspect $VPP_IMAGE >/dev/null 2>&1; then
@@ -38,6 +39,7 @@ function preparePodMockImage() {
 result=0
 
 echo "Running Integration tests..."
+echo "VPP image: ${VPP_IMAGE}"
 echo "Running Calico VPP Agent - CNI tests..."
 prepageImageWithVPPBinary
 preparePodMockImage


### PR DESCRIPTION
This default to WITH_GDB=yes to have GDB present in all the build as it is low footprint (~40Mb), and quite handy to troubleshoot VPP related issues.

This also makes the integration-tests script inherit the TAG from the makefile .ci/common.mk