### PR TITLE
Support v6 hostport

### DIFF
--- a/calico-vpp-agent/cni/storage/storage.go
+++ b/calico-vpp-agent/cni/storage/storage.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	CniServerStateFileVersion = 8  // Used to ensure compatibility wen we reload data
+	CniServerStateFileVersion = 9  // Used to ensure compatibility wen we reload data
 	MaxApiTagLen              = 63 /* No more than 64 characters in API tags */
 	VrfTagHashLen             = 8  /* how many hash charatecters (b64) of the name in tag prefix (useful when trucated) */
 )
@@ -277,14 +277,15 @@ func (ps *LocalPodSpec) Copy() LocalPodSpec {
 // XXX: Increment CniServerStateFileVersion when changing this struct
 type HostPortBinding struct {
 	HostPort      uint16
-	HostIP        net.IP `struc:"[16]byte"`
+	HostIP6       net.IP `struc:"[16]byte"`
+	HostIP4       net.IP `struc:"[16]byte"`
 	ContainerPort uint16
 	EntryID       uint32
 	Protocol      types.IPProto
 }
 
 func (hp *HostPortBinding) String() string {
-	s := fmt.Sprintf("%s %s:%d", hp.Protocol.String(), hp.HostIP, hp.HostPort)
+	s := fmt.Sprintf("%s %s %s:%d", hp.Protocol.String(), hp.HostIP4 , hp.HostIP6, hp.HostPort)
 	s += fmt.Sprintf(" cport=%d", hp.ContainerPort)
 	s += fmt.Sprintf(" id=%d", hp.EntryID)
 	return s

--- a/calico-vpp-agent/cni/storage/storage.go
+++ b/calico-vpp-agent/cni/storage/storage.go
@@ -285,7 +285,7 @@ type HostPortBinding struct {
 }
 
 func (hp *HostPortBinding) String() string {
-	s := fmt.Sprintf("%s %s %s:%d", hp.Protocol.String(), hp.HostIP4 , hp.HostIP6, hp.HostPort)
+	s := fmt.Sprintf("%s %s %s:%d", hp.Protocol.String(), hp.HostIP4, hp.HostIP6, hp.HostPort)
 	s += fmt.Sprintf(" cport=%d", hp.ContainerPort)
 	s += fmt.Sprintf(" id=%d", hp.EntryID)
 	return s

--- a/calico-vpp-agent/policy/policy_server.go
+++ b/calico-vpp-agent/policy/policy_server.go
@@ -960,6 +960,8 @@ func (s *Server) handleHostEndpointUpdate(msg *proto.HostEndpointUpdate, pending
 			hep.UplinkSwIfIndexes = append(hep.UplinkSwIfIndexes, interfaceDetails.uplinkIndex)
 			hep.TapSwIfIndexes = append(hep.TapSwIfIndexes, interfaceDetails.tapIndex)
 		} else {
+			// we are not supposed to fallback to expectedIPs if interfaceName doesn't match
+			// this is the current behavior in calico linux
 			s.log.Errorf("cannot find host endpoint: interface named %s does not exist", hep.InterfaceName)
 		}
 	} else if hep.InterfaceName == "" && hep.expectedIPs != nil {


### PR DESCRIPTION
Some Calico CI failures are probably because we miss support for V6 hostports.
A hostport pod is a pod that is exposed on a port on its host node.
This patch adds the support for an ipv6 hostIP address in a hostport, or fallbacking to the nodes ip addresses (including v6 as well) if none is specified.
We only do v4 to v4 and v6 to v6 when we NAT.
This was tested manually, and should be covered by some Calico CI tests.