### PR TITLE
[CORE-11082] Ensure kube-proxy deployment in Openshift

### DIFF
--- a/yaml/platforms/openshift/01-configmap-kubernetes-services-endpoint.yaml
+++ b/yaml/platforms/openshift/01-configmap-kubernetes-services-endpoint.yaml
@@ -1,0 +1,13 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: kubernetes-services-endpoint
+  namespace: tigera-operator
+data:
+# This ConfigMap sets the Kubernetes API server endpoint, required when 
+# installing Calico on OpenShift with eBPF dataplane.
+# If you are installing Calico on OpenShift with the Iptables dataplane, you can leave it commented.
+  
+#  KUBERNETES_SERVICE_HOST: "api.<cluster_name>.<base_domain>"
+#  KUBERNETES_SERVICE_PORT: "6443"
+

--- a/yaml/platforms/openshift/cluster-network-operator.yaml
+++ b/yaml/platforms/openshift/cluster-network-operator.yaml
@@ -1,0 +1,9 @@
+apiVersion: operator.openshift.io/v1
+kind: Network
+metadata:
+  name: cluster
+spec:
+# The eBPF dataplane doesn't require the kube-proxy to be deployed.
+# If you changed the linuxDataplane to Iptables, the deployKubeProxy parameter has to be changed to true.
+  deployKubeProxy: true
+status: {}


### PR DESCRIPTION
Including manifests to ensure `kube-proxy` deployment and comment out unnecessary ConfigMap.