### PR TITLE
openshift: dhcp lease timeout issue

### DIFF
--- a/yaml/platforms/openshift/04-calico-vpp-nohuge.yaml
+++ b/yaml/platforms/openshift/04-calico-vpp-nohuge.yaml
@@ -53,6 +53,8 @@ spec:
           mountPropagation: Bidirectional
           name: netns
       - env:
+        - name: CALICOVPP_HOOK_VPP_RUNNING
+          value: echo 'systemctl restart NetworkManager; sleep 5; nmcli con mod ens5 ipv4.dhcp-timeout infinity' | chroot /host
         - name: DATASTORE_TYPE
           value: kubernetes
         - name: WAIT_FOR_DATASTORE


### PR DESCRIPTION
NetworkManager makes no attempt to renew dhcp lease when the default dhcp lease time of 60 mins expires resulting in the wipe out of the node's ip address. This fix coerces NM to keep trying to renew the lease indefinitely so that node always has its ip address intact as long as vpp is running.