### PR TITLE
Add prometheus config for polling frequency, port & enablement

### DIFF
--- a/calico-vpp-agent/prometheus/prometheus.go
+++ b/calico-vpp-agent/prometheus/prometheus.go
@@ -65,7 +65,7 @@ func (s *Server) recordMetrics(t *tomb.Tomb) {
 		}
 	}()
 	ticker := time.NewTicker(*config.GetCalicoVppInitialConfig().PrometheusRecordMetricInterval)
-	for ;t.Alive() ; <-ticker.C {
+	for ; t.Alive(); <-ticker.C {
 		ifNames, dumpStats, _ := vpplink.GetInterfaceStats(s.sc)
 		for _, sta := range dumpStats {
 			if string(sta.Name) != "/if/names" {
@@ -210,12 +210,18 @@ func NewPrometheusServer(vpp *vpplink.VppLink, l *logrus.Entry) *Server {
 		podInterfacesByKey:       make(map[string]storage.LocalPodSpec),
 		podInterfacesBySwifIndex: make(map[uint32]storage.LocalPodSpec),
 	}
-	reg := common.RegisterHandler(server.channel, "prometheus events")
-	reg.ExpectEvents(common.PodAdded, common.PodDeleted)
+	if *config.GetCalicoVppFeatureGates().PrometheusEnabled {
+		reg := common.RegisterHandler(server.channel, "prometheus events")
+		reg.ExpectEvents(common.PodAdded, common.PodDeleted)
+	}
 	return server
 }
 
 func (s *Server) ServePrometheus(t *tomb.Tomb) error {
+	if !(*config.GetCalicoVppFeatureGates().PrometheusEnabled) {
+		return nil
+	}
+
 	s.log.Infof("Serve() Prometheus exporter")
 	go func() {
 		for t.Alive() {

--- a/calico-vpp-agent/prometheus/prometheus.go
+++ b/calico-vpp-agent/prometheus/prometheus.go
@@ -34,16 +34,8 @@ import (
 
 	"github.com/projectcalico/vpp-dataplane/v3/calico-vpp-agent/cni/storage"
 	"github.com/projectcalico/vpp-dataplane/v3/calico-vpp-agent/common"
+	"github.com/projectcalico/vpp-dataplane/v3/config"
 	"github.com/projectcalico/vpp-dataplane/v3/vpplink"
-)
-
-type Event int
-
-const (
-	Add    Event = 0
-	Delete Event = 1
-
-	recordMetricInterval int64 = 5
 )
 
 type Server struct {
@@ -64,13 +56,16 @@ func (s *Server) recordMetrics(t *tomb.Tomb) {
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", pe)
 	go func() {
-		err := http.ListenAndServe(":8888", mux)
+		err := http.ListenAndServe(
+			config.GetCalicoVppInitialConfig().PrometheusListenEndpoint,
+			mux,
+		)
 		if err != nil {
 			s.log.Fatalf("Failed to serve metrics: %s", err)
 		}
 	}()
-	for t.Alive() {
-		time.Sleep(time.Second * time.Duration(recordMetricInterval))
+	ticker := time.NewTicker(*config.GetCalicoVppInitialConfig().PrometheusRecordMetricInterval)
+	for ;t.Alive() ; <-ticker.C {
 		ifNames, dumpStats, _ := vpplink.GetInterfaceStats(s.sc)
 		for _, sta := range dumpStats {
 			if string(sta.Name) != "/if/names" {
@@ -85,6 +80,7 @@ func (s *Server) recordMetrics(t *tomb.Tomb) {
 			}
 		}
 	}
+	ticker.Stop()
 }
 
 var units = map[int]string{0: "packets", 1: "bytes"}

--- a/config/config.go
+++ b/config/config.go
@@ -302,11 +302,12 @@ func (self *CalicoVppDebugConfigType) Validate() (err error) {
 }
 
 type CalicoVppFeatureGatesConfigType struct {
-	MemifEnabled    *bool `json:"memifEnabled,omitempty"`
-	VCLEnabled      *bool `json:"vclEnabled,omitempty"`
-	MultinetEnabled *bool `json:"multinetEnabled,omitempty"`
-	SRv6Enabled     *bool `json:"srv6Enabled,omitempty"`
-	IPSecEnabled    *bool `json:"ipsecEnabled,omitempty"`
+	MemifEnabled      *bool `json:"memifEnabled,omitempty"`
+	VCLEnabled        *bool `json:"vclEnabled,omitempty"`
+	MultinetEnabled   *bool `json:"multinetEnabled,omitempty"`
+	SRv6Enabled       *bool `json:"srv6Enabled,omitempty"`
+	IPSecEnabled      *bool `json:"ipsecEnabled,omitempty"`
+	PrometheusEnabled *bool `json:"prometheusEnabled,omitempty"`
 }
 
 func (self *CalicoVppFeatureGatesConfigType) Validate() (err error) {
@@ -315,6 +316,7 @@ func (self *CalicoVppFeatureGatesConfigType) Validate() (err error) {
 	self.MultinetEnabled = DefaultToPtr(self.MultinetEnabled, false)
 	self.SRv6Enabled = DefaultToPtr(self.SRv6Enabled, false)
 	self.IPSecEnabled = DefaultToPtr(self.IPSecEnabled, false)
+	self.PrometheusEnabled = DefaultToPtr(self.PrometheusEnabled, false)
 	return nil
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -406,17 +406,35 @@ func (self *CalicoVppInterfacesConfigType) String() string {
 
 type CalicoVppInitialConfigConfigType struct { //out of agent and vppmanager
 	VppStartupSleepSeconds int `json:"vppStartupSleepSeconds"`
-	/* Set the pattern for VPP corefiles. Usually "/var/lib/vpp/vppcore.%e.%p" */
+	// CorePattern is the pattern to use for VPP corefiles.
+	// Usually "/var/lib/vpp/vppcore.%e.%p"
 	CorePattern      string `json:"corePattern"`
 	ExtraAddrCount   int    `json:"extraAddrCount"`
 	IfConfigSavePath string `json:"ifConfigSavePath"`
-	/* Comma separated list of IPs to be configured in VPP as default GW */
+	// DefaultGWs Comma separated list of IPs to be
+	// configured in VPP as default GW
 	DefaultGWs string `json:"defaultGWs"`
-	/* List of rules for redirecting traffic to host */
+	// RedirectToHostRules is a list of rules for redirecting
+	// traffic to host. This is used for DNS support in kind
 	RedirectToHostRules []RedirectToHostRulesConfigType `json:"redirectToHostRules"`
+	// PrometheusListenEndpoint is the endpoint on which prometheus will
+	// listen and report stats. By default curl http://localhost:8888/metrics
+	PrometheusListenEndpoint string `json:"prometheusListenEndpoint"`
+	// PrometheusRecordMetricInterval is the interval at which we update the
+	// prometheus stats polling VPP stats segment. Default to 5 seconds
+	PrometheusRecordMetricInterval *time.Duration `json:"prometheusRecordMetricInterval"`
 }
 
-func (self *CalicoVppInitialConfigConfigType) Validate() (err error) { return nil }
+func (self *CalicoVppInitialConfigConfigType) Validate() (err error) {
+	if self.PrometheusListenEndpoint == "" {
+		self.PrometheusListenEndpoint = ":8888"
+	}
+	if self.PrometheusRecordMetricInterval == nil {
+		prometheusRecordMetricInterval := 5 * time.Second
+		self.PrometheusRecordMetricInterval = &prometheusRecordMetricInterval
+	}
+	return nil
+}
 func (self *CalicoVppInitialConfigConfigType) GetDefaultGWs() (gws []net.IP, err error) {
 	gws = make([]net.IP, 0)
 	if self.DefaultGWs != "" {


### PR DESCRIPTION
This patch adds the ability to configure the polling frequency of prometheus and the port the prometheus server will be listening on and serving metrics under `/metrics`.

This also adds a prometheusEnabled feature gate under
CALICOVPP_FEATURE_GATES to allow disabling the prometheus
exporter if needed.