### PR TITLE
Add auto corepining path

### DIFF
--- a/docs/corepinning.md
+++ b/docs/corepinning.md
@@ -1,0 +1,22 @@
+# Core Pinning for Calico/VPP
+
+This patch adds support in VPP for pinning workers to the CPU
+cores that are assigned by a static allocator.
+
+When kubernetes is configured to run with a [static allocator](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#static-policy
+) and that VPP starts with requests.CPU equal to limits.CPU
+and both integer numbers.
+
+having VPP configured with
+
+```console
+cpu {
+   main-core 0
+   corelist-workers 2-3
+   relative
+}
+```
+
+Will make it so that numbers 0,2,3 do not refer to absolutes CPU
+IDs but to the 0th, 2nd and 3rd CPU of those allotted by the static
+core allocator in kubernetes.

--- a/vpplink/generated/generate.log
+++ b/vpplink/generated/generate.log
@@ -1,4 +1,4 @@
-VPP Version                 : 24.10.0-7~ga51f8b435
+VPP Version                 : 24.10.0-8~gdb2d5b615
 Binapi-generator version    : v0.11.0
 VPP Base commit             : b91e15387 misc: Initial changes for stable/2410 branch
 ------------------ Cherry picked commits --------------------
@@ -8,6 +8,7 @@ acl: acl-plugin custom policies
 cnat: [WIP] no k8s maglev from pods
 pbl: Port based balancer
 gerrit:revert:39675/5 Revert "ip-neighbor: do not use sas to determine NS source address"
+gerrit:41094/24 vlib: add 'relative' keyword for cpu configuration
 gerrit:34726/3 interface: add buffer stats api
 misc: VPP 24.10 Release Notes
 build: fix dpdk mellanox driver build setting

--- a/vpplink/generated/vpp_clone_current.sh
+++ b/vpplink/generated/vpp_clone_current.sh
@@ -96,6 +96,7 @@ function git_clone_cd_and_reset ()
 git_clone_cd_and_reset "$1" cfa0953251cbab435307baf3dcd249fd95afaf1f # misc: VPP 24.10 Release Notes
 
 git_cherry_pick refs/changes/26/34726/3 # 34726: interface: add buffer stats api | https://gerrit.fd.io/r/c/vpp/+/34726
+git_cherry_pick refs/changes/94/41094/24 # 41094: vlib: improve core pinning | https://gerrit.fd.io/r/c/vpp/+/41094
 
 # This is the commit which broke IPv6 from v3.28.0 onwards.
 git_revert refs/changes/75/39675/5  # ip-neighbor: do not use sas to determine NS source address


### PR DESCRIPTION
This patch adds support in VPP for pinning workers to the CPU cores that are assigned by a static allocator.

When k8s is configured to run with a static allocator [0] and that VPP starts with requests.CPU equal to limits.CPU and both integer numbers.

having VPP configured with
```
cpu {
   main-core 0
   corelist-workers 2-3
   relative
}
```

Will make it so that numbers 0,2,3 do not refer to absolutes CPU IDs but to the 0th, 2nd and 3rd CPU of those allotted by the static core allocator in k8s.

[0] https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#static-policy