### PR TITLE
fix auto hep behavior

### DIFF
--- a/calico-vpp-agent/felix/host_endpoint.go
+++ b/calico-vpp-agent/felix/host_endpoint.go
@@ -176,13 +176,13 @@ func (h *HostEndpoint) getTapPolicies(state *PolicyState) (conf *types.Interface
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot create host policies for TapConf")
 	}
-	if len(conf.IngressPolicyIDs) > 0 {
-		conf.IngressPolicyIDs = append(conf.IngressPolicyIDs, h.server.workloadsToHostPolicy.VppID)
+	if len(conf.IngressPolicyIDs) > 0 || len(conf.ProfileIDs) == 0 {
 		conf.IngressPolicyIDs = append([]uint32{h.server.failSafePolicy.VppID}, conf.IngressPolicyIDs...)
+		conf.IngressPolicyIDs = append([]uint32{h.server.workloadsToHostPolicy.VppID}, conf.IngressPolicyIDs...)
 	}
-	if len(conf.EgressPolicyIDs) > 0 {
-		conf.EgressPolicyIDs = append([]uint32{h.server.AllowFromHostPolicy.VppID}, conf.EgressPolicyIDs...)
+	if len(conf.EgressPolicyIDs) > 0 || len(conf.ProfileIDs) == 0 {
 		conf.EgressPolicyIDs = append([]uint32{h.server.failSafePolicy.VppID}, conf.EgressPolicyIDs...)
+		conf.EgressPolicyIDs = append([]uint32{h.server.AllowFromHostPolicy.VppID}, conf.EgressPolicyIDs...)
 	}
 	return conf, nil
 }


### PR DESCRIPTION
a normal hep is expected to deny all traffic if no policies are specified that is not the case for an auto hep, as it should allow all traffic using the default allow profile. Here we remove the implicit deny all policy in the case of an auto hep.

this also adds the behavior: empty (non auto) hep should deny all.
And fixes the order of Failsafe rules and other rules that have a higher priority.