### PR TITLE
fix cnat csum

### DIFF
--- a/vpplink/generated/vpp_clone_current.sh
+++ b/vpplink/generated/vpp_clone_current.sh
@@ -95,6 +95,7 @@ function git_clone_cd_and_reset ()
 git_clone_cd_and_reset "$1" a7dd04d73bf5abed944fb77a5e957bbad24e2750 # misc: Initial 23.10-rc0 commit
 
 git_cherry_pick refs/changes/26/34726/3 # 34726: interface: add buffer stats api | https://gerrit.fd.io/r/c/vpp/+/34726
+git_cherry_pick refs/changes/49/31449/13 # 31449: cnat: Support offloaded check sums | https://gerrit.fd.io/r/c/vpp/+/31449/13
 
 # --------------- private plugins ---------------
 # Generated with 'git format-patch --zero-commit -o ./patches/ HEAD^^^'


### PR DESCRIPTION
This integrates a patch from VPP, that fixes the checksum calculation in cnat. This fix addresses a connectivity failure that showed up in eks dpdk scenario.