### PR TITLE
Fix trying to close vpplink on vpp segfault

### DIFF
--- a/vpp-manager/vpp_runner.go
+++ b/vpp-manager/vpp_runner.go
@@ -848,7 +848,6 @@ func (v *VppRunner) runVpp() (err error) {
 	v.vpp = vpp
 	if err != nil {
 		terminateVpp("Error connecting to VPP: %v", err)
-		v.vpp.Close()
 		<-vppDeadChan
 		return fmt.Errorf("cannot connect to VPP after 10 tries")
 	}


### PR DESCRIPTION
This patch removes the closing of the vpplink channel when VPP fails 
to start as if err != nil, vpp will always be nil.