### PR TITLE
agent: host port per default uses node ip as host ip

### DIFF
--- a/calico-vpp-agent/cmd/calico_vpp_dataplane.go
+++ b/calico-vpp-agent/cmd/calico_vpp_dataplane.go
@@ -176,6 +176,7 @@ func main() {
 		serviceServer.SetOurBGPSpec(ourBGPSpec.(*common.LocalNodeSpec))
 		localSIDWatcher.SetOurBGPSpec(ourBGPSpec.(*common.LocalNodeSpec))
 		netWatcher.SetOurBGPSpec(ourBGPSpec.(*common.LocalNodeSpec))
+		cniServer.SetOurBGPSpec(ourBGPSpec.(*common.LocalNodeSpec))
 	}
 
 	if *config.GetCalicoVppFeatureGates().MultinetEnabled {


### PR DESCRIPTION
this fixes the case where a host port is created without explicit host ip
node ip is used as host ip in that case