### PR TITLE
Add VCL ldp cherrypick

### DIFF
--- a/vpplink/generated/vpp_clone_current.sh
+++ b/vpplink/generated/vpp_clone_current.sh
@@ -119,6 +119,7 @@ fi
 git_clone_cd_and_reset "$VPP_DIR" ${BASE}
 
 git_cherry_pick refs/changes/26/34726/3 # 34726: interface: add buffer stats api | https://gerrit.fd.io/r/c/vpp/+/34726
+git_cherry_pick refs/changes/43/42343/2 # 42343: vcl: LDP default to regular option | https://gerrit.fd.io/r/c/vpp/+/42343
 
 # This is the commit which broke IPv6 from v3.28.0 onwards.
 git_revert refs/changes/75/39675/5  # ip-neighbor: do not use sas to determine NS source address


### PR DESCRIPTION
This patch cherry pick a patch for VCL that introduces the following option

The LDP_DEFAULT_TO_REGULAR option is introduced so that, when set the socket call always defaults to glibc... The only way to create vls_handles in this case is to use vls_socket call instead

This allows having applications that partially LD_PRELOAD their socket calls. This is a hackish workaround, a much better approach would be using something like [0]

[0] https://gerrit.fd.io/r/c/vpp/+/42476