### PR TITLE
vpp: pass hashconfig to vpp for service annotations

### DIFF
--- a/calico-vpp-agent/services/service.go
+++ b/calico-vpp-agent/services/service.go
@@ -15,24 +15,18 @@
 
 package services
 
+import "github.com/projectcalico/vpp-dataplane/v3/vpplink/types"
+
 type lbType string
-type hashConfig string
 
 const (
-	lbTypeECMP          lbType     = "ECMP"
-	lbTypeMaglev        lbType     = "Maglev"
-	lbTypeMaglevDSR     lbType     = "MaglevDSR"
-	hashConfigSrcport   hashConfig = "srcport"
-	hashConfigDstport   hashConfig = "dstport"
-	hashConfigSrcaddr   hashConfig = "srcaddr"
-	hashConfigDstaddr   hashConfig = "dstaddr"
-	hashConfigIproto    hashConfig = "iproto"
-	hashConfigSymmetric hashConfig = "symmetric"
-	hashConfigReverse   hashConfig = "reverse"
+	lbTypeECMP      lbType = "ECMP"
+	lbTypeMaglev    lbType = "Maglev"
+	lbTypeMaglevDSR lbType = "MaglevDSR"
 )
 
 type serviceInfo struct {
 	keepOriginalPacket bool
 	lbType             lbType
-	hashConfig         []hashConfig
+	hashConfig         types.IPFlowHash
 }

--- a/calico-vpp-agent/services/service_handler.go
+++ b/calico-vpp-agent/services/service_handler.go
@@ -68,7 +68,6 @@ func getCnatLBType(lbType lbType) types.CnatLbType {
 		return types.MaglevLB
 	}
 	return types.DefaultLB
-
 }
 
 func getCnatVipDstPort(servicePort *v1.ServicePort, isNodePort bool) uint16 {
@@ -126,9 +125,10 @@ func buildCnatEntryForServicePort(servicePort *v1.ServicePort, service *v1.Servi
 			Port: getCnatVipDstPort(servicePort, isNodePort),
 			IP:   serviceIP,
 		},
-		Backends: backends,
-		IsRealIP: isNodePort,
-		LbType:   getCnatLBType(svcInfo.lbType),
+		Backends:   backends,
+		IsRealIP:   isNodePort,
+		LbType:     getCnatLBType(svcInfo.lbType),
+		HashConfig: svcInfo.hashConfig,
 	}
 }
 

