### PR TITLE
agent: remove policies enabled debug flag

### DIFF
--- a/calico-vpp-agent/felix/felix_server.go
+++ b/calico-vpp-agent/felix/felix_server.go
@@ -432,10 +432,6 @@ func (s *Server) handleFelixServerEvents(evt common.CalicoVppEvent) error {
 func (s *Server) ServeFelix(t *tomb.Tomb) error {
 	s.log.Info("Starting felix server")
 
-	if !*config.GetCalicoVppDebug().PoliciesEnabled {
-		s.log.Warn("Policies disabled, felix server will not configure VPP")
-	}
-
 	listener, err := net.Listen("unix", config.FelixDataplaneSocket)
 	if err != nil {
 		return errors.Wrapf(err, "Could not bind to unix://%s", config.FelixDataplaneSocket)
@@ -529,10 +525,6 @@ func (s *Server) handleFelixUpdate(msg interface{}) (err error) {
 	case *proto.InSync:
 		err = s.handleInSync(m)
 	default:
-		if !*config.GetCalicoVppDebug().PoliciesEnabled {
-			// Skip processing of policy messages
-			return nil
-		}
 		pending := true
 		switch s.state {
 		case StateSyncing:

--- a/config/config.go
+++ b/config/config.go
@@ -277,7 +277,6 @@ type RedirectToHostRulesConfigType struct {
 }
 
 type CalicoVppDebugConfigType struct {
-	PoliciesEnabled         *bool `json:"policiesEnabled,omitempty"`
 	ServicesEnabled         *bool `json:"servicesEnabled,omitempty"`
 	GSOEnabled              *bool `json:"gsoEnabled,omitempty"`
 	SpreadTxQueuesOnWorkers *bool `json:"spreadTxQueuesOnWorkers,omitempty"`
@@ -289,9 +288,6 @@ func (cfg *CalicoVppDebugConfigType) String() string {
 }
 
 func (cfg *CalicoVppDebugConfigType) Validate() (err error) {
-	if cfg.PoliciesEnabled == nil {
-		cfg.PoliciesEnabled = &True
-	}
 	if cfg.ServicesEnabled == nil {
 		cfg.ServicesEnabled = &True
 	}

--- a/docs/config.md
+++ b/docs/config.md
@@ -58,7 +58,6 @@ data:
 
   CALICOVPP_DEBUG: |-
   {
-    "policiesEnabled": true,
     "servicesEnabled": true,
     "gsoEnabled": true
   }

--- a/yaml/overlays/dev/kustomize.sh
+++ b/yaml/overlays/dev/kustomize.sh
@@ -136,7 +136,6 @@ function get_feature_gates ()
 function get_debug ()
 {
     echo "{
-      \"policiesEnabled\": ${CALICOVPP_DEBUG_ENABLE_POLICIES:-true},
       \"servicesEnabled\": ${CALICOVPP_DEBUG_ENABLE_SERVICES:-true},
       \"gsoEnabled\": ${CALICOVPP_DEBUG_ENABLE_GSO:-true}
     }"


### PR DESCRIPTION
this flag is not for policies anymore
it actually controls felix updates at large
so if disabled the agent will never start
maybe we should separate policies updates and flag them