### PR TITLE
Add IP neighbor 30s aging v3.26.2-rc0

### DIFF
--- a/.ci/Dockerfile.depend
+++ b/.ci/Dockerfile.depend
@@ -3,7 +3,7 @@ ARG BASE_IMAGE
 #
 # Dependencies image
 #
-FROM ${BASE_IMAGE} as dependencies
+FROM ${BASE_IMAGE:-ubuntu:22.04} AS dependencies
 
 ENV UNATTENDED=y
 
@@ -11,7 +11,7 @@ RUN apt-get update \
  && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
     apt-utils wget cmake curl git
 
-ENV GOVERSION=1.18.2
+ENV GOVERSION=1.24.0
 ENV GOROOT="/root/.go"
 ENV GOPATH="/root/go"
 ENV PATH=$GOROOT/bin:$PATH
@@ -22,9 +22,14 @@ RUN mkdir -p "${GOROOT}" &&\
 RUN wget -nv "https://dl.google.com/go/go${GOVERSION}.linux-amd64.tar.gz" -O "/tmp/go.tar.gz" && \
     tar -C "${GOROOT}" --strip-components=1 -xzf "/tmp/go.tar.gz" && \
     rm -f "/tmp/go.tar.gz" && \
-    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.50.1
+    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.8
+
+RUN git config --global --add safe.directory /vpp-dataplane
 
 # Get modules used by the source code
-COPY . /vpp-dataplane
+RUN mkdir -p /vpp-dataplane
+RUN git config --global --add safe.directory /vpp-dataplane
+COPY go.mod /vpp-dataplane
+COPY go.sum /vpp-dataplane
 WORKDIR /vpp-dataplane
 RUN go get ./... && rm -fr /vpp-dataplane

--- a/.ci/Makefile
+++ b/.ci/Makefile
@@ -13,7 +13,7 @@ ABS_PATH = $(abspath $(shell pwd)/..)
 # remain stable.
 #
 
-BASE_IMAGE_BUILDER = ubuntu:20.04
+BASE_IMAGE_BUILDER = ubuntu:22.04
 
 # Compute hash to detect any changes and rebuild /push the image
 DEPEND_HASH = $(shell echo "${BASE_IMAGE_BUILDER}-DOCKERFILE:$(shell md5sum Dockerfile.depend)" | md5sum | cut -f1 -d' ')

--- a/.ci/common.mk
+++ b/.ci/common.mk
@@ -15,6 +15,8 @@ SQUASH := --squash
 # push dependency
 PUSH_DEP := image
 
+CGO_ENABLED := 0
+
 # CI specific variables
 ifdef CODEBUILD_BUILD_NUMBER
 	# Define variable when building for CI

--- a/calico-vpp-agent/Makefile
+++ b/calico-vpp-agent/Makefile
@@ -25,9 +25,8 @@ build: felix-api-proxy bin
 	${DOCKER_RUN} go build -o ./bin/calico-vpp-agent ./cmd
 	${DOCKER_RUN} go build -o ./bin/debug ./cmd/debug-state
 
-gobgp: GOBGP_DIR:=$(shell ${DOCKER_RUN} go list -f '{{.Dir}}' -m github.com/osrg/gobgp/v3)
 gobgp: bin
-	${DOCKER_RUN} go build -o ./bin/gobgp $(GOBGP_DIR)/cmd/gobgp/
+	${DOCKER_RUN} go build -o ./bin/gobgp github.com/osrg/gobgp/v3/cmd/gobgp/
 
 image: build gobgp
 	@echo "Image tag                   : $(TAG)"                         > $(VERSION_FILE)

