### PR TITLE
agent: fix network watcher

### DIFF
--- a/test/yaml/multinet/network.yaml
+++ b/test/yaml/multinet/network.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   vni: 56
   range: "172.19.0.0/16"
+  physicalNetworkName: ""
 ---
 apiVersion: projectcalico.org/v3
 kind: Network
@@ -13,3 +14,4 @@ metadata:
 spec:
   vni: 88
   range: "172.21.0.0/16"
+  physicalNetworkName: ""

--- a/test/yaml/multinet/pod-memif.yaml
+++ b/test/yaml/multinet/pod-memif.yaml
@@ -5,8 +5,7 @@ metadata:
   annotations:
     k8s.v1.cni.cncf.io/networks: network-blue-conf@memif1, network-red-conf@eth5
 spec:
-  nodeSelector:
-    kubernetes.io/hostname: node2
+
   containers:
   - name: mvpp
     image: calicovpp/vpp:latest
@@ -22,8 +21,7 @@ metadata:
   annotations:
     k8s.v1.cni.cncf.io/networks: network-blue-conf@eth1, network-red-conf@eth2
 spec:
-  nodeSelector:
-    kubernetes.io/hostname: node1
+
   containers:
   - name: samplepod
     command: ["/bin/ash", "-c", "trap : TERM INT; sleep infinity & wait"]


### PR DESCRIPTION
Prior to this patch we were not correctly restarting the api watcher
for the network objects, ie when the watcher breaks network server in
calicovpp agent logs warning or returns an error and we only recover if
we restart agent. This patch allows to restart the watcher if it breaks,
while keeping the resource version to continue watching.