### PR TITLE
add makefile target to build VPP from master

### DIFF
--- a/docs/developper_guide.md
+++ b/docs/developper_guide.md
@@ -24,6 +24,10 @@ First you will need to build vpp locally with the required patches. This takes a
 ````bash
 make -C vpp-manager/ vpp
 ````
+or
+````bash
+make -C vpp-manager/ vpp-master
+````
 
 Then build the agents, containers & push them to the local docker repository
 ````bash

--- a/vpp-manager/Makefile
+++ b/vpp-manager/Makefile
@@ -78,6 +78,9 @@ clean: clean-vpp
 clone-vpp:
 	bash $(VPPLINK_DIR)/generated/vpp_clone_current.sh ./vpp_build
 
+clone-vpp-master:
+	bash $(VPPLINK_DIR)/generated/vpp_clone_current.sh ./vpp_build master
+
 clean-vpp:
 	git -C vpp_build clean -ffdx || true
 	rm -f ./vpp_build/build-root/*.deb
@@ -90,6 +93,10 @@ rebuild-vpp: vpp-build-env
 		-v $(CURDIR):$(CURDIR):delegated \
 		--user $$(id -u):$$(id -g) \
 		--env NO_BUILD_DEBS=true \
+		--env HTTP_PROXY=$(HTTP_PROXY) \
+		--env HTTPS_PROXY=$(HTTPS_PROXY) \
+		--env http_proxy=$(http_proxy) \
+		--env https_proxy=$(https_proxy) \
 		--network=host \
 		calicovpp/vpp-build:latest
 
@@ -99,6 +106,10 @@ vpp: clone-vpp clean-vpp vpp-build-env
 		-v $(CURDIR):$(CURDIR):delegated \
 		--user $$(id -u):$$(id -g) \
 		--network=host \
+		--env HTTP_PROXY=$(HTTP_PROXY) \
+		--env HTTPS_PROXY=$(HTTPS_PROXY) \
+		--env http_proxy=$(http_proxy) \
+		--env https_proxy=$(https_proxy) \
 		calicovpp/vpp-build:latest
 	for pkg in vpp vpp-plugin-core vpp-plugin-dpdk libvppinfra vpp-dbg ; do \
 		cp vpp_build/build-root/$$pkg_*.deb $(IMAGE_DIR) ; \
@@ -107,6 +118,21 @@ ifdef CI_BUILD
 	find $(IMAGE_DIR) -type f -name '*.deb' -printf "%P\n"  | tar -czvf ${VPP_TARBALL} -C $(IMAGE_DIR) -T -
 	aws s3api put-object --bucket ${VPP_BUCKET} --key ${VPP_TARBALL} --body ${VPP_TARBALL}
 endif
+
+vpp-master: clone-vpp-master clean-vpp vpp-build-env
+	docker run --rm \
+		-e VPP_MGR_DIR=$(CURDIR) \
+		-v $(CURDIR):$(CURDIR):delegated \
+		--user $$(id -u):$$(id -g) \
+		--network=host \
+		--env HTTP_PROXY=$(HTTP_PROXY) \
+		--env HTTPS_PROXY=$(HTTPS_PROXY) \
+		--env http_proxy=$(http_proxy) \
+		--env https_proxy=$(https_proxy) \
+		calicovpp/vpp-build:latest
+	for pkg in vpp vpp-plugin-core vpp-plugin-dpdk libvppinfra vpp-dbg ; do \
+		cp vpp_build/build-root/$$pkg_*.deb $(IMAGE_DIR) ; \
+	done
 
 ${VPP_TARBALL}:
 ifdef CI_BUILD

--- a/vpplink/generated/vpp_clone_current.sh
+++ b/vpplink/generated/vpp_clone_current.sh
@@ -83,17 +83,23 @@ function git_clone_cd_and_reset ()
 		git clone "https://gerrit.fd.io/r/vpp" $VPP_DIR
 	fi
 	cd $VPP_DIR
-	if ! $(commit_exists $VPP_COMMIT); then
-		green "Fetching most recent VPP..."
-		git fetch "https://gerrit.fd.io/r/vpp"
+	if [ $VPP_COMMIT = "master" ]; then
+		git reset --hard origin/master
+		git pull
+	else
+		if ! $(commit_exists $VPP_COMMIT); then
+			green "Fetching most recent VPP..."
+			git fetch "https://gerrit.fd.io/r/vpp"
+		fi
+		git reset --hard ${VPP_COMMIT}
 	fi
-	git reset --hard ${VPP_COMMIT}
 }
 
 # --------------- Things to cherry pick ---------------
 
 # VPP latest commit as on 12/May/2025
-git_clone_cd_and_reset "$1" 5a1d844511e497dd72cbc8a56db97dfe1a4645ef # dev: enable flow on primary interface
+MASTER_OR_COMMIT="${2:-"5a1d844511e497dd72cbc8a56db97dfe1a4645ef"}" # dev: enable flow on primary interface
+git_clone_cd_and_reset "$1" $MASTER_OR_COMMIT
 
 git_cherry_pick refs/changes/26/34726/3 # 34726: interface: add buffer stats api | https://gerrit.fd.io/r/c/vpp/+/34726
 


### PR DESCRIPTION
Added new targets and modified the vpp_clone_current.sh script so we can build and test latest VPP. Also added proxy env variables to some 'docker run' commands to stop containers from timing out in Cisco labs.