### PR TITLE
yaml: Fix ipsec installation component

### DIFF
--- a/yaml/components/ipsec/README.md
+++ b/yaml/components/ipsec/README.md
@@ -1,0 +1,30 @@
+This describes how to enable IPSEC on a Calico/VPP cluster
+
+## Enable ipsec on a running cluster
+
+[You can find the documentation here](https://docs.tigera.io/calico/latest/getting-started/kubernetes/vpp/ipsec)
+
+## Using this kustomize component
+
+You can use the following script to build the appropriate manifest for a cluster with ipsec enabled.
+
+```bash
+cd $REPOSITORY_ROOT/yaml
+
+cat > kustomization.yaml <<EOF
+bases:
+  - ./base
+components:
+  - ./components/ipsec
+EOF
+kubectl kustomize . > calico-vpp-ipsec.yaml
+kubectl apply -f calico-vpp-ipsec.yaml
+```
+
+
+You will also need to create the secret for the PSK out of band
+
+```bash
+kubectl -n calico-vpp-dataplane create secret generic calicovpp-ipsec-secret \
+   --from-literal=psk="$(dd if=/dev/urandom bs=1 count=36 2>/dev/null | base64)"
+```

--- a/yaml/components/ipsec/ipsec.yaml
+++ b/yaml/components/ipsec/ipsec.yaml
@@ -1,11 +1,25 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: calico-vpp-config
+  namespace: calico-vpp-dataplane
+data:
+  CALICOVPP_FEATURE_GATES: |-
+    {
+      "ipsecEnabled": true
+    }
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: calico-vpp-node
+  namespace: calico-vpp-dataplane
 spec:
   template:
     spec:
       containers:
         - name: agent
           env:
-            - name: CALICOVPP_IPSEC_ENABLED
-              value: "true"
             - name: CALICOVPP_IPSEC_IKEV2_PSK
               valueFrom:
                 secretKeyRef:

--- a/yaml/components/ipsec/kustomization.yaml
+++ b/yaml/components/ipsec/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1  # <-- Component notation
+kind: Component
+
+patchesStrategicMerge:
+- ipsec.yaml


### PR DESCRIPTION
When transitionning to the new Config syntax in v3.25.0 we forgot to update the ipsec component.
This patch addresses this

This is linked to the following docs update on tigera/docs https://github.com/tigera/docs/pull/774
