### PR TITLE
Fixes for golangcilint 1.64.6

### DIFF
--- a/.ci/Dockerfile.depend
+++ b/.ci/Dockerfile.depend
@@ -11,7 +11,7 @@ RUN apt-get update \
  && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
     apt-utils wget cmake curl git
 
-ENV GOVERSION=1.22.3
+ENV GOVERSION=1.24.0
 ENV GOROOT="/root/.go"
 ENV GOPATH="/root/go"
 ENV PATH=$GOROOT/bin:$PATH
@@ -22,7 +22,7 @@ RUN mkdir -p "${GOROOT}" &&\
 RUN wget -nv "https://dl.google.com/go/go${GOVERSION}.linux-amd64.tar.gz" -O "/tmp/go.tar.gz" && \
     tar -C "${GOROOT}" --strip-components=1 -xzf "/tmp/go.tar.gz" && \
     rm -f "/tmp/go.tar.gz" && \
-    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.61.0
+    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.6
 
 # Get modules used by the source code
 COPY . /vpp-dataplane

--- a/calico-vpp-agent/cmd/calico_vpp_dataplane.go
+++ b/calico-vpp-agent/cmd/calico_vpp_dataplane.go
@@ -178,13 +178,17 @@ func main() {
 	}
 
 	if ourBGPSpec != nil {
-		prefixWatcher.SetOurBGPSpec(ourBGPSpec.(*common.LocalNodeSpec))
-		connectivityServer.SetOurBGPSpec(ourBGPSpec.(*common.LocalNodeSpec))
-		routingServer.SetOurBGPSpec(ourBGPSpec.(*common.LocalNodeSpec))
-		serviceServer.SetOurBGPSpec(ourBGPSpec.(*common.LocalNodeSpec))
-		localSIDWatcher.SetOurBGPSpec(ourBGPSpec.(*common.LocalNodeSpec))
-		netWatcher.SetOurBGPSpec(ourBGPSpec.(*common.LocalNodeSpec))
-		cniServer.SetOurBGPSpec(ourBGPSpec.(*common.LocalNodeSpec))
+		bgpSpec, ok := ourBGPSpec.(*common.LocalNodeSpec)
+		if !ok {
+			panic("ourBGPSpec is not *common.LocalNodeSpec")
+		}
+		prefixWatcher.SetOurBGPSpec(bgpSpec)
+		connectivityServer.SetOurBGPSpec(bgpSpec)
+		routingServer.SetOurBGPSpec(bgpSpec)
+		serviceServer.SetOurBGPSpec(bgpSpec)
+		localSIDWatcher.SetOurBGPSpec(bgpSpec)
+		netWatcher.SetOurBGPSpec(bgpSpec)
+		cniServer.SetOurBGPSpec(bgpSpec)
 	}
 
 	if *config.GetCalicoVppFeatureGates().MultinetEnabled {
@@ -193,8 +197,12 @@ func main() {
 	}
 
 	if felixConfig != nil {
-		cniServer.SetFelixConfig(felixConfig.(*felixconfig.Config))
-		connectivityServer.SetFelixConfig(felixConfig.(*felixconfig.Config))
+		felixCfg, ok := felixConfig.(*felixconfig.Config)
+		if !ok {
+			panic("ourBGPSpec is not *felixconfig.Config")
+		}
+		cniServer.SetFelixConfig(felixCfg)
+		connectivityServer.SetFelixConfig(felixCfg)
 	}
 
 	Go(routeWatcher.WatchRoutes)

--- a/calico-vpp-agent/cni/cni_server.go
+++ b/calico-vpp-agent/cni/cni_server.go
@@ -171,7 +171,11 @@ func (s *Server) newLocalPodSpecFromAdd(request *cniproto.AddRequest) (*storage.
 		if !ok {
 			s.log.Errorf("trying to create a pod in an unexisting network %s", podSpec.NetworkName)
 		} else {
-			_, route, err := net.ParseCIDR(value.(*watchers.NetworkDefinition).Range)
+			networkDefinition, ok := value.(*watchers.NetworkDefinition)
+			if !ok || networkDefinition == nil {
+				panic("Value is not of type *watchers.NetworkDefinition")
+			}
+			_, route, err := net.ParseCIDR(networkDefinition.Range)
 			if err == nil {
 				podSpec.Routes = append(podSpec.Routes, storage.LocalIPNet{
 					IP:   route.IP,

--- a/calico-vpp-agent/cni/network_vpp.go
+++ b/calico-vpp-agent/cni/network_vpp.go
@@ -243,7 +243,11 @@ func (s *Server) AddVppInterface(podSpec *storage.LocalPodSpec, doHostSideConf b
 		if !ok {
 			s.log.Errorf("network not found %s", podSpec.NetworkName)
 		} else {
-			vni = value.(*watchers.NetworkDefinition).Vni
+			networkDefinition, ok := value.(*watchers.NetworkDefinition)
+			if !ok || networkDefinition == nil {
+				panic("networkDefinition not of type *watchers.NetworkDefinition")
+			}
+			vni = networkDefinition.Vni
 		}
 	}
 
@@ -312,7 +316,11 @@ func (s *Server) DelVppInterface(podSpec *storage.LocalPodSpec) {
 		if !ok {
 			deleteLocalPodAddress = false
 		} else {
-			vni = value.(*watchers.NetworkDefinition).Vni
+			networkDefinition, ok := value.(*watchers.NetworkDefinition)
+			if !ok || networkDefinition == nil {
+				panic("networkDefinition not of type *watchers.NetworkDefinition")
+			}
+			vni = networkDefinition.Vni
 		}
 	}
 	if deleteLocalPodAddress {

--- a/calico-vpp-agent/cni/network_vpp_routes.go
+++ b/calico-vpp-agent/cni/network_vpp_routes.go
@@ -37,7 +37,11 @@ func (s *Server) RoutePodInterface(podSpec *storage.LocalPodSpec, stack *vpplink
 			if !ok {
 				s.log.Errorf("network not found %s", podSpec.NetworkName)
 			} else {
-				table = value.(*watchers.NetworkDefinition).VRF.Tables[idx]
+				networkDefinition, ok := value.(*watchers.NetworkDefinition)
+				if !ok || networkDefinition == nil {
+					panic("networkDefinition not of type *watchers.NetworkDefinition")
+				}
+				table = networkDefinition.VRF.Tables[idx]
 			}
 		} else if inPodVrf {
 			table = podSpec.GetVrfId(vpplink.IpFamilyFromIPNet(containerIP))
@@ -83,7 +87,11 @@ func (s *Server) UnroutePodInterface(podSpec *storage.LocalPodSpec, swIfIndex ui
 			if !ok {
 				s.log.Errorf("network not found %s", podSpec.NetworkName)
 			} else {
-				table = value.(*watchers.NetworkDefinition).VRF.Tables[idx]
+				networkDefinition, ok := value.(*watchers.NetworkDefinition)
+				if !ok || networkDefinition == nil {
+					panic("networkDefinition not of type *watchers.NetworkDefinition")
+				}
+				table = networkDefinition.VRF.Tables[idx]
 			}
 		} else if inPodVrf {
 			table = podSpec.GetVrfId(vpplink.IpFamilyFromIPNet(containerIP))
@@ -205,7 +213,11 @@ func (s *Server) CreatePodVRF(podSpec *storage.LocalPodSpec, stack *vpplink.Clea
 			if !ok {
 				return errors.Errorf("network not found %s", podSpec.NetworkName)
 			}
-			vrfIndex = value.(*watchers.NetworkDefinition).PodVRF.Tables[idx]
+			networkDefinition, ok := value.(*watchers.NetworkDefinition)
+			if !ok || networkDefinition == nil {
+				panic("networkDefinition not of type *watchers.NetworkDefinition")
+			}
+			vrfIndex = networkDefinition.PodVRF.Tables[idx]
 		}
 		s.log.Infof("pod(add) VRF %d %s default route via VRF %d", vrfId, ipFamily.Str, vrfIndex)
 		err = s.vpp.AddDefaultRouteViaTable(vrfId, vrfIndex, ipFamily.IsIp6)
@@ -373,7 +385,11 @@ func (s *Server) DeletePodVRF(podSpec *storage.LocalPodSpec) {
 			if !ok {
 				s.log.Errorf("network not found %s", podSpec.NetworkName)
 			} else {
-				vrfIndex = value.(*watchers.NetworkDefinition).PodVRF.Tables[idx]
+				networkDefinition, ok := value.(*watchers.NetworkDefinition)
+				if !ok || networkDefinition == nil {
+					panic("networkDefinition not of type *watchers.NetworkDefinition")
+				}
+				vrfIndex = networkDefinition.PodVRF.Tables[idx]
 			}
 		}
 		s.log.Infof("pod(del) VRF %d %s default route via VRF %d", vrfId, ipFamily.Str, vrfIndex)

--- a/calico-vpp-agent/connectivity/connectivity_server.go
+++ b/calico-vpp-agent/connectivity/connectivity_server.go
@@ -191,7 +191,11 @@ func (s *ConnectivityServer) ServeConnectivity(t *tomb.Tomb) error {
 				if !ok {
 					s.log.Errorf("evt.New is not a *common.NodeWireguardPublicKey %v", evt.New)
 				}
-				s.providers[WIREGUARD].(*WireguardProvider).nodesToWGPublicKey[new.Name] = new.WireguardPublicKey
+				wgProvider, ok := s.providers[WIREGUARD].(*WireguardProvider)
+				if !ok {
+					panic("Type is not WireguardProvider")
+				}
+				wgProvider.nodesToWGPublicKey[new.Name] = new.WireguardPublicKey
 				change := common.GetStringChangeType(old.WireguardPublicKey, new.WireguardPublicKey)
 				if change != common.ChangeSame {
 					s.log.Infof("connectivity(upd) WireguardPublicKey Changed (%s) %s->%s", old.Name, old.WireguardPublicKey, new.WireguardPublicKey)
@@ -420,5 +424,9 @@ func (s *ConnectivityServer) ForceNodeAddition(newNode common.LocalNodeSpec, new
 // ForceWGPublicKeyAddition will add other node information as provided by calico configuration
 // The usage is mainly for testing purposes.
 func (s *ConnectivityServer) ForceWGPublicKeyAddition(newNode string, wgPublicKey string) {
-	s.providers[WIREGUARD].(*WireguardProvider).nodesToWGPublicKey[newNode] = wgPublicKey
+	wgProvider, ok := s.providers[WIREGUARD].(*WireguardProvider)
+	if !ok {
+		panic("Type is not WireguardProvider")
+	}
+	wgProvider.nodesToWGPublicKey[newNode] = wgPublicKey
 }

--- a/calico-vpp-agent/watchers/bgpfilter_watcher.go
+++ b/calico-vpp-agent/watchers/bgpfilter_watcher.go
@@ -71,14 +71,23 @@ func (w *BGPFilterWatcher) WatchBGPFilters(t *tomb.Tomb) error {
 					w.log.Debug("BGPFilter watch returned, restarting...")
 					goto restart
 				case watch.EventType(api.WatchModified):
-					filter := *event.Object.(*calicov3.BGPFilter)
-					w.UpdateFilter(filter)
+					filter, ok := event.Object.(*calicov3.BGPFilter)
+					if !ok || filter == nil {
+						w.log.Fatal("api.WatchModified Object is not BGPFilter or is nil")
+					}
+					w.UpdateFilter(*filter)
 				case watch.EventType(api.WatchAdded):
-					filter := *event.Object.(*calicov3.BGPFilter)
-					w.AddNewFilter(filter)
+					filter, ok := event.Object.(*calicov3.BGPFilter)
+					if !ok || filter == nil {
+						w.log.Fatal("api.WatchAdded	 Object is not BGPFilter or is nil")
+					}
+					w.AddNewFilter(*filter)
 				case watch.EventType(api.WatchDeleted):
-					filter := *event.Previous.(*calicov3.BGPFilter)
-					w.RemoveFilter(filter)
+					filter, ok := event.Previous.(*calicov3.BGPFilter)
+					if !ok || filter == nil {
+						w.log.Fatal("api.WatchDeleted Previous is not BGPFilter or is nil")
+					}
+					w.RemoveFilter(*filter)
 				}
 			}
 		}

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/projectcalico/vpp-dataplane/v3
 
-go 1.22.7
-toolchain go1.23.2
+go 1.23.0
 
 require (
 	github.com/calico-vpp/vpplink v0.1.0


### PR DESCRIPTION
This patch fixes several nitpicks raised by golangcilint 1.64.6 It also bumps the builder image for CI to
- golang 1.24
- golangcilint 1.64.6