### PR TITLE
yaml: add support for generating static Kubernetes manifest

### DIFF
--- a/docs/manifest_based_install.md
+++ b/docs/manifest_based_install.md
@@ -1,0 +1,1 @@
+../yaml/static/README.md

--- a/yaml/static/README.md
+++ b/yaml/static/README.md
@@ -1,0 +1,54 @@
+## Install Calico VPP using static Kubernetes manifest
+
+The recommended way to install Calico VPP is using operator. However, it is also possible
+to bypass the operator and install Calico VPP using the Kubernetes manifest directly.
+To be able to do so, one would need the static Calico VPP manifest.
+
+Here's how to generate the static Kubernetes manifest:
+
+* Clone the Calico VPP repo and go to the `vpp-dataplane/yaml/static` dir:
+
+  ```bash
+  cd vpp-dataplane/yaml/static
+  ```
+
+* Download the appropriate Calico Kubernetes manifest file. For example, to
+  install Calico VPP v3.28.0, download the corresponding Calico v3.28.0 manifest:
+
+  ```bash
+  wget https://raw.githubusercontent.com/projectcalico/calico/release-v3.28/manifests/calico.yaml
+  ```
+
+* Copy the appropriate **generated** Calico VPP daemonset yaml and rename it to `calico-vpp-daemonset.yaml`.
+For example, to install Calico VPP v3.28.0 in EKS:
+
+  ```bash
+  git checkout release/v3.28.0
+  cp ../generated/calico-vpp-eks.yaml ./calico-vpp-daemonset.yaml
+  ```
+
+  One can also download the same directly:
+
+  ```bash
+  wget -O calico-vpp-daemonset.yaml https://raw.githubusercontent.com/projectcalico/vpp-dataplane/release/v3.28.0/yaml/generated/calico-vpp-eks.yaml
+  ```
+
+* Finally, run kustomize:
+
+  ```bash
+  kubectl kustomize . > calico-vpp-eks.yaml
+  ```
+
+  `calico-vpp-eks.yaml` is the static Kubernetes manifest that can be used to install Calico VPP in EKS directly.
+
+
+Having generated the static manifest, one can then customize it per one's requirements and environment before installing.
+Please refer to [Getting Started](https://docs.projectcalico.org/getting-started/kubernetes/vpp/getting-started) for more information.
+
+
+**NOTE:** If installing in EKS, add the following to the `calico-node` env definitions:
+```
+- name:  FELIX_AWSSRCDSTCHECK
+  value: "Disable"
+```
+

--- a/yaml/static/calico-patch.yaml
+++ b/yaml/static/calico-patch.yaml
@@ -1,0 +1,83 @@
+# calico-config configmap changes
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: calico-config
+  namespace: kube-system
+data:
+  calico_backend: "none"
+  cni_network_config: |-
+    {
+      "name": "k8s-pod-network",
+      "cniVersion": "0.3.1",
+      "plugins": [
+        {
+          "type": "calico",
+          "log_level": "debug",
+          "datastore_type": "kubernetes",
+          "nodename": "__KUBERNETES_NODE_NAME__",
+          "mtu": __CNI_MTU__,
+          "ipam": {
+              "type": "calico-ipam"
+          },
+          "policy": {
+              "type": "k8s"
+          },
+          "kubernetes": {
+              "kubeconfig": "__KUBECONFIG_FILEPATH__"
+          },
+          "dataplane_options": {
+            "type": "grpc",
+            "socket": "unix:///var/run/calico/cni-server.sock"
+          }
+        },
+        {
+          "type": "portmap",
+          "snat": true,
+          "capabilities": {"portMappings": true}
+        }
+      ]
+    }
+
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: calico-node
+  namespace: kube-system
+  labels:
+    k8s-app: calico-node
+spec:
+  template:
+    spec:
+      containers:
+        - name: calico-node
+          env:
+            - name: FELIX_USEINTERNALDATAPLANEDRIVER
+              value: "false"
+            - name: FELIX_DATAPLANEDRIVER
+              value: /usr/local/bin/felix-plugins/felix-api-proxy
+            - name: FELIX_XDPENABLED
+              value: "false"
+            # Cluster type to identify the deployment type
+            - name: CLUSTER_TYPE
+              value: "k8s,bgp,vpp"
+          # Remove bird from liveness and readiness probes
+          livenessProbe:
+            exec:
+              command:
+              - /bin/calico-node
+              - -felix-live
+          readinessProbe:
+            exec:
+              command:
+              - /bin/calico-node
+              - -felix-ready
+          volumeMounts:
+            - mountPath: /usr/local/bin/felix-plugins
+              name: felix-plugins
+              readOnly: true
+      volumes:
+        - name: felix-plugins
+          hostPath:
+            path: /var/lib/calico/felix-plugins

--- a/yaml/static/kustomization.yaml
+++ b/yaml/static/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+- calico.yaml
+- calico-vpp-daemonset.yaml
+patchesStrategicMerge:
+- calico-patch.yaml


### PR DESCRIPTION
This patch provides a way to generate the static Kubernetes manifest which can be used to install Calico VPP without using operator.