### PR TITLE
agent: fix nodeport service snat

### DIFF
--- a/calico-vpp-agent/services/service_handler.go
+++ b/calico-vpp-agent/services/service_handler.go
@@ -108,8 +108,8 @@ func buildCnatEntryForServicePort(servicePort *v1.ServicePort, service *v1.Servi
 							},
 							Flags: flags,
 						}
-						/* In nodeports, we also sNAT */
-						if isNodePort {
+						/* In nodeports, we need to sNAT when endpoint is not local to have a symmetric traffic */
+						if isNodePort && !isEndpointAddressLocal(&endpointAddress) {
 							backend.SrcEndpoint.IP = serviceIP
 						}
 						backends = append(backends, backend)


### PR DESCRIPTION
We snat when endpoint is not local, no need to do it when it is local.
This is for the returned traffic to pass by the node.