### PR TITLE
Feature/dynamic uplink interfaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,7 @@ install-multinet:
 	@kubectl apply -f test/yaml/multinet/projectcalico.org_networks.yaml
 	@kubectl apply -f test/yaml/multinet/whereabouts-daemonset-install.yaml
 	@echo "--Installing multus daemonset..."
-	@kubectl apply -f https://github.com/k8snetworkplumbingwg/multus-cni/raw/master/deployments/multus-daemonset-thick.yml
+	@kubectl apply -f https://github.com/k8snetworkplumbingwg/multus-cni/raw/99c4481e08a4a8f0a3d0013446f03e4206033cae/deployments/multus-daemonset-thick.yml
 	@echo "--Installing whereabouts daemonset..."
 	@kubectl apply -f https://github.com/k8snetworkplumbingwg/whereabouts/raw/master/doc/crds/whereabouts.cni.cncf.io_ippools.yaml
 	@kubectl apply -f https://github.com/k8snetworkplumbingwg/whereabouts/raw/master/doc/crds/whereabouts.cni.cncf.io_overlappingrangeipreservations.yaml
@@ -233,7 +233,7 @@ delete-multinet:
 	@kubectl delete -f https://github.com/k8snetworkplumbingwg/whereabouts/raw/master/doc/crds/whereabouts.cni.cncf.io_ippools.yaml
 	@kubectl delete -f https://github.com/k8snetworkplumbingwg/whereabouts/raw/master/doc/crds/whereabouts.cni.cncf.io_overlappingrangeipreservations.yaml
 	@echo "--Deleting multus daemonset..."
-	@kubectl delete -f https://github.com/k8snetworkplumbingwg/multus-cni/raw/master/deployments/multus-daemonset-thick.yml
+	@kubectl delete -f https://github.com/k8snetworkplumbingwg/multus-cni/raw/99c4481e08a4a8f0a3d0013446f03e4206033cae/deployments/multus-daemonset-thick.yml
 	@echo "--Deleting network CRD..."
 	@kubectl delete -f test/yaml/multinet/projectcalico.org_networks.yaml
 	@kubectl delete -f test/yaml/multinet/whereabouts-daemonset-install.yaml

--- a/calico-vpp-agent/common/pubsub.go
+++ b/calico-vpp-agent/common/pubsub.go
@@ -64,10 +64,9 @@ const (
 	NetDeleted        CalicoVppEventType = "NetDeleted"
 	NetsSynced        CalicoVppEventType = "NetsSynced"
 
-	IpamPoolUpdate CalicoVppEventType = "IpamPoolUpdate"
-	IpamPoolRemove CalicoVppEventType = "IpamPoolRemove"
-
 	WireguardPublicKeyChanged CalicoVppEventType = "WireguardPublicKeyChanged"
+
+	UplinksUpdated CalicoVppEventType = "UplinksUpdated"
 )
 
 var (

--- a/calico-vpp-agent/watchers/uplink_manager_watcher.go
+++ b/calico-vpp-agent/watchers/uplink_manager_watcher.go
@@ -1,0 +1,64 @@
+// Copyright (C) 2023 Cisco Systems Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package watchers
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/projectcalico/vpp-dataplane/v3/calico-vpp-agent/common"
+	"github.com/projectcalico/vpp-dataplane/v3/config"
+	log "github.com/sirupsen/logrus"
+	"gopkg.in/tomb.v2"
+)
+
+type UplinkManagerWatcher struct {
+	log               *log.Entry
+	usr2SignalChannel chan os.Signal
+}
+
+func NewUplinkManagerWatcher(usr2SignalChannel chan os.Signal, log *log.Entry) *UplinkManagerWatcher {
+	return &UplinkManagerWatcher{
+		usr2SignalChannel: usr2SignalChannel,
+		log:               log,
+	}
+}
+
+func (w *UplinkManagerWatcher) WatchUplinks(t *tomb.Tomb) error {
+	for t.Alive() {
+		<-w.usr2SignalChannel
+		/* vpp-manager pokes us with USR2 if status changes (dynamically added interface) */
+		w.log.Info("Vpp manager state changed")
+		dat, err := os.ReadFile(config.VppManagerInfoFile)
+		if err != nil {
+			w.log.Error(err)
+		} else {
+			err2 := json.Unmarshal(dat, common.VppManagerInfo)
+			if err2 != nil {
+				w.log.Error(errors.Errorf("cannot unmarshal vpp manager info file %s", err2))
+			} else if common.VppManagerInfo.Status == config.Ready {
+				w.log.Info("local vppmanager state updated")
+				common.SendEvent(common.CalicoVppEvent{
+					Type: common.UplinksUpdated,
+				})
+			} else {
+				w.log.Error(errors.Errorf("vpp manager file status not ready after dynamically added interface"))
+			}
+		}
+	}
+	return nil
+}

--- a/docs/kind.md
+++ b/docs/kind.md
@@ -50,7 +50,7 @@ nodes:
 # multinet CRDs, multus plugin and ipam
 kubectl create -f https://raw.githubusercontent.com/projectcalico/vpp-dataplane/master/test/yaml/multinet/projectcalico.org_networks.yaml
 kubectl create -f https://raw.githubusercontent.com/projectcalico/vpp-dataplane/master/test/yaml/multinet/whereabouts-daemonset-install.yaml
-kubectl create -f https://github.com/k8snetworkplumbingwg/multus-cni/raw/master/deployments/multus-daemonset-thick.yml
+kubectl create -f https://github.com/k8snetworkplumbingwg/multus-cni/raw/99c4481e08a4a8f0a3d0013446f03e4206033cae/deployments/multus-daemonset-thick.yml
 kubectl create -f https://github.com/k8snetworkplumbingwg/whereabouts/raw/master/doc/crds/whereabouts.cni.cncf.io_ippools.yaml
 kubectl create -f https://github.com/k8snetworkplumbingwg/whereabouts/raw/master/doc/crds/whereabouts.cni.cncf.io_overlappingrangeipreservations.yaml
 

--- a/docs/multinet.md
+++ b/docs/multinet.md
@@ -186,7 +186,7 @@ kubectl apply -f test/yaml/multinet/whereabouts-daemonset-install.yaml
 #### Installing multus deamonset
 
 ````yaml
-kubectl apply -f https://github.com/k8snetworkplumbingwg/multus-cni/raw/master/deployments/multus-daemonset-thick.yml
+kubectl apply -f https://github.com/k8snetworkplumbingwg/multus-cni/raw/99c4481e08a4a8f0a3d0013446f03e4206033cae/deployments/multus-daemonset-thick.yml
 kubectl apply -f https://github.com/k8snetworkplumbingwg/whereabouts/raw/master/doc/crds/whereabouts.cni.cncf.io_ippools.yaml
 kubectl apply -f https://github.com/k8snetworkplumbingwg/whereabouts/raw/master/doc/crds/whereabouts.cni.cncf.io_overlappingrangeipreservations.yaml
 ````


### PR DESCRIPTION
this adds a feature that allows to have uplinks dynamically added to infra in calicovpp. Only af packet was tested for now. Vpp manager sends information to calicovpp agent to have everything updated accordingly.