### PR TITLE
Disable memif if queue spread by default

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -278,9 +278,10 @@ type RedirectToHostRulesConfigType struct {
 }
 
 type CalicoVppDebugConfigType struct {
-	PoliciesEnabled *bool `json:"policiesEnabled,omitempty"`
-	ServicesEnabled *bool `json:"servicesEnabled,omitempty"`
-	GSOEnabled      *bool `json:"gsoEnabled,omitempty"`
+	PoliciesEnabled         *bool `json:"policiesEnabled,omitempty"`
+	ServicesEnabled         *bool `json:"servicesEnabled,omitempty"`
+	GSOEnabled              *bool `json:"gsoEnabled,omitempty"`
+	SpreadTxQueuesOnWorkers *bool `json:"spreadTxQueuesOnWorkers,omitempty"`
 }
 
 func (self *CalicoVppDebugConfigType) String() string {
@@ -297,6 +298,9 @@ func (self *CalicoVppDebugConfigType) Validate() (err error) {
 	}
 	if self.GSOEnabled == nil {
 		self.GSOEnabled = &True
+	}
+	if self.SpreadTxQueuesOnWorkers == nil {
+		self.SpreadTxQueuesOnWorkers = &False
 	}
 	return
 }


### PR DESCRIPTION
This patch disables memif interface queue spreading on workers by default. Users can enable it again using the debug knob : ``CALICOVPP_DEBUG='{"spreadTxQueuesOnWorkers": true}'``.

This is a consequence of the pinning behaviour of VPP by default. When #queues < #workers, queues are shared by default and pinning them removes their sharing rendering them unusable on some workers.

When #queues > #workers, the extra queues are unpined by default, rendering multi-tx harder to use.

As the latter feature is harder and more niche than the former, we chose to go with a default that suits most usecase, while we work on a better pinning framework.