### PR TITLE
[release/3.26] vpp: bump vpp version to 25.06

### DIFF
--- a/vpp-manager/images/dev/Dockerfile
+++ b/vpp-manager/images/dev/Dockerfile
@@ -8,9 +8,7 @@ RUN apt-get update \
  && apt-get install -y openssl libapr1 libnuma1 libasan5 \
 	  libmbedcrypto7 libmbedtls14 libmbedx509-1 libsubunit0 \
 	  iptables iproute2 iputils-ping inetutils-traceroute \
-	  netcat-openbsd ethtool gdb \
-	  libnl-3-dev libnl-route-3-dev \
-	  libunwind8 libpcap-dev \
+	  netcat-openbsd ethtool gdb libunwind8 libpcap0.8 \
  && rm -rf /var/lib/apt/lists/*
 
 ADD entrypoint.sh /usr/bin/entrypoint

--- a/vpp-manager/images/ubuntu-build/Dockerfile
+++ b/vpp-manager/images/ubuntu-build/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update \
 	libconfuse-dev git-review exuberant-ctags cscope pkg-config \
 	gcovr lcov chrpath autoconf libnuma-dev \
 	python3-all python3-setuptools check \
-	libffi-dev python3-ply libunwind-dev \
+	libffi-dev python3-ply \
 	cmake ninja-build python3-jsonschema python3-yaml \
 	python3-venv \
 	python3-dev python3-pip \
@@ -23,11 +23,14 @@ RUN apt-get update \
 	nasm \
 	iperf ethtool \
 	libpcap-dev \
-	tshark \
-	jq \
-	clang clang-format-15 \
+	python3-virtualenv \
+	libssl-dev \
+	clang clang-format-11 \
 	libffi7 \
-	enchant-2
+	enchant-2 \
+	tshark \
+	libllvm15 libclang-cpp15 clang-format-15 libonig5 libjq1 jq  libunwind8 liblzma-dev libunwind-dev \
+	libiberty-dev
 
 WORKDIR /
 
@@ -40,4 +43,4 @@ RUN cd /usr/bin; mv tar tar.orig && \
 
 ADD build_script.sh /
 
-CMD "/build_script.sh"
+CMD ["/build_script.sh"]

--- a/vpp-manager/images/ubuntu/Dockerfile
+++ b/vpp-manager/images/ubuntu/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
  && apt-get install -y openssl libapr1 libnuma1 \
     libmbedcrypto7 libmbedtls14 libmbedx509-1 libsubunit0 \
     iproute2 ifupdown ethtool libnl-3-dev libnl-route-3-dev \
-    libunwind8 libpcap-dev \
+    libpcap0.8 libunwind8 \
  && rm -rf /var/lib/apt/lists/*
 
 # set work directory

--- a/vpplink/generated/bindings/feature/feature.ba.go
+++ b/vpplink/generated/bindings/feature/feature.ba.go
@@ -3,7 +3,7 @@
 // Package feature contains generated bindings for API file feature.api.
 //
 // Contents:
-// -  2 messages
+// -  4 messages
 package feature
 
 import (
@@ -21,7 +21,7 @@ const _ = api.GoVppAPIPackageIsVersion2
 const (
 	APIFile    = "feature"
 	APIVersion = "1.0.2"
-	VersionCrc = 0x8a6e6da1
+	VersionCrc = 0x30d6f180
 )
 
 // Feature path enable/disable request
@@ -106,10 +106,90 @@ func (m *FeatureEnableDisableReply) Unmarshal(b []byte) error {
 	return nil
 }
 
+// FeatureIsEnabled defines message 'feature_is_enabled'.
+type FeatureIsEnabled struct {
+	ArcName     string                         `binapi:"string[64],name=arc_name" json:"arc_name,omitempty"`
+	FeatureName string                         `binapi:"string[64],name=feature_name" json:"feature_name,omitempty"`
+	SwIfIndex   interface_types.InterfaceIndex `binapi:"interface_index,name=sw_if_index" json:"sw_if_index,omitempty"`
+}
+
+func (m *FeatureIsEnabled) Reset()               { *m = FeatureIsEnabled{} }
+func (*FeatureIsEnabled) GetMessageName() string { return "feature_is_enabled" }
+func (*FeatureIsEnabled) GetCrcString() string   { return "55db09e2" }
+func (*FeatureIsEnabled) GetMessageType() api.MessageType {
+	return api.RequestMessage
+}
+
+func (m *FeatureIsEnabled) Size() (size int) {
+	if m == nil {
+		return 0
+	}
+	size += 64 // m.ArcName
+	size += 64 // m.FeatureName
+	size += 4  // m.SwIfIndex
+	return size
+}
+func (m *FeatureIsEnabled) Marshal(b []byte) ([]byte, error) {
+	if b == nil {
+		b = make([]byte, m.Size())
+	}
+	buf := codec.NewBuffer(b)
+	buf.EncodeString(m.ArcName, 64)
+	buf.EncodeString(m.FeatureName, 64)
+	buf.EncodeUint32(uint32(m.SwIfIndex))
+	return buf.Bytes(), nil
+}
+func (m *FeatureIsEnabled) Unmarshal(b []byte) error {
+	buf := codec.NewBuffer(b)
+	m.ArcName = buf.DecodeString(64)
+	m.FeatureName = buf.DecodeString(64)
+	m.SwIfIndex = interface_types.InterfaceIndex(buf.DecodeUint32())
+	return nil
+}
+
+// FeatureIsEnabledReply defines message 'feature_is_enabled_reply'.
+type FeatureIsEnabledReply struct {
+	Retval    int32 `binapi:"i32,name=retval" json:"retval,omitempty"`
+	IsEnabled bool  `binapi:"bool,name=is_enabled" json:"is_enabled,omitempty"`
+}
+
+func (m *FeatureIsEnabledReply) Reset()               { *m = FeatureIsEnabledReply{} }
+func (*FeatureIsEnabledReply) GetMessageName() string { return "feature_is_enabled_reply" }
+func (*FeatureIsEnabledReply) GetCrcString() string   { return "03f284b5" }
+func (*FeatureIsEnabledReply) GetMessageType() api.MessageType {
+	return api.RequestMessage
+}
+
+func (m *FeatureIsEnabledReply) Size() (size int) {
+	if m == nil {
+		return 0
+	}
+	size += 4 // m.Retval
+	size += 1 // m.IsEnabled
+	return size
+}
+func (m *FeatureIsEnabledReply) Marshal(b []byte) ([]byte, error) {
+	if b == nil {
+		b = make([]byte, m.Size())
+	}
+	buf := codec.NewBuffer(b)
+	buf.EncodeInt32(m.Retval)
+	buf.EncodeBool(m.IsEnabled)
+	return buf.Bytes(), nil
+}
+func (m *FeatureIsEnabledReply) Unmarshal(b []byte) error {
+	buf := codec.NewBuffer(b)
+	m.Retval = buf.DecodeInt32()
+	m.IsEnabled = buf.DecodeBool()
+	return nil
+}
+
 func init() { file_feature_binapi_init() }
 func file_feature_binapi_init() {
 	api.RegisterMessage((*FeatureEnableDisable)(nil), "feature_enable_disable_7531c862")
 	api.RegisterMessage((*FeatureEnableDisableReply)(nil), "feature_enable_disable_reply_e8d4e804")
+	api.RegisterMessage((*FeatureIsEnabled)(nil), "feature_is_enabled_55db09e2")
+	api.RegisterMessage((*FeatureIsEnabledReply)(nil), "feature_is_enabled_reply_03f284b5")
 }
 
 // Messages returns list of all messages in this module.
@@ -117,5 +197,7 @@ func AllMessages() []api.Message {
 	return []api.Message{
 		(*FeatureEnableDisable)(nil),
 		(*FeatureEnableDisableReply)(nil),
+		(*FeatureIsEnabled)(nil),
+		(*FeatureIsEnabledReply)(nil),
 	}
 }

--- a/vpplink/generated/bindings/feature/feature_rpc.ba.go
+++ b/vpplink/generated/bindings/feature/feature_rpc.ba.go
@@ -11,6 +11,7 @@ import (
 // RPCService defines RPC service feature.
 type RPCService interface {
 	FeatureEnableDisable(ctx context.Context, in *FeatureEnableDisable) (*FeatureEnableDisableReply, error)
+	FeatureIsEnabled(ctx context.Context, in *FeatureIsEnabled) (*FeatureIsEnabledReply, error)
 }
 
 type serviceClient struct {
@@ -23,6 +24,15 @@ func NewServiceClient(conn api.Connection) RPCService {
 
 func (c *serviceClient) FeatureEnableDisable(ctx context.Context, in *FeatureEnableDisable) (*FeatureEnableDisableReply, error) {
 	out := new(FeatureEnableDisableReply)
+	err := c.conn.Invoke(ctx, in, out)
+	if err != nil {
+		return nil, err
+	}
+	return out, api.RetvalToVPPApiError(out.Retval)
+}
+
+func (c *serviceClient) FeatureIsEnabled(ctx context.Context, in *FeatureIsEnabled) (*FeatureIsEnabledReply, error) {
+	out := new(FeatureIsEnabledReply)
 	err := c.conn.Invoke(ctx, in, out)
 	if err != nil {
 		return nil, err

--- a/vpplink/generated/bindings/interface/interface.ba.go
+++ b/vpplink/generated/bindings/interface/interface.ba.go
@@ -23,7 +23,7 @@ const _ = api.GoVppAPIPackageIsVersion2
 const (
 	APIFile    = "interface"
 	APIVersion = "3.2.3"
-	VersionCrc = 0x446ae86d
+	VersionCrc = 0x2c32eb46
 )
 
 // Enable or disable detailed interface stats
@@ -2706,13 +2706,13 @@ func (m *SwInterfaceSetTableReply) Unmarshal(b []byte) error {
 type SwInterfaceSetTxPlacement struct {
 	SwIfIndex interface_types.InterfaceIndex `binapi:"interface_index,name=sw_if_index" json:"sw_if_index,omitempty"`
 	QueueID   uint32                         `binapi:"u32,name=queue_id" json:"queue_id,omitempty"`
-	ArraySize uint8                          `binapi:"u8,name=array_size" json:"-"`
+	ArraySize uint32                         `binapi:"u32,name=array_size" json:"-"`
 	Threads   []uint32                       `binapi:"u32[array_size],name=threads" json:"threads,omitempty"`
 }
 
 func (m *SwInterfaceSetTxPlacement) Reset()               { *m = SwInterfaceSetTxPlacement{} }
 func (*SwInterfaceSetTxPlacement) GetMessageName() string { return "sw_interface_set_tx_placement" }
-func (*SwInterfaceSetTxPlacement) GetCrcString() string   { return "0b855b40" }
+func (*SwInterfaceSetTxPlacement) GetCrcString() string   { return "4e0cd5ff" }
 func (*SwInterfaceSetTxPlacement) GetMessageType() api.MessageType {
 	return api.RequestMessage
 }
@@ -2723,7 +2723,7 @@ func (m *SwInterfaceSetTxPlacement) Size() (size int) {
 	}
 	size += 4                  // m.SwIfIndex
 	size += 4                  // m.QueueID
-	size += 1                  // m.ArraySize
+	size += 4                  // m.ArraySize
 	size += 4 * len(m.Threads) // m.Threads
 	return size
 }
@@ -2734,7 +2734,7 @@ func (m *SwInterfaceSetTxPlacement) Marshal(b []byte) ([]byte, error) {
 	buf := codec.NewBuffer(b)
 	buf.EncodeUint32(uint32(m.SwIfIndex))
 	buf.EncodeUint32(m.QueueID)
-	buf.EncodeUint8(uint8(len(m.Threads)))
+	buf.EncodeUint32(uint32(len(m.Threads)))
 	for i := 0; i < len(m.Threads); i++ {
 		var x uint32
 		if i < len(m.Threads) {
@@ -2748,7 +2748,7 @@ func (m *SwInterfaceSetTxPlacement) Unmarshal(b []byte) error {
 	buf := codec.NewBuffer(b)
 	m.SwIfIndex = interface_types.InterfaceIndex(buf.DecodeUint32())
 	m.QueueID = buf.DecodeUint32()
-	m.ArraySize = buf.DecodeUint8()
+	m.ArraySize = buf.DecodeUint32()
 	m.Threads = make([]uint32, m.ArraySize)
 	for i := 0; i < len(m.Threads); i++ {
 		m.Threads[i] = buf.DecodeUint32()
@@ -3247,7 +3247,7 @@ func file_interfaces_binapi_init() {
 	api.RegisterMessage((*SwInterfaceSetRxPlacementReply)(nil), "sw_interface_set_rx_placement_reply_e8d4e804")
 	api.RegisterMessage((*SwInterfaceSetTable)(nil), "sw_interface_set_table_df42a577")
 	api.RegisterMessage((*SwInterfaceSetTableReply)(nil), "sw_interface_set_table_reply_e8d4e804")
-	api.RegisterMessage((*SwInterfaceSetTxPlacement)(nil), "sw_interface_set_tx_placement_0b855b40")
+	api.RegisterMessage((*SwInterfaceSetTxPlacement)(nil), "sw_interface_set_tx_placement_4e0cd5ff")
 	api.RegisterMessage((*SwInterfaceSetTxPlacementReply)(nil), "sw_interface_set_tx_placement_reply_e8d4e804")
 	api.RegisterMessage((*SwInterfaceSetUnnumbered)(nil), "sw_interface_set_unnumbered_154a6439")
 	api.RegisterMessage((*SwInterfaceSetUnnumberedReply)(nil), "sw_interface_set_unnumbered_reply_e8d4e804")

--- a/vpplink/generated/bindings/ip_session_redirect/ip_session_redirect.ba.go
+++ b/vpplink/generated/bindings/ip_session_redirect/ip_session_redirect.ba.go
@@ -3,7 +3,7 @@
 // Package ip_session_redirect contains generated bindings for API file ip_session_redirect.api.
 //
 // Contents:
-// -  6 messages
+// -  8 messages
 package ip_session_redirect
 
 import (
@@ -23,7 +23,7 @@ const _ = api.GoVppAPIPackageIsVersion2
 const (
 	APIFile    = "ip_session_redirect"
 	APIVersion = "0.3.0"
-	VersionCrc = 0xf174f8ba
+	VersionCrc = 0x54be863a
 )
 
 // Add or update a session redirection
@@ -459,6 +459,188 @@ func (m *IPSessionRedirectDelReply) Unmarshal(b []byte) error {
 	return nil
 }
 
+// Session redirection operational state response
+//   - table_index - classifier table index
+//   - opaque_index - classifier session opaque index
+//   - is_punt - true = punted traffic, false = forwarded traffic
+//   - is_ip6 - true = payload proto is ip6, false = payload proto is ip4
+//   - match_len - classifier session match length in bytes (max is 80-bytes)
+//   - match - classifier session match
+//   - n_paths - number of paths
+//   - paths - the paths of the redirect
+//
+// IPSessionRedirectDetails defines message 'ip_session_redirect_details'.
+type IPSessionRedirectDetails struct {
+	Retval      int32               `binapi:"i32,name=retval" json:"retval,omitempty"`
+	TableIndex  uint32              `binapi:"u32,name=table_index" json:"table_index,omitempty"`
+	OpaqueIndex uint32              `binapi:"u32,name=opaque_index" json:"opaque_index,omitempty"`
+	IsPunt      bool                `binapi:"bool,name=is_punt" json:"is_punt,omitempty"`
+	IsIP6       bool                `binapi:"bool,name=is_ip6" json:"is_ip6,omitempty"`
+	MatchLength uint32              `binapi:"u32,name=match_length" json:"match_length,omitempty"`
+	Match       []byte              `binapi:"u8[80],name=match" json:"match,omitempty"`
+	NPaths      uint8               `binapi:"u8,name=n_paths" json:"-"`
+	Paths       []fib_types.FibPath `binapi:"fib_path[n_paths],name=paths" json:"paths,omitempty"`
+}
+
+func (m *IPSessionRedirectDetails) Reset()               { *m = IPSessionRedirectDetails{} }
+func (*IPSessionRedirectDetails) GetMessageName() string { return "ip_session_redirect_details" }
+func (*IPSessionRedirectDetails) GetCrcString() string   { return "4487a233" }
+func (*IPSessionRedirectDetails) GetMessageType() api.MessageType {
+	return api.ReplyMessage
+}
+
+func (m *IPSessionRedirectDetails) Size() (size int) {
+	if m == nil {
+		return 0
+	}
+	size += 4      // m.Retval
+	size += 4      // m.TableIndex
+	size += 4      // m.OpaqueIndex
+	size += 1      // m.IsPunt
+	size += 1      // m.IsIP6
+	size += 4      // m.MatchLength
+	size += 1 * 80 // m.Match
+	size += 1      // m.NPaths
+	for j1 := 0; j1 < len(m.Paths); j1++ {
+		var s1 fib_types.FibPath
+		_ = s1
+		if j1 < len(m.Paths) {
+			s1 = m.Paths[j1]
+		}
+		size += 4      // s1.SwIfIndex
+		size += 4      // s1.TableID
+		size += 4      // s1.RpfID
+		size += 1      // s1.Weight
+		size += 1      // s1.Preference
+		size += 4      // s1.Type
+		size += 4      // s1.Flags
+		size += 4      // s1.Proto
+		size += 1 * 16 // s1.Nh.Address
+		size += 4      // s1.Nh.ViaLabel
+		size += 4      // s1.Nh.ObjID
+		size += 4      // s1.Nh.ClassifyTableIndex
+		size += 1      // s1.NLabels
+		for j2 := 0; j2 < 16; j2++ {
+			size += 1 // s1.LabelStack[j2].IsUniform
+			size += 4 // s1.LabelStack[j2].Label
+			size += 1 // s1.LabelStack[j2].TTL
+			size += 1 // s1.LabelStack[j2].Exp
+		}
+	}
+	return size
+}
+func (m *IPSessionRedirectDetails) Marshal(b []byte) ([]byte, error) {
+	if b == nil {
+		b = make([]byte, m.Size())
+	}
+	buf := codec.NewBuffer(b)
+	buf.EncodeInt32(m.Retval)
+	buf.EncodeUint32(m.TableIndex)
+	buf.EncodeUint32(m.OpaqueIndex)
+	buf.EncodeBool(m.IsPunt)
+	buf.EncodeBool(m.IsIP6)
+	buf.EncodeUint32(m.MatchLength)
+	buf.EncodeBytes(m.Match, 80)
+	buf.EncodeUint8(uint8(len(m.Paths)))
+	for j0 := 0; j0 < len(m.Paths); j0++ {
+		var v0 fib_types.FibPath // Paths
+		if j0 < len(m.Paths) {
+			v0 = m.Paths[j0]
+		}
+		buf.EncodeUint32(v0.SwIfIndex)
+		buf.EncodeUint32(v0.TableID)
+		buf.EncodeUint32(v0.RpfID)
+		buf.EncodeUint8(v0.Weight)
+		buf.EncodeUint8(v0.Preference)
+		buf.EncodeUint32(uint32(v0.Type))
+		buf.EncodeUint32(uint32(v0.Flags))
+		buf.EncodeUint32(uint32(v0.Proto))
+		buf.EncodeBytes(v0.Nh.Address.XXX_UnionData[:], 16)
+		buf.EncodeUint32(v0.Nh.ViaLabel)
+		buf.EncodeUint32(v0.Nh.ObjID)
+		buf.EncodeUint32(v0.Nh.ClassifyTableIndex)
+		buf.EncodeUint8(v0.NLabels)
+		for j1 := 0; j1 < 16; j1++ {
+			buf.EncodeUint8(v0.LabelStack[j1].IsUniform)
+			buf.EncodeUint32(v0.LabelStack[j1].Label)
+			buf.EncodeUint8(v0.LabelStack[j1].TTL)
+			buf.EncodeUint8(v0.LabelStack[j1].Exp)
+		}
+	}
+	return buf.Bytes(), nil
+}
+func (m *IPSessionRedirectDetails) Unmarshal(b []byte) error {
+	buf := codec.NewBuffer(b)
+	m.Retval = buf.DecodeInt32()
+	m.TableIndex = buf.DecodeUint32()
+	m.OpaqueIndex = buf.DecodeUint32()
+	m.IsPunt = buf.DecodeBool()
+	m.IsIP6 = buf.DecodeBool()
+	m.MatchLength = buf.DecodeUint32()
+	m.Match = make([]byte, 80)
+	copy(m.Match, buf.DecodeBytes(len(m.Match)))
+	m.NPaths = buf.DecodeUint8()
+	m.Paths = make([]fib_types.FibPath, m.NPaths)
+	for j0 := 0; j0 < len(m.Paths); j0++ {
+		m.Paths[j0].SwIfIndex = buf.DecodeUint32()
+		m.Paths[j0].TableID = buf.DecodeUint32()
+		m.Paths[j0].RpfID = buf.DecodeUint32()
+		m.Paths[j0].Weight = buf.DecodeUint8()
+		m.Paths[j0].Preference = buf.DecodeUint8()
+		m.Paths[j0].Type = fib_types.FibPathType(buf.DecodeUint32())
+		m.Paths[j0].Flags = fib_types.FibPathFlags(buf.DecodeUint32())
+		m.Paths[j0].Proto = fib_types.FibPathNhProto(buf.DecodeUint32())
+		copy(m.Paths[j0].Nh.Address.XXX_UnionData[:], buf.DecodeBytes(16))
+		m.Paths[j0].Nh.ViaLabel = buf.DecodeUint32()
+		m.Paths[j0].Nh.ObjID = buf.DecodeUint32()
+		m.Paths[j0].Nh.ClassifyTableIndex = buf.DecodeUint32()
+		m.Paths[j0].NLabels = buf.DecodeUint8()
+		for j1 := 0; j1 < 16; j1++ {
+			m.Paths[j0].LabelStack[j1].IsUniform = buf.DecodeUint8()
+			m.Paths[j0].LabelStack[j1].Label = buf.DecodeUint32()
+			m.Paths[j0].LabelStack[j1].TTL = buf.DecodeUint8()
+			m.Paths[j0].LabelStack[j1].Exp = buf.DecodeUint8()
+		}
+	}
+	return nil
+}
+
+// Dump available session redirections
+//   - table_index - classifier table index
+//
+// IPSessionRedirectDump defines message 'ip_session_redirect_dump'.
+type IPSessionRedirectDump struct {
+	TableIndex uint32 `binapi:"u32,name=table_index" json:"table_index,omitempty"`
+}
+
+func (m *IPSessionRedirectDump) Reset()               { *m = IPSessionRedirectDump{} }
+func (*IPSessionRedirectDump) GetMessageName() string { return "ip_session_redirect_dump" }
+func (*IPSessionRedirectDump) GetCrcString() string   { return "33554253" }
+func (*IPSessionRedirectDump) GetMessageType() api.MessageType {
+	return api.RequestMessage
+}
+
+func (m *IPSessionRedirectDump) Size() (size int) {
+	if m == nil {
+		return 0
+	}
+	size += 4 // m.TableIndex
+	return size
+}
+func (m *IPSessionRedirectDump) Marshal(b []byte) ([]byte, error) {
+	if b == nil {
+		b = make([]byte, m.Size())
+	}
+	buf := codec.NewBuffer(b)
+	buf.EncodeUint32(m.TableIndex)
+	return buf.Bytes(), nil
+}
+func (m *IPSessionRedirectDump) Unmarshal(b []byte) error {
+	buf := codec.NewBuffer(b)
+	m.TableIndex = buf.DecodeUint32()
+	return nil
+}
+
 func init() { file_ip_session_redirect_binapi_init() }
 func file_ip_session_redirect_binapi_init() {
 	api.RegisterMessage((*IPSessionRedirectAdd)(nil), "ip_session_redirect_add_2f78ffda")
@@ -467,6 +649,8 @@ func file_ip_session_redirect_binapi_init() {
 	api.RegisterMessage((*IPSessionRedirectAddV2Reply)(nil), "ip_session_redirect_add_v2_reply_e8d4e804")
 	api.RegisterMessage((*IPSessionRedirectDel)(nil), "ip_session_redirect_del_fb643388")
 	api.RegisterMessage((*IPSessionRedirectDelReply)(nil), "ip_session_redirect_del_reply_e8d4e804")
+	api.RegisterMessage((*IPSessionRedirectDetails)(nil), "ip_session_redirect_details_4487a233")
+	api.RegisterMessage((*IPSessionRedirectDump)(nil), "ip_session_redirect_dump_33554253")
 }
 
 // Messages returns list of all messages in this module.
@@ -478,5 +662,7 @@ func AllMessages() []api.Message {
 		(*IPSessionRedirectAddV2Reply)(nil),
 		(*IPSessionRedirectDel)(nil),
 		(*IPSessionRedirectDelReply)(nil),
+		(*IPSessionRedirectDetails)(nil),
+		(*IPSessionRedirectDump)(nil),
 	}
 }

--- a/vpplink/generated/bindings/ip_session_redirect/ip_session_redirect_rpc.ba.go
+++ b/vpplink/generated/bindings/ip_session_redirect/ip_session_redirect_rpc.ba.go
@@ -4,7 +4,10 @@ package ip_session_redirect
 
 import (
 	"context"
+	"fmt"
+	"io"
 
+	memclnt "github.com/projectcalico/vpp-dataplane/v3/vpplink/generated/bindings/memclnt"
 	api "go.fd.io/govpp/api"
 )
 
@@ -13,6 +16,7 @@ type RPCService interface {
 	IPSessionRedirectAdd(ctx context.Context, in *IPSessionRedirectAdd) (*IPSessionRedirectAddReply, error)
 	IPSessionRedirectAddV2(ctx context.Context, in *IPSessionRedirectAddV2) (*IPSessionRedirectAddV2Reply, error)
 	IPSessionRedirectDel(ctx context.Context, in *IPSessionRedirectDel) (*IPSessionRedirectDelReply, error)
+	IPSessionRedirectDump(ctx context.Context, in *IPSessionRedirectDump) (RPCService_IPSessionRedirectDumpClient, error)
 }
 
 type serviceClient struct {
@@ -48,4 +52,47 @@ func (c *serviceClient) IPSessionRedirectDel(ctx context.Context, in *IPSessionR
 		return nil, err
 	}
 	return out, api.RetvalToVPPApiError(out.Retval)
+}
+
+func (c *serviceClient) IPSessionRedirectDump(ctx context.Context, in *IPSessionRedirectDump) (RPCService_IPSessionRedirectDumpClient, error) {
+	stream, err := c.conn.NewStream(ctx)
+	if err != nil {
+		return nil, err
+	}
+	x := &serviceClient_IPSessionRedirectDumpClient{stream}
+	if err := x.Stream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err = x.Stream.SendMsg(&memclnt.ControlPing{}); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+type RPCService_IPSessionRedirectDumpClient interface {
+	Recv() (*IPSessionRedirectDetails, error)
+	api.Stream
+}
+
+type serviceClient_IPSessionRedirectDumpClient struct {
+	api.Stream
+}
+
+func (c *serviceClient_IPSessionRedirectDumpClient) Recv() (*IPSessionRedirectDetails, error) {
+	msg, err := c.Stream.RecvMsg()
+	if err != nil {
+		return nil, err
+	}
+	switch m := msg.(type) {
+	case *IPSessionRedirectDetails:
+		return m, nil
+	case *memclnt.ControlPingReply:
+		err = c.Stream.Close()
+		if err != nil {
+			return nil, err
+		}
+		return nil, io.EOF
+	default:
+		return nil, fmt.Errorf("unexpected message: %T %v", m, m)
+	}
 }

--- a/vpplink/generated/generate.log
+++ b/vpplink/generated/generate.log
@@ -1,28 +1,32 @@
-VPP Version                 : 25.02.0-7~gb9dbf2b76
+VPP Version                 : 25.06.0-20~gbdaf6e0c7
 Binapi-generator version    : v0.11.0
-VPP Base commit             : 90f9501ea misc: Initial changes for stable/2502 branch
+VPP Base commit             : 47505bc21 misc: Initial changes for stable/2506 branch
 ------------------ Cherry picked commits --------------------
-interface: Fix interface.api endianness
 capo: Calico Policies plugin
 acl: acl-plugin custom policies
 cnat: [WIP] no k8s maglev from pods
 pbl: Port based balancer
+gerrit:42876/10 gso: add support for ipip tso for phyiscal interfaces
+gerrit:42598/12 pg: add support for checksum offload
+gerrit:43336/3 gso: fix ip fragment support for gso packet
+gerrit:42425/8 interface: add support for proper checksum handling
+gerrit:43083/3 virtio: conditionally set checksum offload based on TCP/UDP offload flags
+gerrit:43084/3 af_packet: conditionally set checksum offload based on TCP/UDP offload flags
+gerrit:43082/6 ipip: fix the offload flags
+gerrit:42891/5 ip: compute checksums before fragmentation if offloaded
+gerrit:43081/2 interface: clear flags after checksum computation
+gerrit:42419/5 dpdk: fix the outer flags
+gerrit:42186/6 tap: enable IPv4 checksum offload on interface
+gerrit:42185/6 vnet: add assert for offload flags in debug mode
+gerrit:42184/6 interface: add a new cap for virtual interfaces
+gerrit:revert:39675/5 Revert "ip-neighbor: do not use sas to determine NS source address"
 gerrit:42343/2 vcl: LDP default to regular option
 gerrit:34726/3 interface: add buffer stats api
-misc: VPP 25.02 Release Notes
-session: do not match listeners when looking for lcl port
-hs-test: fix numa node core retrieval
-http: confirm postponed connection close
-dpdk: patch add to ice driver for flow action handles
-l2: fix segment fault
-http: buf_fifo_get_segs minor fix
-hs-test: fixed incorrect exit status
-http: http_app_tx_callback check if conn closed
-vpp_config: leave kernel.shmmax alone by default
-vpp_config: leave vm.max_map_count alone by default
-sflow: replace VAPI with DLAPI
-hs-test: fix broken test
-sflow: Update build rules
-snort: validate sw_if_index in attach/detach api handlers
-misc: Initial changes for stable/2502 branch
+misc: VPP 25.06 Release Notes
+hsa: http client init wrk->vlib_main in setup
+tls: add half close support
+af_packet: show host interface offload flags
+af_packet: fix the error handling on transmit
+dma_intel: fix ats_disable attribute handling
+misc: Initial changes for stable/2506 branch
 -------------------------------------------------------------

--- a/vpplink/interfaces.go
+++ b/vpplink/interfaces.go
@@ -590,7 +590,7 @@ func (v *VppLink) SetInterfaceTxPlacement(swIfIndex uint32, queue int, worker in
 	_, err := client.SwInterfaceSetTxPlacement(v.GetContext(), &interfaces.SwInterfaceSetTxPlacement{
 		SwIfIndex: interface_types.InterfaceIndex(swIfIndex),
 		QueueID:   uint32(queue),
-		ArraySize: uint8(1),
+		ArraySize: uint32(1),
 		Threads:   []uint32{uint32(worker)},
 	})
 	if err != nil {


### PR DESCRIPTION
VPP version 25.06 was released on 25/Jun/2025. Release notes:

https://docs.fd.io/vpp/25.06/aboutvpp/releasenotes/v25.06.html

This commit bumps Calico/VPP to VPP 25.06.