### PR TITLE
openshift: add podSecurity labels

### DIFF
--- a/yaml/platforms/openshift/00-namespace-calico-vpp-dataplane.yaml
+++ b/yaml/platforms/openshift/00-namespace-calico-vpp-dataplane.yaml
@@ -7,3 +7,7 @@ metadata:
   labels:
     name: calico-vpp-dataplane
     openshift.io/run-level: "0"
+    security.openshift.io/scc.podSecurityLabelSync: "false"
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged


### PR DESCRIPTION
Openshift has pod security admission enabled by default. Adding the required labels.