--- a/calico-vpp-agent/services/service_server.go
+++ b/calico-vpp-agent/services/service_server.go
@@ -112,19 +112,19 @@ func (s *Server) ParseServiceAnnotations(annotations map[string]string, name str
 			for _, hc := range hashConfigList {
 				switch strings.TrimSpace(strings.ToLower(hc)) {
 				case "srcport":
-					svc.hashConfig = append(svc.hashConfig, hashConfigSrcport)
+					svc.hashConfig |= types.FlowHashSrcPort
 				case "dstport":
-					svc.hashConfig = append(svc.hashConfig, hashConfigDstport)
+					svc.hashConfig |= types.FlowHashDstPort
 				case "srcaddr":
-					svc.hashConfig = append(svc.hashConfig, hashConfigSrcaddr)
+					svc.hashConfig |= types.FlowHashSrcIP
 				case "dstaddr":
-					svc.hashConfig = append(svc.hashConfig, hashConfigDstaddr)
+					svc.hashConfig |= types.FlowHashDstIP
 				case "iproto":
-					svc.hashConfig = append(svc.hashConfig, hashConfigIproto)
+					svc.hashConfig |= types.FlowHashProto
 				case "reverse":
-					svc.hashConfig = append(svc.hashConfig, hashConfigReverse)
+					svc.hashConfig |= types.FlowHashReverse
 				case "symmetric":
-					svc.hashConfig = append(svc.hashConfig, hashConfigSymmetric)
+					svc.hashConfig |= types.FlowHashSymetric
 				default:
 					err = append(err, errors.Errorf("Unknown value %s for key %s", value, key))
 				}

--- a/vpplink/cnat.go
+++ b/vpplink/cnat.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/projectcalico/vpp-dataplane/v3/vpplink/generated/bindings/cnat"
 	"github.com/projectcalico/vpp-dataplane/v3/vpplink/generated/bindings/interface_types"
+	"github.com/projectcalico/vpp-dataplane/v3/vpplink/generated/bindings/ip"
 	"github.com/projectcalico/vpp-dataplane/v3/vpplink/types"
 )
 
@@ -59,12 +60,13 @@ func (v *VppLink) CnatTranslateAdd(tr *types.CnatTranslateEntry) (uint32, error)
 
 	response, err := client.CnatTranslationUpdate(v.GetContext(), &cnat.CnatTranslationUpdate{
 		Translation: cnat.CnatTranslation{
-			Vip:      types.ToCnatEndpoint(tr.Endpoint),
-			IPProto:  types.ToVppIPProto(tr.Proto),
-			Paths:    paths,
-			IsRealIP: BoolToU8(tr.IsRealIP),
-			Flags:    uint8(cnat.CNAT_TRANSLATION_ALLOC_PORT),
-			LbType:   cnat.CnatLbType(tr.LbType),
+			Vip:            types.ToCnatEndpoint(tr.Endpoint),
+			IPProto:        types.ToVppIPProto(tr.Proto),
+			Paths:          paths,
+			IsRealIP:       BoolToU8(tr.IsRealIP),
+			Flags:          uint8(cnat.CNAT_TRANSLATION_ALLOC_PORT),
+			LbType:         cnat.CnatLbType(tr.LbType),
+			FlowHashConfig: ip.IPFlowHashConfigV2(tr.HashConfig),
 		},
 	})
 	if err != nil {

--- a/vpplink/generated/generate.log
+++ b/vpplink/generated/generate.log
@@ -1,12 +1,13 @@
-VPP Version                 : 23.10-rc0~8-gb811f2187
+VPP Version                 : 23.10-rc0~9-gfbdcaa4c1
 Binapi-generator version    : v0.8.0-dev
-VPP Base commit             : 32203ce45 gerrit:34726/3 interface: add buffer stats api
+VPP Base commit             : 4b39caada gerrit:34726/3 interface: add buffer stats api
 ------------------ Cherry picked commits --------------------
 interface: Fix interface.api endianness
 capo: Calico Policies plugin
 acl: acl-plugin custom policies
 cnat: [WIP] no k8s maglev from pods
 pbl: Port based balancer
+gerrit:39507/11 cnat: add flow hash config to cnat translation
 gerrit:39387/5 cnat: add host tag to bitmap in cnat snat
 gerrit:31449/13 cnat: Support offloaded check sums
 gerrit:34726/3 interface: add buffer stats api

--- a/vpplink/generated/vpp_clone_current.sh
+++ b/vpplink/generated/vpp_clone_current.sh
@@ -97,6 +97,7 @@ git_clone_cd_and_reset "$1" a7dd04d73bf5abed944fb77a5e957bbad24e2750 # misc: Ini
 git_cherry_pick refs/changes/26/34726/3 # 34726: interface: add buffer stats api | https://gerrit.fd.io/r/c/vpp/+/34726
 git_cherry_pick refs/changes/49/31449/13 # 31449: cnat: Support offloaded check sums | https://gerrit.fd.io/r/c/vpp/+/31449/13
 git_cherry_pick refs/changes/87/39387/5 # 39387: cnat: add host tag to bitmap in cnat snat | https://gerrit.fd.io/r/c/vpp/+/39387/2
+git_cherry_pick refs/changes/07/39507/13 # 39507: cnat: add flow hash config to cnat translation | https://gerrit.fd.io/r/c/vpp/+/39507/13
 
 # --------------- private plugins ---------------
 # Generated with 'git format-patch --zero-commit -o ./patches/ HEAD^^^'

--- a/vpplink/types/cnat.go
+++ b/vpplink/types/cnat.go
@@ -69,11 +69,12 @@ func (e *CnatTranslateEntry) Key() string {
 }
 
 type CnatTranslateEntry struct {
-	Endpoint CnatEndpoint
-	Backends []CnatEndpointTuple
-	Proto    IPProto
-	IsRealIP bool
-	LbType   CnatLbType
+	Endpoint   CnatEndpoint
+	Backends   []CnatEndpointTuple
+	Proto      IPProto
+	IsRealIP   bool
+	LbType     CnatLbType
+	HashConfig IPFlowHash
 }
 
 func (n *CnatTranslateEntry) String() string {
@@ -81,12 +82,13 @@ func (n *CnatTranslateEntry) String() string {
 	for _, e := range n.Backends {
 		strLst = append(strLst, e.String())
 	}
-	return fmt.Sprintf("[%s real=%t lbtyp=%d vip=%s rw=%s]",
+	return fmt.Sprintf("[%s real=%t lbtyp=%d vip=%s rw=%s hashc=%+v]",
 		n.Proto.String(),
 		n.IsRealIP,
 		n.LbType,
 		n.Endpoint.String(),
 		strings.Join(strLst, ", "),
+		n.HashConfig,
 	)
 }
 


### PR DESCRIPTION
This patch uses the newly introduced field in cnat translation vpp api to pass ecmp hashconfig defined by annotations in services.