### PR TITLE
[WIP] build: fix vppbranch URL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,6 +194,7 @@ release: check-TAG check-CALICO_TAG
 	@echo
 	@echo "***IMPORTANT***IMPORTANT***IMPORTANT***IMPORTANT***"
 	@echo "Please update \"vppbranch\" in https://github.com/projectcalico/calico/blob/${CALICO_TAG}/calico/_config.yml to ${TAG} otherwise the install docs get broken."
+	@echo "Please update \"vppbranch\" in https://github.com/tigera/docs/blob/main/calico_versioned_docs/${CALICO_TAG}/variables.js to ${TAG} otherwise the install docs get broken."
 
 .PHONY: run-integration-tests
 run-integration-tests:


### PR DESCRIPTION
The calico docs were moved to a dedicated docs repo and as such the "vppbranch" var which used to live in

  https://github.com/projectcalico/calico/blob/${CALICO_TAG}/calico/_config.yml

has now moved to

  https://github.com/tigera/docs/blob/main/calico_versioned_docs/${CALICO_TAG}/variables.js