### PR TITLE
use single pbl index per pod

### DIFF
--- a/calico-vpp-agent/cni/network_vpp_routes.go
+++ b/calico-vpp-agent/cni/network_vpp_routes.go
@@ -150,7 +150,7 @@ func (s *Server) RoutePblPortsPodInterface(podSpec *storage.LocalPodSpec, stack 
 		} else {
 			stack.Push(s.vpp.DelPblClient, pblIndex)
 		}
-		podSpec.PblIndexes = append(podSpec.PblIndexes, pblIndex)
+		podSpec.PblIndex = pblIndex
 
 		if !isL3 {
 			s.log.Infof("pod(add) neighbor if[%d] %s", swIfIndex, containerIP.IP.String())
@@ -169,12 +169,10 @@ func (s *Server) RoutePblPortsPodInterface(podSpec *storage.LocalPodSpec, stack 
 }
 
 func (s *Server) UnroutePblPortsPodInterface(podSpec *storage.LocalPodSpec, swIfIndex uint32) {
-	for _, pblIndex := range podSpec.PblIndexes {
-		s.log.Infof("pod(del) PBL client[%d]", pblIndex)
-		err := s.vpp.DelPblClient(pblIndex)
-		if err != nil {
-			s.log.Warnf("Error deleting pbl conf %s", err)
-		}
+	s.log.Infof("pod(del) PBL client[%d]", podSpec.PblIndex)
+	err := s.vpp.DelPblClient(podSpec.PblIndex)
+	if err != nil {
+		s.log.Warnf("Error deleting pbl conf %s", err)
 	}
 }
 

--- a/calico-vpp-agent/cni/storage/storage.go
+++ b/calico-vpp-agent/cni/storage/storage.go
@@ -126,11 +126,6 @@ func (ps *LocalPodSpec) FullString() string {
 	for _, e := range routes {
 		routesLst = append(routesLst, e.String())
 	}
-	pblIndexes := ps.PblIndexes
-	pblIndexesLst := make([]string, 0, len(pblIndexes))
-	for _, e := range pblIndexes {
-		pblIndexesLst = append(pblIndexesLst, fmt.Sprint(e))
-	}
 	s := fmt.Sprintf("InterfaceName:      %s\n", ps.InterfaceName)
 	s += fmt.Sprintf("NetnsName:          %s\n", ps.NetnsName)
 	s += fmt.Sprintf("AllowIPForwarding:  %t\n", ps.AllowIPForwarding)
@@ -151,7 +146,7 @@ func (ps *LocalPodSpec) FullString() string {
 	s += fmt.Sprintf("TunTapSwIfIndex:    %d\n", ps.TunTapSwIfIndex)
 	s += fmt.Sprintf("MemifSwIfIndex:     %d\n", ps.MemifSwIfIndex)
 	s += fmt.Sprintf("LoopbackSwIfIndex:  %d\n", ps.LoopbackSwIfIndex)
-	s += fmt.Sprintf("PblIndexes:         %s\n", strings.Join(pblIndexesLst, ", "))
+	s += fmt.Sprintf("PblIndexes:         %d\n", ps.PblIndex)
 	s += fmt.Sprintf("V4VrfID:            %d\n", ps.V4VrfID)
 	s += fmt.Sprintf("V6VrfID:            %d\n", ps.V6VrfID)
 	return s
@@ -238,8 +233,7 @@ type LocalPodSpec struct {
 	TunTapSwIfIndex   uint32
 	MemifSwIfIndex    uint32
 	LoopbackSwIfIndex uint32
-	PblIndexesLen     int `struc:"int16,sizeof=PblIndexes"`
-	PblIndexes        []uint32
+	PblIndex          uint32
 
 	/**
 	 * These fields are only a runtime cache, but we also store them
@@ -268,7 +262,6 @@ func (ps *LocalPodSpec) Copy() LocalPodSpec {
 	newPs.ContainerIps = append(make([]LocalIP, 0), ps.ContainerIps...)
 	newPs.HostPorts = append(make([]HostPortBinding, 0), ps.HostPorts...)
 	newPs.IfPortConfigs = append(make([]LocalIfPortConfigs, 0), ps.IfPortConfigs...)
-	newPs.PblIndexes = append(make([]uint32, 0), ps.PblIndexes...)
 
 	return newPs
 


### PR DESCRIPTION
This patch addresses an issue where upon dataplane restart a pod with PBL enabled would find itself with multiple PBL instances as we did use a list and did not check for existing entries on recreation.
This patch solves this using a single entry per pod while waiting for a proper refactoring.