### PR TITLE
add makefile target to build VPP from master

### DIFF
--- a/docs/developper_guide.md
+++ b/docs/developper_guide.md
@@ -24,6 +24,11 @@ First you will need to build vpp locally with the required patches. This takes a
 ````bash
 make -C vpp-manager/ vpp
 ````
+or
+
+````bash
+make -C vpp-manager/ vpp BASE=origin/master
+````
 
 Then build the agents, containers & push them to the local docker repository
 ````bash

--- a/vpp-manager/Makefile
+++ b/vpp-manager/Makefile
@@ -76,7 +76,7 @@ imageonly: build
 clean: clean-vpp
 
 clone-vpp:
-	bash $(VPPLINK_DIR)/generated/vpp_clone_current.sh ./vpp_build
+	BASE=$(BASE) bash $(VPPLINK_DIR)/generated/vpp_clone_current.sh ./vpp_build
 
 clean-vpp:
 	git -C vpp_build clean -ffdx || true
@@ -90,6 +90,10 @@ rebuild-vpp: vpp-build-env
 		-v $(CURDIR):$(CURDIR):delegated \
 		--user $$(id -u):$$(id -g) \
 		--env NO_BUILD_DEBS=true \
+		--env HTTP_PROXY=$(HTTP_PROXY) \
+		--env HTTPS_PROXY=$(HTTPS_PROXY) \
+		--env http_proxy=$(http_proxy) \
+		--env https_proxy=$(https_proxy) \
 		--network=host \
 		calicovpp/vpp-build:latest
 
@@ -99,6 +103,10 @@ vpp: clone-vpp clean-vpp vpp-build-env
 		-v $(CURDIR):$(CURDIR):delegated \
 		--user $$(id -u):$$(id -g) \
 		--network=host \
+		--env HTTP_PROXY=$(HTTP_PROXY) \
+		--env HTTPS_PROXY=$(HTTPS_PROXY) \
+		--env http_proxy=$(http_proxy) \
+		--env https_proxy=$(https_proxy) \
 		calicovpp/vpp-build:latest
 	for pkg in vpp vpp-plugin-core vpp-plugin-dpdk libvppinfra vpp-dbg ; do \
 		cp vpp_build/build-root/$$pkg_*.deb $(IMAGE_DIR) ; \

--- a/vpplink/generated/vpp_clone_current.sh
+++ b/vpplink/generated/vpp_clone_current.sh
@@ -93,7 +93,8 @@ function git_clone_cd_and_reset ()
 # --------------- Things to cherry pick ---------------
 
 # VPP latest commit as on 12/May/2025
-git_clone_cd_and_reset "$1" 5a1d844511e497dd72cbc8a56db97dfe1a4645ef # dev: enable flow on primary interface
+BASE="${BASE:-"5a1d844511e497dd72cbc8a56db97dfe1a4645ef"}" # dev: enable flow on primary interface
+git_clone_cd_and_reset "$1" ${BASE}
 
 git_cherry_pick refs/changes/26/34726/3 # 34726: interface: add buffer stats api | https://gerrit.fd.io/r/c/vpp/+/34726
 


### PR DESCRIPTION
Added new targets and modified the vpp_clone_current.sh script so we can build and test latest VPP. Also added proxy env variables to some 'docker run' commands to stop containers from timing out in Cisco labs.