### PR TITLE
yaml: increase buffers-per-numa for openshift scenario

### DIFF
--- a/yaml/platforms/openshift/03-configmap-calico-vpp-resources.yaml
+++ b/yaml/platforms/openshift/03-configmap-calico-vpp-resources.yaml
@@ -28,7 +28,7 @@ data:
         plugin dispatch_trace_plugin.so { enable }
     }
     buffers {
-      buffers-per-numa 131072
+      buffers-per-numa 262144
     }
   CALICOVPP_INITIAL_CONFIG: |-
     {


### PR DESCRIPTION
Openshift scenario in CI fails to deploy due to buffer shortage; Double the buffers-per-numa.