### PR TITLE
cnat: fix fib entry cleanup

### DIFF
--- a/vpplink/generated/generate.log
+++ b/vpplink/generated/generate.log
@@ -1,11 +1,13 @@
-VPP Version                 : 24.02-rc0~6-g2be60e67d
+VPP Version                 : 24.02-rc0~8-gfc2d69296
 Binapi-generator version    : v0.8.0-dev
-VPP Base commit             : 2d0dac57e gerrit:34726/3 interface: add buffer stats api
+VPP Base commit             : f514c5ea5 gerrit:34726/3 interface: add buffer stats api
 ------------------ Cherry picked commits --------------------
 capo: Calico Policies plugin
 acl: acl-plugin custom policies
 cnat: [WIP] no k8s maglev from pods
 pbl: Port based balancer
+gerrit:40078/3 vnet: allow format deleted swifidx
+gerrit:40090/3 cnat: undo fib_entry_contribute_forwarding
 gerrit:39507/13 cnat: add flow hash config to cnat translation
 gerrit:34726/3 interface: add buffer stats api
 -------------------------------------------------------------

--- a/vpplink/generated/vpp_clone_current.sh
+++ b/vpplink/generated/vpp_clone_current.sh
@@ -96,6 +96,8 @@ git_clone_cd_and_reset "$1" 7419bede7ad73544338fd4363da833b2d5fc89a5 # misc: Ini
 
 git_cherry_pick refs/changes/26/34726/3 # 34726: interface: add buffer stats api | https://gerrit.fd.io/r/c/vpp/+/34726
 git_cherry_pick refs/changes/07/39507/13 # 39507: cnat: add flow hash config to cnat translation | https://gerrit.fd.io/r/c/vpp/+/39507/13
+git_cherry_pick refs/changes/90/40090/3 # 40090: cnat: undo fib_entry_contribute_forwarding | https://gerrit.fd.io/r/c/vpp/+/40090
+git_cherry_pick refs/changes/78/40078/3 # 40078: vnet: allow format deleted swifidx | https://gerrit.fd.io/r/c/vpp/+/40078
 
 # --------------- private plugins ---------------
 # Generated with 'git format-patch --zero-commit -o ./patches/ HEAD^^^'


### PR DESCRIPTION
This patch cherry picks two cnat patches that aim at
- fixing a segfault in the fib display when entries are leftover
- address a cleanup issue in the cnat that leaks LB objects, so also fib entries, ipip adjacencies, etc...