### PR TITLE
agent: Add failsafe termination after 10s

### DIFF
--- a/calico-vpp-agent/cmd/calico_vpp_dataplane.go
+++ b/calico-vpp-agent/cmd/calico_vpp_dataplane.go
@@ -238,6 +238,10 @@ func main() {
 	case <-t.Dying():
 		log.Errorf("tomb Dying %s", t.Err())
 	}
+	go func() {
+		time.Sleep(*config.CalicoVppGracefulShutdownTimeout)
+		panic("Graceful shutdown took too long")
+	}()
 	e := t.Wait()
 	log.Infof("Tomb exited with %v", e)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -64,15 +65,16 @@ var (
 	NodeName = RequiredStringEnvVar("NODENAME")
 	LogLevel = EnvVar("CALICOVPP_LOG_LEVEL", logrus.InfoLevel, logrus.ParseLevel)
 
-	ServiceCIDRs           = PrefixListEnvVar("SERVICE_PREFIX")
-	IPSecIkev2Psk          = StringEnvVar("CALICOVPP_IPSEC_IKEV2_PSK", "")
-	CalicoVppDebug         = JsonEnvVar("CALICOVPP_DEBUG", &CalicoVppDebugConfigType{})
-	CalicoVppInterfaces    = JsonEnvVar("CALICOVPP_INTERFACES", &CalicoVppInterfacesConfigType{})
-	CalicoVppFeatureGates  = JsonEnvVar("CALICOVPP_FEATURE_GATES", &CalicoVppFeatureGatesConfigType{})
-	CalicoVppIpsec         = JsonEnvVar("CALICOVPP_IPSEC", &CalicoVppIpsecConfigType{})
-	CalicoVppSrv6          = JsonEnvVar("CALICOVPP_SRV6", &CalicoVppSrv6ConfigType{})
-	CalicoVppInitialConfig = JsonEnvVar("CALICOVPP_INITIAL_CONFIG", &CalicoVppInitialConfigConfigType{})
-	LogFormat              = StringEnvVar("CALICOVPP_LOG_FORMAT", "")
+	ServiceCIDRs                     = PrefixListEnvVar("SERVICE_PREFIX")
+	IPSecIkev2Psk                    = StringEnvVar("CALICOVPP_IPSEC_IKEV2_PSK", "")
+	CalicoVppDebug                   = JsonEnvVar("CALICOVPP_DEBUG", &CalicoVppDebugConfigType{})
+	CalicoVppInterfaces              = JsonEnvVar("CALICOVPP_INTERFACES", &CalicoVppInterfacesConfigType{})
+	CalicoVppFeatureGates            = JsonEnvVar("CALICOVPP_FEATURE_GATES", &CalicoVppFeatureGatesConfigType{})
+	CalicoVppIpsec                   = JsonEnvVar("CALICOVPP_IPSEC", &CalicoVppIpsecConfigType{})
+	CalicoVppSrv6                    = JsonEnvVar("CALICOVPP_SRV6", &CalicoVppSrv6ConfigType{})
+	CalicoVppInitialConfig           = JsonEnvVar("CALICOVPP_INITIAL_CONFIG", &CalicoVppInitialConfigConfigType{})
+	CalicoVppGracefulShutdownTimeout = EnvVar("CALICOVPP_GRACEFUL_SHUTDOWN_TIMEOUT", 10*time.Second, time.ParseDuration)
+	LogFormat                        = StringEnvVar("CALICOVPP_LOG_FORMAT", "")
 
 	/* Deprecated vars */
 	/* linux name of the uplink interface to be used by VPP */


### PR DESCRIPTION
In the case one of the goroutine fails to gracefully terminate, we add a failsafe condition to panic after a configurable amount of time after the tomb has returned.
It defaults to 10 seconds.