--- a/calico-vpp-agent/cni/network_vpp_routes.go
+++ b/calico-vpp-agent/cni/network_vpp_routes.go
@@ -62,6 +62,7 @@ func (s *Server) RoutePodInterface(podSpec *storage.LocalPodSpec, stack *vpplink
 				SwIfIndex:    swIfIndex,
 				IP:           containerIP.IP,
 				HardwareAddr: common.ContainerSideMacAddress,
+				Flags:        types.IPNeighborStatic,
 			})
 			if err != nil {
 				return errors.Wrapf(err, "Error adding neighbor if[%d] %s", swIfIndex, containerIP.IP.String())
@@ -149,6 +150,7 @@ func (s *Server) RoutePblPortsPodInterface(podSpec *storage.LocalPodSpec, stack 
 				SwIfIndex:    swIfIndex,
 				IP:           containerIP.IP,
 				HardwareAddr: common.ContainerSideMacAddress,
+				Flags:        types.IPNeighborStatic,
 			})
 			if err != nil {
 				return errors.Wrapf(err, "Cannot add neighbor if[%d] %s", swIfIndex, containerIP.IP.String())

--- a/config/config.go
+++ b/config/config.go
@@ -427,6 +427,22 @@ type CalicoVppInitialConfigConfigType struct { //out of agent and vppmanager
 	// PrometheusRecordMetricInterval is the interval at which we update the
 	// prometheus stats polling VPP stats segment. Default to 5 seconds
 	PrometheusRecordMetricInterval *time.Duration `json:"prometheusRecordMetricInterval"`
+	// IP4NeighborsMaxNumber is the maximum number of allowed IPv4 neighbors
+	// VPP allows. Defaults to 50k
+	IP4NeighborsMaxNumber *uint32 `json:"ip4NeighborsMaxNumber"`
+	// IP6NeighborsMaxNumber is the maximum number of allowed IPv4 neighbors
+	// VPP allows. Defaults to 50k
+	IP6NeighborsMaxNumber *uint32 `json:"ip6NeighborsMaxNumber"`
+	// IP4NeighborsMaxAge is the maximum age of IPv4 neighbors in seconds
+	// ARPs will be issued after said interval. Be aware ARPs in VPP are
+	// issued using a pre-existing vlib buffer hence dropping a packet
+	// defaults to 30 seconds. Use 0 to disable.
+	IP4NeighborsMaxAge *uint32 `json:"ip4NeighborsMaxAge"`
+	// IP6NeighborsMaxAge is the maximum age of IPv4 neighbors in seconds
+	// ARPs will be issued after said interval. Be aware ARPs in VPP are
+	// issued using a pre-existing vlib buffer hence dropping a packet
+	// defaults to 30 seconds. Use 0 to disable.
+	IP6NeighborsMaxAge *uint32 `json:"ip6NeighborsMaxAge"`
 }
 
 func (self *CalicoVppInitialConfigConfigType) Validate() (err error) {
@@ -437,6 +453,18 @@ func (self *CalicoVppInitialConfigConfigType) Validate() (err error) {
 		prometheusRecordMetricInterval := 5 * time.Second
 		self.PrometheusRecordMetricInterval = &prometheusRecordMetricInterval
 	}
+	self.IP4NeighborsMaxNumber = DefaultToPtr(
+		self.IP4NeighborsMaxNumber, 50000,
+	)
+	self.IP6NeighborsMaxNumber = DefaultToPtr(
+		self.IP6NeighborsMaxNumber, 50000,
+	)
+	self.IP4NeighborsMaxAge = DefaultToPtr(
+		self.IP4NeighborsMaxAge, 30,
+	)
+	self.IP6NeighborsMaxAge = DefaultToPtr(
+		self.IP6NeighborsMaxAge, 30,
+	)
 	return nil
 }
 func (self *CalicoVppInitialConfigConfigType) GetDefaultGWs() (gws []net.IP, err error) {
@@ -711,4 +739,11 @@ func PrintAgentConfig(log *logrus.Logger) {
 		log.Infof("Version info\n%s", versionFileStr)
 	}
 	PrintEnvVarConfig(log)
+}
+
+func DefaultToPtr[T any](ptr *T, defaultV T) *T {
+	if ptr == nil {
+		return &defaultV
+	}
+	return ptr
 }

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/projectcalico/vpp-dataplane/v3
 
 go 1.23.0
 
-toolchain go1.24.0
+toolchain go1.24.3
 
 require (
 	github.com/calico-vpp/vpplink v0.0.0-20230609075304-43385ab1325d

--- a/vpp-manager/vpp_runner.go
+++ b/vpp-manager/vpp_runner.go
@@ -146,6 +146,7 @@ func (v *VppRunner) configurePunt(tapSwIfIndex uint32, ifState config.LinuxInter
 			SwIfIndex:    tapSwIfIndex,
 			IP:           neigh,
 			HardwareAddr: ifState.HardwareAddr,
+			Flags:        types.IPNeighborStatic,
 		})
 		if err != nil {
 			return errors.Wrapf(err, "Error adding neighbor %s to tap", neigh)
@@ -665,6 +666,22 @@ func (v *VppRunner) doVppGlobalConfiguration() (err error) {
 	err = v.vpp.SetK8sSnatPolicy()
 	if err != nil {
 		return errors.Wrap(err, "Error configuring cnat source policy")
+	}
+
+	err = v.vpp.ConfigureNeighborsV4(&types.NeighborConfig{
+		MaxNumber: *config.GetCalicoVppInitialConfig().IP4NeighborsMaxNumber,
+		MaxAge:    *config.GetCalicoVppInitialConfig().IP4NeighborsMaxAge,
+	})
+	if err != nil {
+		return errors.Wrap(err, "error configuring v4 ip neighbors")
+	}
+
+	err = v.vpp.ConfigureNeighborsV6(&types.NeighborConfig{
+		MaxNumber: *config.GetCalicoVppInitialConfig().IP6NeighborsMaxNumber,
+		MaxAge:    *config.GetCalicoVppInitialConfig().IP6NeighborsMaxAge,
+	})
+	if err != nil {
+		return errors.Wrap(err, "error configuring v6 ip neighbors")
 	}
 
 	return nil

--- a/vpplink/neighbor.go
+++ b/vpplink/neighbor.go
@@ -1,0 +1,74 @@
+// Copyright (C) 2025 Cisco Systems Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vpplink
+
+import (
+	"fmt"
+
+	"github.com/projectcalico/vpp-dataplane/v3/vpplink/generated/bindings/interface_types"
+	"github.com/projectcalico/vpp-dataplane/v3/vpplink/generated/bindings/ip_neighbor"
+	"github.com/projectcalico/vpp-dataplane/v3/vpplink/types"
+)
+
+func (v *VppLink) AddNeighbor(neighbor *types.Neighbor) error {
+	return v.addDelNeighbor(neighbor, true)
+}
+
+func (v *VppLink) DelNeighbor(neighbor *types.Neighbor) error {
+	return v.addDelNeighbor(neighbor, false)
+}
+
+func (v *VppLink) addDelNeighbor(neighbor *types.Neighbor, isAdd bool) error {
+	client := ip_neighbor.NewServiceClient(v.GetConnection())
+
+	_, err := client.IPNeighborAddDel(v.GetContext(), &ip_neighbor.IPNeighborAddDel{
+		IsAdd: isAdd,
+		Neighbor: ip_neighbor.IPNeighbor{
+			SwIfIndex:  interface_types.InterfaceIndex(neighbor.SwIfIndex),
+			Flags:      types.ToVppNeighborFlags(neighbor.Flags),
+			MacAddress: types.MacAddress(neighbor.HardwareAddr),
+			IPAddress:  types.ToVppAddress(neighbor.IP),
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to %s neighbor from VPP: %w", isAddStr(isAdd), err)
+	}
+	v.GetLog().Debugf("%sed neighbor %+v", isAddStr(isAdd), neighbor)
+	return nil
+}
+
+func (v *VppLink) configureNeighbors(neighborConfig *types.NeighborConfig, isIP6 bool) error {
+	client := ip_neighbor.NewServiceClient(v.GetConnection())
+	_, err := client.IPNeighborConfig(v.GetContext(), &ip_neighbor.IPNeighborConfig{
+		Af:        types.ToVppAddressFamily(isIP6),
+		MaxNumber: neighborConfig.MaxNumber,
+		MaxAge:    neighborConfig.MaxAge,
+		Recycle:   neighborConfig.Recycle,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to set neighbor config in VPP: %s, %w", neighborConfig, err)
+	}
+	v.GetLog().Debugf("set neighbor config %s", neighborConfig)
+	return nil
+}
+
+func (v *VppLink) ConfigureNeighborsV4(neighborConfig *types.NeighborConfig) error {
+	return v.configureNeighbors(neighborConfig, false /* isIP6 */)
+}
+
+func (v *VppLink) ConfigureNeighborsV6(neighborConfig *types.NeighborConfig) error {
+	return v.configureNeighbors(neighborConfig, true /* isIP6 */)
+}

--- a/vpplink/routes.go
+++ b/vpplink/routes.go
@@ -21,9 +21,7 @@ import (
 	"net"
 
 	"github.com/projectcalico/vpp-dataplane/v3/vpplink/generated/bindings/fib_types"
-	"github.com/projectcalico/vpp-dataplane/v3/vpplink/generated/bindings/interface_types"
 	vppip "github.com/projectcalico/vpp-dataplane/v3/vpplink/generated/bindings/ip"
-	"github.com/projectcalico/vpp-dataplane/v3/vpplink/generated/bindings/ip_neighbor"
 	"github.com/projectcalico/vpp-dataplane/v3/vpplink/generated/bindings/ip_types"
 	"github.com/projectcalico/vpp-dataplane/v3/vpplink/generated/bindings/mfib_types"
 	"github.com/projectcalico/vpp-dataplane/v3/vpplink/types"
@@ -58,33 +56,6 @@ func (v *VppLink) GetRoutes(tableID uint32, isIPv6 bool) ([]types.Route, error) 
 		routes = append(routes, route)
 	}
 	return routes, nil
-}
-
-func (v *VppLink) AddNeighbor(neighbor *types.Neighbor) error {
-	return v.addDelNeighbor(neighbor, true)
-}
-
-func (v *VppLink) DelNeighbor(neighbor *types.Neighbor) error {
-	return v.addDelNeighbor(neighbor, false)
-}
-
-func (v *VppLink) addDelNeighbor(neighbor *types.Neighbor, isAdd bool) error {
-	client := ip_neighbor.NewServiceClient(v.GetConnection())
-
-	_, err := client.IPNeighborAddDel(v.GetContext(), &ip_neighbor.IPNeighborAddDel{
-		IsAdd: isAdd,
-		Neighbor: ip_neighbor.IPNeighbor{
-			SwIfIndex:  interface_types.InterfaceIndex(neighbor.SwIfIndex),
-			Flags:      types.ToVppNeighborFlags(neighbor.Flags),
-			MacAddress: types.MacAddress(neighbor.HardwareAddr),
-			IPAddress:  types.ToVppAddress(neighbor.IP),
-		},
-	})
-	if err != nil {
-		return fmt.Errorf("failed to %s neighbor from VPP: %w", isAddStr(isAdd), err)
-	}
-	v.GetLog().Debugf("%sed neighbor %+v", isAddStr(isAdd), neighbor)
-	return nil
 }
 
 func (v *VppLink) RoutesAdd(Dsts []*net.IPNet, routepath *types.RoutePath) error {

--- a/vpplink/types/neigh.go
+++ b/vpplink/types/neigh.go
@@ -16,6 +16,7 @@
 package types
 
 import (
+	"fmt"
 	"net"
 
 	"github.com/projectcalico/vpp-dataplane/v3/vpplink/generated/bindings/ip_neighbor"
@@ -42,4 +43,19 @@ func ToVppNeighborFlags(flags IPNeighborFlags) ip_neighbor.IPNeighborFlags {
 
 func FromVppNeighborFlags(flags ip_neighbor.IPNeighborFlags) IPNeighborFlags {
 	return IPNeighborFlags(flags)
+}
+
+type NeighborConfig struct {
+	MaxNumber uint32
+	MaxAge    uint32
+	Recycle   bool
+}
+
+func (neighborConfig *NeighborConfig) String() string {
+	return fmt.Sprintf(
+		"max-number:%d max-age:%d recycle:%t",
+		neighborConfig.MaxNumber,
+		neighborConfig.MaxAge,
+		neighborConfig.Recycle,
+	)
 }


### PR DESCRIPTION
This patch enables IP neighbor aeging in VPP, defaulting to a 30sec
renewal. IP neighbors older than 30s will trigger an ARP request
or be retired.

This patch also marks the static neighbors we require as static so
that they are not subject to aeging.

This addresses an issue in Cloud environment where nodes or peer VMs
are recreated, keeping the same IP but changing the associated MAC
without triggering a gratuitous ARP. When this happens, VPP keeps the
old MAC entry indefinitely and traffic to said node is blackholed.

This can be configured using
```
CALICOVPP_INITIAL_CONFIG={
"ip4NeighborsMaxNumber": 50000,
"ip6NeighborsMaxNumber": 50000,
"ip4NeighborsMaxAge": 30,
"ip6NeighborsMaxAge": 30
}
```