### PR TITLE
simplify punt fake gateway

### DIFF
--- a/vpp-manager/uplink/default.go
+++ b/vpp-manager/uplink/default.go
@@ -86,7 +86,7 @@ func (d *DefaultDriver) CreateMainVppInterface(vpp *vpplink.VppLink, vppPid int,
 		log.Infof("Moved interface %s to VPP netns", d.spec.InterfaceName)
 	}
 	// refusing to run on secondary interfaces as we have no way to figure out the sw_if_index
-	if !d.spec.GetIsMain() {
+	if !d.spec.IsMain {
 		return fmt.Errorf("%s driver not supported for secondary interfaces", d.name)
 	}
 	swIfIndex, err := vpp.SearchInterfaceWithTag("main-" + d.spec.InterfaceName)

--- a/vpp-manager/uplink/dpdk.go
+++ b/vpp-manager/uplink/dpdk.go
@@ -177,7 +177,7 @@ func (d *DPDKDriver) RestoreLinux(allInterfacesPhysical bool) {
 func (d *DPDKDriver) CreateMainVppInterface(vpp *vpplink.VppLink, vppPid int, uplinkSpec *config.UplinkInterfaceSpec) (err error) {
 	// Nothing to do VPP autocreates on startup
 	// refusing to run on secondary interfaces as we have no way to figure out the sw_if_index
-	if !d.spec.GetIsMain() {
+	if !d.spec.IsMain {
 		return fmt.Errorf("%s driver not supported for secondary interfaces", d.name)
 	}
 	swIfIndex, err := vpp.SearchInterfaceWithTag("main-" + d.spec.InterfaceName)

--- a/vpp-manager/utils/utils.go
+++ b/vpp-manager/utils/utils.go
@@ -47,12 +47,6 @@ import (
 	"github.com/projectcalico/vpp-dataplane/v3/vpplink"
 )
 
-var (
-	FakeVppNextHopIP4 = net.ParseIP("169.254.0.1")
-	FakeVppNextHopIP6 = net.ParseIP("fc00:ffff:ffff:ffff:ca11:c000:fd10:fffe")
-	VppSideMac, _     = net.ParseMAC("02:ca:11:c0:fd:10")
-)
-
 func IsDriverLoaded(driver string) (bool, error) {
 	_, err := os.Stat("/sys/bus/pci/drivers/" + driver)
 	if err == nil {


### PR DESCRIPTION
This patch simplifies the way we handle the punt routes when routing for-me traffic VPP cannot handle to the host. Previously, we were using different fake gateways for ip4 & ip6. We now use the ip4 indirection in both cases.
We also generate different hardware addresses using the uplink order in the configuration.

Finally, we also make the isMain parameter public in the config.