### PR TITLE
refact: move agent binaries to bin/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,5 @@
 # Binaries
-calico-vpp-agent/cmd/calico-vpp-agent
-calico-vpp-agent/cmd/felix-api-proxy
-calico-vpp-agent/cmd/debug
-calico-vpp-agent/dep/gobgp
+calico-vpp-agent/bin
 vpp-manager/images/*/vpp-manager
 vpp-manager/images/*/vppdev.sh
 vpp-manager/vpp_build/

--- a/calico-vpp-agent/Dockerfile
+++ b/calico-vpp-agent/Dockerfile
@@ -2,10 +2,10 @@ FROM ubuntu:22.04
 
 LABEL maintainer="aloaugus@cisco.com"
 
-ADD dep/gobgp /bin/gobgp
-ADD cmd/debug /bin/debug
+ADD bin/gobgp /bin/gobgp
+ADD bin/debug /bin/debug
 ADD version /etc/calicovppversion
-ADD cmd/felix-api-proxy /bin/felix-api-proxy
-ADD cmd/calico-vpp-agent /bin/calico-vpp-agent
+ADD bin/felix-api-proxy /bin/felix-api-proxy
+ADD bin/calico-vpp-agent /bin/calico-vpp-agent
 
 ENTRYPOINT ["/bin/calico-vpp-agent"]

--- a/calico-vpp-agent/Makefile
+++ b/calico-vpp-agent/Makefile
@@ -11,20 +11,23 @@ all: build gobgp image
 
 export GOOS=linux
 
+bin:
+	mkdir -p bin
+
 # We make felix-api-proxy a static executable as it will run in the calico container
 # for which we have less control on the env and glibc version
 .PHONY: felix-api-proxy
 felix-api-proxy: CGO_ENABLED=0
-felix-api-proxy:
-	${DOCKER_RUN} go build -o ./cmd/felix-api-proxy ./cmd/api-proxy
+felix-api-proxy: bin
+	${DOCKER_RUN} go build -o ./bin/felix-api-proxy ./cmd/api-proxy
 
-build: felix-api-proxy
-	${DOCKER_RUN} go build -o ./cmd/calico-vpp-agent ./cmd
-	${DOCKER_RUN} go build -o ./cmd/debug ./cmd/debug-state
+build: felix-api-proxy bin
+	${DOCKER_RUN} go build -o ./bin/calico-vpp-agent ./cmd
+	${DOCKER_RUN} go build -o ./bin/debug ./cmd/debug-state
 
 gobgp: GOBGP_DIR:=$(shell ${DOCKER_RUN} go list -f '{{.Dir}}' -m github.com/osrg/gobgp/v3)
-gobgp:
-	${DOCKER_RUN} go build -o ./dep/gobgp $(GOBGP_DIR)/cmd/gobgp/
+gobgp: bin
+	${DOCKER_RUN} go build -o ./bin/gobgp $(GOBGP_DIR)/cmd/gobgp/
 
 image: build gobgp
 	@echo "Image tag                   : $(TAG)"                         > $(VERSION_FILE)

--- a/calico-vpp-agent/cni/pod_annotations.go
+++ b/calico-vpp-agent/cni/pod_annotations.go
@@ -109,17 +109,6 @@ func (s *Server) ParseEnableDisableAnnotation(value string) (bool, error) {
 	}
 }
 
-func (s *Server) ParseTrueFalseAnnotation(value string) (bool, error) {
-	switch value {
-	case "true":
-		return true, nil
-	case "false":
-		return false, nil
-	default:
-		return false, errors.Errorf("Unknown value %s", value)
-	}
-}
-
 func (s *Server) ParseSpoofAddressAnnotation(value string) ([]cnet.IPNet, error) {
 	var requestedSourcePrefixes []string
 	var allowedSources []cnet.IPNet

--- a/config/config.go
+++ b/config/config.go
@@ -18,7 +18,6 @@ package config
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"regexp"
@@ -566,7 +565,7 @@ func (c *LinuxInterfaceState) SortRoutes() {
 }
 
 func getCpusetCpu() (string, error) {
-	content, err := ioutil.ReadFile("/sys/fs/cgroup/cpuset.cpus")
+	content, err := os.ReadFile("/sys/fs/cgroup/cpuset.cpus")
 	if err != nil {
 		if os.IsNotExist(err) {
 			return "", nil


### PR DESCRIPTION
This patch moves agent binaries to bin/ instead of the same folder as their sources.