### PR TITLE
Refactor the prometheus exporter

### DIFF
--- a/.ci/Dockerfile.depend
+++ b/.ci/Dockerfile.depend
@@ -11,7 +11,7 @@ RUN apt-get update \
  && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
     apt-utils wget cmake curl git
 
-ENV GOVERSION=1.22.3
+ENV GOVERSION=1.24.0
 ENV GOROOT="/root/.go"
 ENV GOPATH="/root/go"
 ENV PATH=$GOROOT/bin:$PATH
@@ -22,7 +22,7 @@ RUN mkdir -p "${GOROOT}" &&\
 RUN wget -nv "https://dl.google.com/go/go${GOVERSION}.linux-amd64.tar.gz" -O "/tmp/go.tar.gz" && \
     tar -C "${GOROOT}" --strip-components=1 -xzf "/tmp/go.tar.gz" && \
     rm -f "/tmp/go.tar.gz" && \
-    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.61.0
+    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.6
 
 # Get modules used by the source code
 COPY . /vpp-dataplane

--- a/calico-vpp-agent/cmd/calico_vpp_dataplane.go
+++ b/calico-vpp-agent/cmd/calico_vpp_dataplane.go
@@ -178,13 +178,17 @@ func main() {
 	}
 
 	if ourBGPSpec != nil {
-		prefixWatcher.SetOurBGPSpec(ourBGPSpec.(*common.LocalNodeSpec))
-		connectivityServer.SetOurBGPSpec(ourBGPSpec.(*common.LocalNodeSpec))
-		routingServer.SetOurBGPSpec(ourBGPSpec.(*common.LocalNodeSpec))
-		serviceServer.SetOurBGPSpec(ourBGPSpec.(*common.LocalNodeSpec))
-		localSIDWatcher.SetOurBGPSpec(ourBGPSpec.(*common.LocalNodeSpec))
-		netWatcher.SetOurBGPSpec(ourBGPSpec.(*common.LocalNodeSpec))
-		cniServer.SetOurBGPSpec(ourBGPSpec.(*common.LocalNodeSpec))
+		bgpSpec, ok := ourBGPSpec.(*common.LocalNodeSpec)
+		if !ok {
+			panic("ourBGPSpec is not *common.LocalNodeSpec")
+		}
+		prefixWatcher.SetOurBGPSpec(bgpSpec)
+		connectivityServer.SetOurBGPSpec(bgpSpec)
+		routingServer.SetOurBGPSpec(bgpSpec)
+		serviceServer.SetOurBGPSpec(bgpSpec)
+		localSIDWatcher.SetOurBGPSpec(bgpSpec)
+		netWatcher.SetOurBGPSpec(bgpSpec)
+		cniServer.SetOurBGPSpec(bgpSpec)
 	}
 
 	if *config.GetCalicoVppFeatureGates().MultinetEnabled {
@@ -193,8 +197,12 @@ func main() {
 	}
 
 	if felixConfig != nil {
-		cniServer.SetFelixConfig(felixConfig.(*felixconfig.Config))
-		connectivityServer.SetFelixConfig(felixConfig.(*felixconfig.Config))
+		felixCfg, ok := felixConfig.(*felixconfig.Config)
+		if !ok {
+			panic("ourBGPSpec is not *felixconfig.Config")
+		}
+		cniServer.SetFelixConfig(felixCfg)
+		connectivityServer.SetFelixConfig(felixCfg)
 	}
 
 	Go(routeWatcher.WatchRoutes)

--- a/calico-vpp-agent/cni/cni_server.go
+++ b/calico-vpp-agent/cni/cni_server.go
@@ -171,7 +171,11 @@ func (s *Server) newLocalPodSpecFromAdd(request *cniproto.AddRequest) (*storage.
 		if !ok {
 			s.log.Errorf("trying to create a pod in an unexisting network %s", podSpec.NetworkName)
 		} else {
-			_, route, err := net.ParseCIDR(value.(*watchers.NetworkDefinition).Range)
+			networkDefinition, ok := value.(*watchers.NetworkDefinition)
+			if !ok || networkDefinition == nil {
+				panic("Value is not of type *watchers.NetworkDefinition")
+			}
+			_, route, err := net.ParseCIDR(networkDefinition.Range)
 			if err == nil {
 				podSpec.Routes = append(podSpec.Routes, storage.LocalIPNet{
 					IP:   route.IP,

--- a/calico-vpp-agent/cni/network_vpp.go
+++ b/calico-vpp-agent/cni/network_vpp.go
@@ -243,7 +243,11 @@ func (s *Server) AddVppInterface(podSpec *storage.LocalPodSpec, doHostSideConf b
 		if !ok {
 			s.log.Errorf("network not found %s", podSpec.NetworkName)
 		} else {
-			vni = value.(*watchers.NetworkDefinition).Vni
+			networkDefinition, ok := value.(*watchers.NetworkDefinition)
+			if !ok || networkDefinition == nil {
+				panic("networkDefinition not of type *watchers.NetworkDefinition")
+			}
+			vni = networkDefinition.Vni
 		}
 	}
 
@@ -312,7 +316,11 @@ func (s *Server) DelVppInterface(podSpec *storage.LocalPodSpec) {
 		if !ok {
 			deleteLocalPodAddress = false
 		} else {
-			vni = value.(*watchers.NetworkDefinition).Vni
+			networkDefinition, ok := value.(*watchers.NetworkDefinition)
+			if !ok || networkDefinition == nil {
+				panic("networkDefinition not of type *watchers.NetworkDefinition")
+			}
+			vni = networkDefinition.Vni
 		}
 	}
 	if deleteLocalPodAddress {

--- a/calico-vpp-agent/cni/network_vpp_routes.go
+++ b/calico-vpp-agent/cni/network_vpp_routes.go
@@ -37,7 +37,11 @@ func (s *Server) RoutePodInterface(podSpec *storage.LocalPodSpec, stack *vpplink
 			if !ok {
 				s.log.Errorf("network not found %s", podSpec.NetworkName)
 			} else {
-				table = value.(*watchers.NetworkDefinition).VRF.Tables[idx]
+				networkDefinition, ok := value.(*watchers.NetworkDefinition)
+				if !ok || networkDefinition == nil {
+					panic("networkDefinition not of type *watchers.NetworkDefinition")
+				}
+				table = networkDefinition.VRF.Tables[idx]
 			}
 		} else if inPodVrf {
 			table = podSpec.GetVrfId(vpplink.IpFamilyFromIPNet(containerIP))
@@ -83,7 +87,11 @@ func (s *Server) UnroutePodInterface(podSpec *storage.LocalPodSpec, swIfIndex ui
 			if !ok {
 				s.log.Errorf("network not found %s", podSpec.NetworkName)
 			} else {
-				table = value.(*watchers.NetworkDefinition).VRF.Tables[idx]
+				networkDefinition, ok := value.(*watchers.NetworkDefinition)
+				if !ok || networkDefinition == nil {
+					panic("networkDefinition not of type *watchers.NetworkDefinition")
+				}
+				table = networkDefinition.VRF.Tables[idx]
 			}
 		} else if inPodVrf {
 			table = podSpec.GetVrfId(vpplink.IpFamilyFromIPNet(containerIP))
@@ -205,7 +213,11 @@ func (s *Server) CreatePodVRF(podSpec *storage.LocalPodSpec, stack *vpplink.Clea
 			if !ok {
 				return errors.Errorf("network not found %s", podSpec.NetworkName)
 			}
-			vrfIndex = value.(*watchers.NetworkDefinition).PodVRF.Tables[idx]
+			networkDefinition, ok := value.(*watchers.NetworkDefinition)
+			if !ok || networkDefinition == nil {
+				panic("networkDefinition not of type *watchers.NetworkDefinition")
+			}
+			vrfIndex = networkDefinition.PodVRF.Tables[idx]
 		}
 		s.log.Infof("pod(add) VRF %d %s default route via VRF %d", vrfId, ipFamily.Str, vrfIndex)
 		err = s.vpp.AddDefaultRouteViaTable(vrfId, vrfIndex, ipFamily.IsIp6)
@@ -373,7 +385,11 @@ func (s *Server) DeletePodVRF(podSpec *storage.LocalPodSpec) {
 			if !ok {
 				s.log.Errorf("network not found %s", podSpec.NetworkName)
 			} else {
-				vrfIndex = value.(*watchers.NetworkDefinition).PodVRF.Tables[idx]
+				networkDefinition, ok := value.(*watchers.NetworkDefinition)
+				if !ok || networkDefinition == nil {
+					panic("networkDefinition not of type *watchers.NetworkDefinition")
+				}
+				vrfIndex = networkDefinition.PodVRF.Tables[idx]
 			}
 		}
 		s.log.Infof("pod(del) VRF %d %s default route via VRF %d", vrfId, ipFamily.Str, vrfIndex)

--- a/calico-vpp-agent/connectivity/connectivity_server.go
+++ b/calico-vpp-agent/connectivity/connectivity_server.go
@@ -191,7 +191,11 @@ func (s *ConnectivityServer) ServeConnectivity(t *tomb.Tomb) error {
 				if !ok {
 					s.log.Errorf("evt.New is not a *common.NodeWireguardPublicKey %v", evt.New)
 				}
-				s.providers[WIREGUARD].(*WireguardProvider).nodesToWGPublicKey[new.Name] = new.WireguardPublicKey
+				wgProvider, ok := s.providers[WIREGUARD].(*WireguardProvider)
+				if !ok {
+					panic("Type is not WireguardProvider")
+				}
+				wgProvider.nodesToWGPublicKey[new.Name] = new.WireguardPublicKey
 				change := common.GetStringChangeType(old.WireguardPublicKey, new.WireguardPublicKey)
 				if change != common.ChangeSame {
 					s.log.Infof("connectivity(upd) WireguardPublicKey Changed (%s) %s->%s", old.Name, old.WireguardPublicKey, new.WireguardPublicKey)
@@ -420,5 +424,9 @@ func (s *ConnectivityServer) ForceNodeAddition(newNode common.LocalNodeSpec, new
 // ForceWGPublicKeyAddition will add other node information as provided by calico configuration
 // The usage is mainly for testing purposes.
 func (s *ConnectivityServer) ForceWGPublicKeyAddition(newNode string, wgPublicKey string) {
-	s.providers[WIREGUARD].(*WireguardProvider).nodesToWGPublicKey[newNode] = wgPublicKey
+	wgProvider, ok := s.providers[WIREGUARD].(*WireguardProvider)
+	if !ok {
+		panic("Type is not WireguardProvider")
+	}
+	wgProvider.nodesToWGPublicKey[newNode] = wgPublicKey
 }

--- a/calico-vpp-agent/prometheus/prometheus.go
+++ b/calico-vpp-agent/prometheus/prometheus.go
@@ -65,7 +65,7 @@ func (s *Server) recordMetrics(t *tomb.Tomb) {
 		}
 	}()
 	ticker := time.NewTicker(*config.GetCalicoVppInitialConfig().PrometheusRecordMetricInterval)
-	for ;t.Alive() ; <-ticker.C {
+	for ; t.Alive(); <-ticker.C {
 		ifNames, dumpStats, _ := vpplink.GetInterfaceStats(s.sc)
 		for _, sta := range dumpStats {
 			if string(sta.Name) != "/if/names" {
@@ -210,12 +210,18 @@ func NewPrometheusServer(vpp *vpplink.VppLink, l *logrus.Entry) *Server {
 		podInterfacesByKey:       make(map[string]storage.LocalPodSpec),
 		podInterfacesBySwifIndex: make(map[uint32]storage.LocalPodSpec),
 	}
-	reg := common.RegisterHandler(server.channel, "prometheus events")
-	reg.ExpectEvents(common.PodAdded, common.PodDeleted)
+	if *config.GetCalicoVppFeatureGates().PrometheusEnabled {
+		reg := common.RegisterHandler(server.channel, "prometheus events")
+		reg.ExpectEvents(common.PodAdded, common.PodDeleted)
+	}
 	return server
 }
 
 func (s *Server) ServePrometheus(t *tomb.Tomb) error {
+	if !(*config.GetCalicoVppFeatureGates().PrometheusEnabled) {
+		return nil
+	}
+
 	s.log.Infof("Serve() Prometheus exporter")
 	go func() {
 		for t.Alive() {

--- a/calico-vpp-agent/prometheus/prometheus.go
+++ b/calico-vpp-agent/prometheus/prometheus.go
@@ -34,16 +34,8 @@ import (
 
 	"github.com/projectcalico/vpp-dataplane/v3/calico-vpp-agent/cni/storage"
 	"github.com/projectcalico/vpp-dataplane/v3/calico-vpp-agent/common"
+	"github.com/projectcalico/vpp-dataplane/v3/config"
 	"github.com/projectcalico/vpp-dataplane/v3/vpplink"
-)
-
-type Event int
-
-const (
-	Add    Event = 0
-	Delete Event = 1
-
-	recordMetricInterval int64 = 5
 )
 
 type Server struct {
@@ -64,13 +56,16 @@ func (s *Server) recordMetrics(t *tomb.Tomb) {
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", pe)
 	go func() {
-		err := http.ListenAndServe(":8888", mux)
+		err := http.ListenAndServe(
+			config.GetCalicoVppInitialConfig().PrometheusListenEndpoint,
+			mux,
+		)
 		if err != nil {
 			s.log.Fatalf("Failed to serve metrics: %s", err)
 		}
 	}()
-	for t.Alive() {
-		time.Sleep(time.Second * time.Duration(recordMetricInterval))
+	ticker := time.NewTicker(*config.GetCalicoVppInitialConfig().PrometheusRecordMetricInterval)
+	for ;t.Alive() ; <-ticker.C {
 		ifNames, dumpStats, _ := vpplink.GetInterfaceStats(s.sc)
 		for _, sta := range dumpStats {
 			if string(sta.Name) != "/if/names" {
@@ -85,6 +80,7 @@ func (s *Server) recordMetrics(t *tomb.Tomb) {
 			}
 		}
 	}
+	ticker.Stop()
 }
 
 var units = map[int]string{0: "packets", 1: "bytes"}

--- a/calico-vpp-agent/prometheus/prometheus.go
+++ b/calico-vpp-agent/prometheus/prometheus.go
@@ -17,7 +17,6 @@ package prometheus
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -38,178 +37,45 @@ import (
 	"github.com/projectcalico/vpp-dataplane/v3/vpplink"
 )
 
-type Server struct {
-	log                      *logrus.Entry
-	vpp                      *vpplink.VppLink
-	podInterfacesBySwifIndex map[uint32]storage.LocalPodSpec
-	podInterfacesByKey       map[string]storage.LocalPodSpec
-	sc                       *statsclient.StatsClient
-	channel                  chan common.CalicoVppEvent
-	lock                     sync.Mutex
+type podInterfaceDetails struct {
+	podNamespace  string
+	podName       string
+	interfaceName string
 }
 
-func (s *Server) recordMetrics(t *tomb.Tomb) {
-	pe, err := prometheusExporter.New(prometheusExporter.Options{})
+type PrometheusServer struct {
+	log                             *logrus.Entry
+	vpp                             *vpplink.VppLink
+	podInterfacesDetailsBySwifIndex map[uint32]podInterfaceDetails
+	podInterfacesByKey              map[string]storage.LocalPodSpec
+	statsclient                     *statsclient.StatsClient
+	channel                         chan common.CalicoVppEvent
+	lock                            sync.Mutex
+	httpServer                      *http.Server
+	exporter                        *prometheusExporter.Exporter
+}
+
+func NewPrometheusServer(vpp *vpplink.VppLink, log *logrus.Entry) *PrometheusServer {
+	exporter, err := prometheusExporter.New(prometheusExporter.Options{})
 	if err != nil {
-		s.log.Fatalf("Failed to create new exporter: %v", err)
+		log.Fatalf("Failed to create new exporter: %v", err)
 	}
 	mux := http.NewServeMux()
-	mux.Handle("/metrics", pe)
-	go func() {
-		err := http.ListenAndServe(
-			config.GetCalicoVppInitialConfig().PrometheusListenEndpoint,
-			mux,
-		)
-		if err != nil {
-			s.log.Fatalf("Failed to serve metrics: %s", err)
-		}
-	}()
-	ticker := time.NewTicker(*config.GetCalicoVppInitialConfig().PrometheusRecordMetricInterval)
-	for ; t.Alive(); <-ticker.C {
-		ifNames, dumpStats, _ := vpplink.GetInterfaceStats(s.sc)
-		for _, sta := range dumpStats {
-			if string(sta.Name) != "/if/names" {
-				names := []string{strings.Replace(string(sta.Name[4:]), "-", "_", -1)}
-				if sta.Type == adapter.CombinedCounterVector {
-					names = []string{names[0] + "_packets", names[0] + "_bytes"}
-				}
-				err := s.exportMetricsForStat(names, sta, ifNames, pe)
-				if err != nil {
-					s.log.Errorf("exportMetricsForStat errored with %s", err)
-				}
-			}
-		}
-	}
-	ticker.Stop()
-}
-
-var units = map[int]string{0: "packets", 1: "bytes"}
-var descriptions = map[string]string{
-	"drops": "number of drops on interface",
-	"ip4":   "IPv4 received packets",
-	"ip6":   "IPv6 received packets",
-	"punt":  "number of punts on interface",
-
-	"rx_bytes":   "total number of bytes received over the interface",
-	"tx_bytes":   "total number of bytes transmitted by the interface",
-	"rx_packets": "total number of packets received over the interface",
-	"tx_packets": "total number of packets transmitted by the interface",
-
-	"tx_broadcast_packets": "number of multipoint communications transmitted by the interface in packets",
-	"rx_broadcast_packets": "number of multipoint communications received by the interface in packets",
-	"tx_broadcast_bytes":   "number of multipoint communications transmitted by the interface in bytes",
-	"rx_broadcast_bytes":   "number of multipoint communications received by the interface in bytes",
-
-	"tx_unicast_packets": "number of point-to-point communications transmitted by the interface in packets",
-	"rx_unicast_packets": "number of point-to-point communications received by the interface in packets",
-	"tx_unicast_bytes":   "number of point-to-point communications transmitted by the interface in bytes",
-	"rx_unicast_bytes":   "number of point-to-point communications received by the interface in bytes",
-
-	"tx_multicast_packets": "number of one-to-many communications transmitted by the interface in packets",
-	"rx_multicast_packets": "number of one-to-many communications received by the interface in packets",
-	"tx_multicast_bytes":   "number of one-to-many communications transmitted by the interface in bytes",
-	"rx_multicast_bytes":   "number of one-to-many communications received by the interface in bytes",
-
-	"rx_error": "total number of erroneous received packets",
-	"tx_error": "total number of erroneous transmitted packets",
-
-	"rx_miss": "total of rx packets dropped because there are no available buffer",
-	"tx_miss": "total of tx packets dropped because there are no available buffer",
-
-	"rx_no_buf": "total number of rx mbuf allocation failures",
-	"tx_no_buf": "total number of tx mbuf allocation failures",
-}
-
-func (s *Server) exportMetricsForStat(names []string, sta adapter.StatEntry, ifNames adapter.NameStat, pe *prometheusExporter.Exporter) error {
-	for k, name := range names {
-		description, ok := descriptions[name]
-		if !ok {
-			description = name + " of interface"
-		}
-		metric := &metricspb.Metric{
-			MetricDescriptor: &metricspb.MetricDescriptor{
-				Name:        name,
-				Unit:        "",
-				Description: description,
-				LabelKeys: []*metricspb.LabelKey{
-					{Key: "worker", Description: "VPP worker index"},
-					{Key: "namespace", Description: "Kubernetes namespace of the pod"},
-					{Key: "podName", Description: "Name of the pod"},
-					{Key: "nameInPod", Description: "Name of interface in the pod"},
-				},
-			},
-			Timeseries: []*metricspb.TimeSeries{},
-		}
-		s.lock.Lock()
-		if sta.Type == adapter.SimpleCounterVector {
-			values, ok := sta.Data.(adapter.SimpleCounterStat)
-			if !ok {
-				return fmt.Errorf("sta.Data is not a (adapter.SimpleCounterStat), %v", sta.Data)
-			}
-			for worker := range values {
-				for ifIdx := range values[worker] {
-					if string(ifNames[ifIdx]) != "" {
-						if pod, ok := s.podInterfacesBySwifIndex[uint32(ifIdx)]; ok {
-							metric.Timeseries = append(metric.Timeseries, getTimeSeries(worker, pod, float64(values[worker][ifIdx])))
-						}
-					}
-				}
-			}
-		} else if sta.Type == adapter.CombinedCounterVector {
-			metric.MetricDescriptor.Unit = units[k]
-			values, ok := sta.Data.(adapter.CombinedCounterStat)
-			if !ok {
-				return fmt.Errorf("sta.Data is not a (adapter.CombinedCounterStat), %v", sta.Data)
-			}
-			for worker := range values {
-				for ifIdx := range values[worker] {
-					if string(ifNames[ifIdx]) != "" {
-						if pod, ok := s.podInterfacesBySwifIndex[uint32(ifIdx)]; ok {
-							metric.Timeseries = append(metric.Timeseries, getTimeSeries(worker, pod, float64(values[worker][ifIdx][k])))
-						}
-					}
-				}
-			}
-		}
-		s.lock.Unlock()
-		// empty timeseries prevents exporter from updating
-		if len(metric.Timeseries) == 0 {
-			metric.Timeseries = []*metricspb.TimeSeries{{}}
-		}
-		err := pe.ExportMetric(context.Background(), nil, nil, metric)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func getTimeSeries(worker int, pod storage.LocalPodSpec, value float64) *metricspb.TimeSeries {
-	return &metricspb.TimeSeries{
-		LabelValues: []*metricspb.LabelValue{
-			{Value: strconv.Itoa(worker)},
-			{Value: pod.WorkloadID[:strings.Index(pod.WorkloadID, "/")]},
-			{Value: pod.WorkloadID[strings.Index(pod.WorkloadID, "/")+1:]},
-			{Value: pod.InterfaceName},
+	mux.Handle("/metrics", exporter)
+	server := &PrometheusServer{
+		log:                             log,
+		vpp:                             vpp,
+		channel:                         make(chan common.CalicoVppEvent, 10),
+		podInterfacesByKey:              make(map[string]storage.LocalPodSpec),
+		podInterfacesDetailsBySwifIndex: make(map[uint32]podInterfaceDetails),
+		statsclient:                     statsclient.NewStatsClient("" /* default socket name */),
+		httpServer: &http.Server{
+			Addr:    config.GetCalicoVppInitialConfig().PrometheusListenEndpoint,
+			Handler: mux,
 		},
-		Points: []*metricspb.Point{
-			{
-				Value: &metricspb.Point_DoubleValue{
-					DoubleValue: value,
-				},
-			},
-		},
+		exporter: exporter,
 	}
-}
 
-func NewPrometheusServer(vpp *vpplink.VppLink, l *logrus.Entry) *Server {
-	server := &Server{
-		log:                      l,
-		vpp:                      vpp,
-		channel:                  make(chan common.CalicoVppEvent, 10),
-		podInterfacesByKey:       make(map[string]storage.LocalPodSpec),
-		podInterfacesBySwifIndex: make(map[uint32]storage.LocalPodSpec),
-	}
 	if *config.GetCalicoVppFeatureGates().PrometheusEnabled {
 		reg := common.RegisterHandler(server.channel, "prometheus events")
 		reg.ExpectEvents(common.PodAdded, common.PodDeleted)
@@ -217,57 +83,228 @@ func NewPrometheusServer(vpp *vpplink.VppLink, l *logrus.Entry) *Server {
 	return server
 }
 
-func (s *Server) ServePrometheus(t *tomb.Tomb) error {
+func cleanVppStatName(vppStatName string) string {
+	vppStatName = strings.TrimPrefix(vppStatName, "/if/")
+	vppStatName = strings.Replace(vppStatName, "-", "_", -1)
+	return vppStatName
+}
+
+func getVppStatDescription(vppStatName string) string {
+	switch cleanVppStatName(vppStatName) {
+	case "drops":
+		return "number of drops on interface"
+	case "ip4":
+		return "IPv4 received packets"
+	case "ip6":
+		return "IPv6 received packets"
+	case "punt":
+		return "number of punts on interface"
+	case "rx_bytes":
+		return "total number of bytes received over the interface"
+	case "tx_bytes":
+		return "total number of bytes transmitted by the interface"
+	case "rx_packets":
+		return "total number of packets received over the interface"
+	case "tx_packets":
+		return "total number of packets transmitted by the interface"
+	case "tx_broadcast_packets":
+		return "number of multipoint communications transmitted by the interface in packets"
+	case "rx_broadcast_packets":
+		return "number of multipoint communications received by the interface in packets"
+	case "tx_broadcast_bytes":
+		return "number of multipoint communications transmitted by the interface in bytes"
+	case "rx_broadcast_bytes":
+		return "number of multipoint communications received by the interface in bytes"
+	case "tx_unicast_packets":
+		return "number of point-to-point communications transmitted by the interface in packets"
+	case "rx_unicast_packets":
+		return "number of point-to-point communications received by the interface in packets"
+	case "tx_unicast_bytes":
+		return "number of point-to-point communications transmitted by the interface in bytes"
+	case "rx_unicast_bytes":
+		return "number of point-to-point communications received by the interface in bytes"
+	case "tx_multicast_packets":
+		return "number of one-to-many communications transmitted by the interface in packets"
+	case "rx_multicast_packets":
+		return "number of one-to-many communications received by the interface in packets"
+	case "tx_multicast_bytes":
+		return "number of one-to-many communications transmitted by the interface in bytes"
+	case "rx_multicast_bytes":
+		return "number of one-to-many communications received by the interface in bytes"
+	case "rx_error":
+		return "total number of erroneous received packets"
+	case "tx_error":
+		return "total number of erroneous transmitted packets"
+	case "rx_miss":
+		return "total of rx packets dropped because there are no available buffer"
+	case "tx_miss":
+		return "total of tx packets dropped because there are no available buffer"
+	case "rx_no_buf":
+		return "total number of rx mbuf allocation failures"
+	case "tx_no_buf":
+		return "total number of tx mbuf allocation failures"
+	default:
+		return vppStatName
+	}
+}
+
+func (self *PrometheusServer) exportMetrics() error {
+	vppStats, err := self.statsclient.DumpStats("/if/")
+	if err != nil {
+		self.log.Errorf("Error running statsclient.DumpStats %v", err)
+		return nil
+	}
+	var ifNames adapter.NameStat
+	for _, vppStat := range vppStats {
+		switch values := vppStat.Data.(type) {
+		case adapter.NameStat:
+			ifNames = values
+		}
+	}
+
+	self.lock.Lock()
+	for _, vppStat := range vppStats {
+		switch values := vppStat.Data.(type) {
+		case adapter.SimpleCounterStat:
+			for worker, perWorkerValues := range values {
+				for swIfIndex, counter := range perWorkerValues {
+					self.exportInterfaceMetric(string(vppStat.Name), worker, swIfIndex, ifNames, uint64(counter), "")
+				}
+			}
+		case adapter.CombinedCounterStat:
+			for worker, perWorkerValues := range values {
+				for swIfIndex, counter := range perWorkerValues {
+					self.exportInterfaceMetric(string(vppStat.Name)+"_packets", worker, swIfIndex, ifNames, counter[0], "packets")
+					self.exportInterfaceMetric(string(vppStat.Name)+"_bytes", worker, swIfIndex, ifNames, counter[1], "bytes")
+				}
+			}
+		}
+	}
+	self.lock.Unlock()
+	return nil
+}
+
+func (self *PrometheusServer) exportInterfaceMetric(name string, worker int, swIfIndex int, ifNames adapter.NameStat, value uint64, unit string) {
+	pod := self.podInterfacesDetailsBySwifIndex[uint32(swIfIndex)]
+	vppIfName := ""
+	if swIfIndex < len(ifNames) {
+		vppIfName = string(ifNames[swIfIndex])
+	}
+	err := self.exporter.ExportMetric(
+		context.Background(),
+		nil, /* node */
+		nil, /* resource */
+		&metricspb.Metric{
+			MetricDescriptor: &metricspb.MetricDescriptor{
+				Name:        cleanVppStatName(name),
+				Unit:        unit,
+				Description: getVppStatDescription(name),
+				// empty timeseries prevents exporter from updating
+				LabelKeys: []*metricspb.LabelKey{
+					{Key: "worker", Description: "VPP worker index"},
+					{Key: "namespace", Description: "Kubernetes namespace of the pod"},
+					{Key: "podName", Description: "Name of the pod"},
+					{Key: "podInterfaceName", Description: "Name of interface in the pod"},
+					{Key: "vppInterfaceName", Description: "Name of interface in VPP"},
+				},
+			},
+			Timeseries: []*metricspb.TimeSeries{{
+				LabelValues: []*metricspb.LabelValue{
+					{Value: strconv.Itoa(worker)},
+					{Value: pod.podNamespace},
+					{Value: pod.podName},
+					{Value: pod.interfaceName},
+					{Value: vppIfName},
+				},
+				Points: []*metricspb.Point{
+					{
+						Value: &metricspb.Point_DoubleValue{
+							DoubleValue: float64(value),
+						},
+					},
+				},
+			}},
+		},
+	)
+	if err != nil {
+		self.log.Errorf("Error prometheus exporter.ExportMetric %v", err)
+	}
+}
+
+func (self *PrometheusServer) ServePrometheus(t *tomb.Tomb) error {
 	if !(*config.GetCalicoVppFeatureGates().PrometheusEnabled) {
 		return nil
 	}
-
-	s.log.Infof("Serve() Prometheus exporter")
+	self.log.Infof("Serve() Prometheus exporter")
 	go func() {
 		for t.Alive() {
 			/* Note: we will only receive events we ask for when registering the chan */
-			evt := <-s.channel
+			evt := <-self.channel
 			switch evt.Type {
 			case common.PodAdded:
 				podSpec, ok := evt.New.(*storage.LocalPodSpec)
 				if !ok {
-					s.log.Errorf("evt.New is not a *storage.LocalPodSpec %v", evt.New)
+					self.log.Errorf("evt.New is not a *storage.LocalPodSpec %v", evt.New)
 					continue
 				}
-				s.lock.Lock()
-				if podSpec.TunTapSwIfIndex == vpplink.INVALID_SW_IF_INDEX {
-					s.podInterfacesBySwifIndex[podSpec.MemifSwIfIndex] = *podSpec
-				} else {
-					s.podInterfacesBySwifIndex[podSpec.TunTapSwIfIndex] = *podSpec
+				splittedWorkloadId := strings.SplitN(podSpec.WorkloadID, "/", 2)
+				if len(splittedWorkloadId) != 2 {
+					continue
 				}
-				s.podInterfacesByKey[podSpec.Key()] = *podSpec
-				s.lock.Unlock()
+				self.lock.Lock()
+				if podSpec.TunTapSwIfIndex == vpplink.INVALID_SW_IF_INDEX {
+					memifName := podSpec.InterfaceName
+					if podSpec.NetworkName == "" {
+						memifName = "vpp/memif-" + podSpec.InterfaceName
+					}
+					self.podInterfacesDetailsBySwifIndex[podSpec.MemifSwIfIndex] = podInterfaceDetails{
+						podNamespace:  splittedWorkloadId[0],
+						podName:       splittedWorkloadId[1],
+						interfaceName: memifName,
+					}
+				} else {
+					self.podInterfacesDetailsBySwifIndex[podSpec.TunTapSwIfIndex] = podInterfaceDetails{
+						podNamespace:  splittedWorkloadId[0],
+						podName:       splittedWorkloadId[1],
+						interfaceName: podSpec.InterfaceName,
+					}
+				}
+				self.podInterfacesByKey[podSpec.Key()] = *podSpec
+				self.lock.Unlock()
 			case common.PodDeleted:
-				s.lock.Lock()
+				self.lock.Lock()
 				podSpec, ok := evt.Old.(*storage.LocalPodSpec)
 				if !ok {
-					s.log.Errorf("evt.Old is not a *storage.LocalPodSpec %v", evt.Old)
+					self.log.Errorf("evt.Old is not a *storage.LocalPodSpec %v", evt.Old)
 					continue
 				}
-				initialPod := s.podInterfacesByKey[podSpec.Key()]
-				delete(s.podInterfacesByKey, initialPod.Key())
+				initialPod := self.podInterfacesByKey[podSpec.Key()]
+				delete(self.podInterfacesByKey, initialPod.Key())
 				if podSpec.TunTapSwIfIndex == vpplink.INVALID_SW_IF_INDEX {
-					delete(s.podInterfacesBySwifIndex, initialPod.MemifSwIfIndex)
+					delete(self.podInterfacesDetailsBySwifIndex, initialPod.MemifSwIfIndex)
 				} else {
-					delete(s.podInterfacesBySwifIndex, initialPod.TunTapSwIfIndex)
+					delete(self.podInterfacesDetailsBySwifIndex, initialPod.TunTapSwIfIndex)
 				}
-				s.lock.Unlock()
+				self.lock.Unlock()
 			}
 		}
 	}()
-	s.sc = statsclient.NewStatsClient("")
-	err := s.sc.Connect()
+	err := self.statsclient.Connect()
 	if err != nil {
 		return errors.Wrap(err, "could not connect statsclient")
 	}
-	s.recordMetrics(t)
 
-	s.log.Warn("Prometheus Server returned")
+	go self.httpServer.ListenAndServe()
+	ticker := time.NewTicker(*config.GetCalicoVppInitialConfig().PrometheusRecordMetricInterval)
+	for ; t.Alive(); <-ticker.C {
+		self.exportMetrics()
+	}
+	ticker.Stop()
+	self.log.Warn("Prometheus Server returned")
+	err = self.httpServer.Shutdown(context.Background())
+	if err != nil {
+		return errors.Wrap(err, "Could not shutdown http server")
+	}
 
 	return nil
 }

--- a/calico-vpp-agent/watchers/bgpfilter_watcher.go
+++ b/calico-vpp-agent/watchers/bgpfilter_watcher.go
@@ -71,14 +71,23 @@ func (w *BGPFilterWatcher) WatchBGPFilters(t *tomb.Tomb) error {
 					w.log.Debug("BGPFilter watch returned, restarting...")
 					goto restart
 				case watch.EventType(api.WatchModified):
-					filter := *event.Object.(*calicov3.BGPFilter)
-					w.UpdateFilter(filter)
+					filter, ok := event.Object.(*calicov3.BGPFilter)
+					if !ok || filter == nil {
+						w.log.Fatal("api.WatchModified Object is not BGPFilter or is nil")
+					}
+					w.UpdateFilter(*filter)
 				case watch.EventType(api.WatchAdded):
-					filter := *event.Object.(*calicov3.BGPFilter)
-					w.AddNewFilter(filter)
+					filter, ok := event.Object.(*calicov3.BGPFilter)
+					if !ok || filter == nil {
+						w.log.Fatal("api.WatchAdded	 Object is not BGPFilter or is nil")
+					}
+					w.AddNewFilter(*filter)
 				case watch.EventType(api.WatchDeleted):
-					filter := *event.Previous.(*calicov3.BGPFilter)
-					w.RemoveFilter(filter)
+					filter, ok := event.Previous.(*calicov3.BGPFilter)
+					if !ok || filter == nil {
+						w.log.Fatal("api.WatchDeleted Previous is not BGPFilter or is nil")
+					}
+					w.RemoveFilter(*filter)
 				}
 			}
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -302,11 +302,12 @@ func (self *CalicoVppDebugConfigType) Validate() (err error) {
 }
 
 type CalicoVppFeatureGatesConfigType struct {
-	MemifEnabled    *bool `json:"memifEnabled,omitempty"`
-	VCLEnabled      *bool `json:"vclEnabled,omitempty"`
-	MultinetEnabled *bool `json:"multinetEnabled,omitempty"`
-	SRv6Enabled     *bool `json:"srv6Enabled,omitempty"`
-	IPSecEnabled    *bool `json:"ipsecEnabled,omitempty"`
+	MemifEnabled      *bool `json:"memifEnabled,omitempty"`
+	VCLEnabled        *bool `json:"vclEnabled,omitempty"`
+	MultinetEnabled   *bool `json:"multinetEnabled,omitempty"`
+	SRv6Enabled       *bool `json:"srv6Enabled,omitempty"`
+	IPSecEnabled      *bool `json:"ipsecEnabled,omitempty"`
+	PrometheusEnabled *bool `json:"prometheusEnabled,omitempty"`
 }
 
 func (self *CalicoVppFeatureGatesConfigType) Validate() (err error) {
@@ -315,6 +316,7 @@ func (self *CalicoVppFeatureGatesConfigType) Validate() (err error) {
 	self.MultinetEnabled = DefaultToPtr(self.MultinetEnabled, false)
 	self.SRv6Enabled = DefaultToPtr(self.SRv6Enabled, false)
 	self.IPSecEnabled = DefaultToPtr(self.IPSecEnabled, false)
+	self.PrometheusEnabled = DefaultToPtr(self.PrometheusEnabled, false)
 	return nil
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -406,17 +406,35 @@ func (self *CalicoVppInterfacesConfigType) String() string {
 
 type CalicoVppInitialConfigConfigType struct { //out of agent and vppmanager
 	VppStartupSleepSeconds int `json:"vppStartupSleepSeconds"`
-	/* Set the pattern for VPP corefiles. Usually "/var/lib/vpp/vppcore.%e.%p" */
+	// CorePattern is the pattern to use for VPP corefiles.
+	// Usually "/var/lib/vpp/vppcore.%e.%p"
 	CorePattern      string `json:"corePattern"`
 	ExtraAddrCount   int    `json:"extraAddrCount"`
 	IfConfigSavePath string `json:"ifConfigSavePath"`
-	/* Comma separated list of IPs to be configured in VPP as default GW */
+	// DefaultGWs Comma separated list of IPs to be
+	// configured in VPP as default GW
 	DefaultGWs string `json:"defaultGWs"`
-	/* List of rules for redirecting traffic to host */
+	// RedirectToHostRules is a list of rules for redirecting
+	// traffic to host. This is used for DNS support in kind
 	RedirectToHostRules []RedirectToHostRulesConfigType `json:"redirectToHostRules"`
+	// PrometheusListenEndpoint is the endpoint on which prometheus will
+	// listen and report stats. By default curl http://localhost:8888/metrics
+	PrometheusListenEndpoint string `json:"prometheusListenEndpoint"`
+	// PrometheusRecordMetricInterval is the interval at which we update the
+	// prometheus stats polling VPP stats segment. Default to 5 seconds
+	PrometheusRecordMetricInterval *time.Duration `json:"prometheusRecordMetricInterval"`
 }
 
-func (self *CalicoVppInitialConfigConfigType) Validate() (err error) { return nil }
+func (self *CalicoVppInitialConfigConfigType) Validate() (err error) {
+	if self.PrometheusListenEndpoint == "" {
+		self.PrometheusListenEndpoint = ":8888"
+	}
+	if self.PrometheusRecordMetricInterval == nil {
+		prometheusRecordMetricInterval := 5 * time.Second
+		self.PrometheusRecordMetricInterval = &prometheusRecordMetricInterval
+	}
+	return nil
+}
 func (self *CalicoVppInitialConfigConfigType) GetDefaultGWs() (gws []net.IP, err error) {
 	gws = make([]net.IP, 0)
 	if self.DefaultGWs != "" {

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/projectcalico/vpp-dataplane/v3
 
-go 1.22.7
-toolchain go1.23.2
+go 1.23.0
 
 require (
 	github.com/calico-vpp/vpplink v0.1.0

--- a/vpplink/stats.go
+++ b/vpplink/stats.go
@@ -18,32 +18,8 @@ package vpplink
 import (
 	"fmt"
 
-	"go.fd.io/govpp/adapter"
-	"go.fd.io/govpp/adapter/statsclient"
-
 	interfaces "github.com/projectcalico/vpp-dataplane/v3/vpplink/generated/bindings/interface"
 )
-
-func GetInterfaceStats(sc *statsclient.StatsClient) (ifNames adapter.NameStat, dumpStats []adapter.StatEntry, err error) {
-
-	dumpStatsNames, err := sc.DumpStats("/if/names")
-	if err != nil {
-		return nil, nil, fmt.Errorf("dump stats failed: %w", err)
-	}
-	if len(dumpStatsNames) == 0 {
-		return nil, nil, fmt.Errorf("no interfaces available: %w", err)
-	}
-	ifNames, ok := dumpStatsNames[0].Data.(adapter.NameStat)
-	if !ok {
-		return nil, nil, fmt.Errorf("dumpStatsNames[0].Data. is not an adapter.NameStat: %v", dumpStatsNames[0].Data)
-	}
-
-	dumpStats, err = sc.DumpStats("/if/")
-	if err != nil {
-		return nil, nil, fmt.Errorf("dump stats failed: %w", err)
-	}
-	return ifNames, dumpStats, nil
-}
 
 func (v *VppLink) GetBufferStats() (available uint32, cached uint32, used uint32, err error) {
 	client := interfaces.NewServiceClient(v.GetConnection())


### PR DESCRIPTION
This patch refactors the Prometheus exporter code.
This should prevent the occurrence of race conditions where interfaces are
deleted while the controlplane is running and indexes are off.

Additionally, this adds supports for displaying VPP side interface names and
properly tagging memifs (displaying the name of the abstract socket)
