### PR TITLE
vpp-manager: Fix unsafe iommu detection & enabling

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -519,13 +519,23 @@ func (i *VppManagerInfo) GetMainSwIfIndex() uint32 {
 	return vpplink.INVALID_SW_IF_INDEX
 }
 
+// UnsafeNoIommuMode represents the content of the /sys/module/vfio/parameters/enable_unsafe_noiommu_mode
+// file. The 'disabled' value is used when no iommu is available in the environment.
+type UnsafeNoIommuMode string
+
+const (
+	VFIO_UNSAFE_NO_IOMMU_MODE_YES      UnsafeNoIommuMode = "Y"
+	VFIO_UNSAFE_NO_IOMMU_MODE_NO       UnsafeNoIommuMode = "N"
+	VFIO_UNSAFE_NO_IOMMU_MODE_DISABLED UnsafeNoIommuMode = "disabled"
+)
+
 type VppManagerParams struct {
 	UplinksSpecs []UplinkInterfaceSpec
 	/* Capabilities */
-	LoadedDrivers      map[string]bool
-	KernelVersion      *KernelVersion
-	AvailableHugePages int
-	VfioUnsafeiommu    bool
+	LoadedDrivers                      map[string]bool
+	KernelVersion                      *KernelVersion
+	AvailableHugePages                 int
+	InitialVfioEnableUnsafeNoIommuMode UnsafeNoIommuMode
 
 	NodeAnnotations map[string]string
 }

--- a/vpp-manager/startup/startup.go
+++ b/vpp-manager/startup/startup.go
@@ -78,11 +78,10 @@ func NewVppManagerParams() *config.VppManagerParams {
 	params.AvailableHugePages = nrHugepages
 
 	/* Iommu */
-	iommu, err := utils.IsVfioUnsafeiommu()
+	params.InitialVfioEnableUnsafeNoIommuMode, err = utils.GetVfioEnableUnsafeNoIommuMode()
 	if err != nil {
 		log.Warnf("Error getting vfio iommu state %v", err)
 	}
-	params.VfioUnsafeiommu = iommu
 
 	return params
 
@@ -93,7 +92,7 @@ func PrintVppManagerConfig(params *config.VppManagerParams, confs []*config.Linu
 	log.Infof("Hugepages            %d", params.AvailableHugePages)
 	log.Infof("KernelVersion        %s", params.KernelVersion)
 	log.Infof("Drivers              %v", params.LoadedDrivers)
-	log.Infof("vfio iommu:          %t", params.VfioUnsafeiommu)
+	log.Infof("initial iommu status %s", params.InitialVfioEnableUnsafeNoIommuMode)
 	for _, ifSpec := range params.UplinksSpecs {
 		log.Infof("-- Interface Spec --")
 		log.Infof("Interface Name:      %s", ifSpec.InterfaceName)

--- a/vpp-manager/uplink/virtio.go
+++ b/vpp-manager/uplink/virtio.go
@@ -62,8 +62,8 @@ func (d *VirtioDriver) PreconfigureLinux() (err error) {
 		doSwapDriver = config.DRIVER_VFIO_PCI != d.conf.Driver
 	}
 
-	if !d.params.VfioUnsafeiommu {
-		err := utils.SetVfioUnsafeiommu(true)
+	if d.params.InitialVfioEnableUnsafeNoIommuMode == config.VFIO_UNSAFE_NO_IOMMU_MODE_NO {
+		err := utils.SetVfioEnableUnsafeNoIommuMode(config.VFIO_UNSAFE_NO_IOMMU_MODE_YES)
 		if err != nil {
 			return errors.Wrapf(err, "failed to configure vfio")
 		}
@@ -79,8 +79,8 @@ func (d *VirtioDriver) PreconfigureLinux() (err error) {
 }
 
 func (d *VirtioDriver) RestoreLinux(allInterfacesPhysical bool) {
-	if !d.params.VfioUnsafeiommu {
-		err := utils.SetVfioUnsafeiommu(false)
+	if d.params.InitialVfioEnableUnsafeNoIommuMode == config.VFIO_UNSAFE_NO_IOMMU_MODE_NO {
+		err := utils.SetVfioEnableUnsafeNoIommuMode(config.VFIO_UNSAFE_NO_IOMMU_MODE_NO)
 		if err != nil {
 			log.Warnf("Virtio restore error %v", err)
 		}

--- a/vpp-manager/uplink/vmxnet3.go
+++ b/vpp-manager/uplink/vmxnet3.go
@@ -43,8 +43,8 @@ func (d *Vmxnet3Driver) IsSupported(warn bool) (supported bool) {
 }
 
 func (d *Vmxnet3Driver) PreconfigureLinux() (err error) {
-	if !d.params.VfioUnsafeiommu {
-		err := utils.SetVfioUnsafeiommu(true)
+	if d.params.InitialVfioEnableUnsafeNoIommuMode == config.VFIO_UNSAFE_NO_IOMMU_MODE_NO {
+		err := utils.SetVfioEnableUnsafeNoIommuMode(config.VFIO_UNSAFE_NO_IOMMU_MODE_YES)
 		if err != nil {
 			return errors.Wrapf(err, "Vmxnet3 preconfigure error")
 		}
@@ -84,6 +84,13 @@ func (d *Vmxnet3Driver) RestoreLinux(allInterfacesPhysical bool) {
 
 	// Re-add all adresses and routes
 	d.restoreLinuxIfConf(link)
+
+	if d.params.InitialVfioEnableUnsafeNoIommuMode == config.VFIO_UNSAFE_NO_IOMMU_MODE_NO {
+		err = utils.SetVfioEnableUnsafeNoIommuMode(config.VFIO_UNSAFE_NO_IOMMU_MODE_NO)
+		if err != nil {
+			log.Errorf("Vmxnet3 restore error %s", err)
+		}
+	}
 }
 
 func (d *Vmxnet3Driver) CreateMainVppInterface(vpp *vpplink.VppLink, vppPid int, uplinkSpec *config.UplinkInterfaceSpec) (err error) {


### PR DESCRIPTION
This patch fixes the detection of unsafe iommu being available, initially enabled or disabled. It makes sure the available drivers properly restore the initial state, and that we do not try to enable unsafe-iommu when no iommu is available.