### PR TITLE
Add make-kind directive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,27 @@ image:
 	$(MAKE) -C vpp-manager $@
 	$(MAKE) -C multinet-monitor $@
 
+.PHONY: image-kind
+image-kind: image
+	docker image tag calicovpp/vpp:$(TAG) localhost:5000/calicovpp/vpp:latest
+	docker push localhost:5000/calicovpp/vpp:latest
+	docker image tag calicovpp/agent:$(TAG) localhost:5000/calicovpp/agent:latest
+	docker push localhost:5000/calicovpp/agent:latest
+	docker image tag calicovpp/multinet-monitor:$(TAG) localhost:5000/calicovpp/multinet-monitor:latest
+	docker push localhost:5000/calicovpp/multinet-monitor:latest
+
+
+.PHONY: kind-new-cluster
+kind-new-cluster:
+	make -C test/kind new-cluster
+
+.PHONY: kind-install-cni
+kind-install-cni:
+	make -C test/kind install-cni
+
+.PHONY: kind
+kind: kind-new-cluster image-kind kind-install-cni
+
 .PHONY: push
 push:
 	$(MAKE) -C calico-vpp-agent $@
@@ -41,10 +62,6 @@ dev.k3s: dev
 		sudo k3s ctr images import /tmp/$$x.tar ; \
 		rm -f /tmp/$$x.tar ; \
 	done
-
-.PHONY: kind-new-cluster
-kind-new-cluster:
-	make -C test/kind new-cluster
 
 .PHONY: dev-kind
 dev-kind: dev

--- a/test/kind/Makefile
+++ b/test/kind/Makefile
@@ -1,12 +1,20 @@
 TAG ?= latest # Tag images with :$(TAG)
-N_KIND_WORKERS ?= 3
+N_KIND_WORKERS ?= 2
 N_KIND_CONTROL_PLANES ?= 1
 CPU_PINNING ?= false
 KIND_CALICO_VERSION ?= master
 
 .PHONY: new-cluster
 new-cluster:
-	@N_KIND_WORKERS=$(N_KIND_WORKERS) N_KIND_CONTROL_PLANES=$(N_KIND_CONTROL_PLANES) CPU_PINNING=$(CPU_PINNING) ./new_cluster.sh
+	@N_KIND_WORKERS=$(N_KIND_WORKERS) \
+		N_KIND_CONTROL_PLANES=$(N_KIND_CONTROL_PLANES) \
+		CPU_PINNING=$(CPU_PINNING) \
+		./new_cluster.sh
+
+.PHONY: install-cni
+install-cni:
+	@./install_calico_vpp.sh
+
 
 .PHONY: delete-cluster
 delete-cluster:

--- a/test/kind/install_calico_vpp.sh
+++ b/test/kind/install_calico_vpp.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+kubectl create -f https://raw.githubusercontent.com/projectcalico/calico/master/manifests/tigera-operator.yaml
+
+while [[ "$(kubectl api-resources --api-group=operator.tigera.io | grep Installation)" == "" ]]; do echo "waiting for Installation kubectl resource"; sleep 2; done
+
+export TAG=${TAG:-latest}
+
+export CALICO_AGENT_IMAGE=localhost:5000/calicovpp/agent:${TAG}
+export CALICO_VPP_IMAGE=localhost:5000/calicovpp/vpp:${TAG}
+export MULTINET_MONITOR_IMAGE=localhost:5000/calicovpp/multinet-monitor:${TAG}
+
+export IMAGE_PULL_POLICY=Always # Always Never IfNotPresent
+export CALICOVPP_ENABLE_MEMIF=true
+export CALICOVPP_ENABLE_VCL=true
+export CALICOVPP_LOG_LEVEL=debug
+
+# ---------------- interfaces ----------------
+export CALICOVPP_MAIN_INTERFACE=eth0
+export CALICOVPP_INTERFACES='{
+    "defaultPodIfSpec": {
+      "rx": 1,
+      "tx": 1,
+      "rxqsz": 128,
+      "txqsz": 128,
+      "isl3": true,
+      "rxMode": "interrupt"
+    },
+    "vppHostTapSpec": {
+      "rx": 1,
+      "tx": 1,
+      "rxqsz": 512,
+      "txqsz": 512,
+      "isl3": false,
+      "rxMode": "interrupt"
+    },
+  "uplinkInterfaces": [
+    {
+      "interfaceName": "eth0",
+      "vppDriver": "af_packet",
+      "rxMode": "interrupt"
+    }
+  ]
+}'
+
+export CALICOVPP_FEATURE_GATES='{
+	"prometheusEnabled": true,
+	"vclEnabled": true,
+	"memifEnabled": true
+}'
+export CALICO_ENCAPSULATION=IPIP # VXLAN IPIP None
+export CALICO_NAT_OUTGOING=Enabled
+export CALICOVPP_DISABLE_HUGEPAGES=true
+
+export CALICOVPP_CONFIG_TEMPLATE="unix {
+  nodaemon
+  full-coredump
+  log /var/run/vpp/vpp.log
+  cli-listen /var/run/vpp/cli.sock
+  pidfile /run/vpp/vpp.pid
+}
+cpu {
+  workers 0
+}
+socksvr {
+  socket-name /var/run/vpp/vpp-api.sock
+}
+buffers {
+  buffers-per-numa 16384
+  page-size 4K
+}
+plugins {
+    plugin default { enable }
+    plugin calico_plugin.so { enable }
+    plugin dpdk_plugin.so { disable }
+}
+"
+
+${SCRIPTDIR}/../../yaml/overlays/dev/kustomize.sh up

--- a/test/kind/new_cluster.sh
+++ b/test/kind/new_cluster.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 set -o errexit
 
+if [[ $(kind get clusters | grep -E '^kind$') == "kind" ]]; then
+	echo "Cluster kind already exists"
+	exit 0
+fi
+
+N_KIND_CONTROL_PLANES=${N_KIND_CONTROL_PLANES:-1}
+N_KIND_WORKERS=${N_KIND_WORKERS:-2}
+
 # create registry container unless it already exists
 reg_name='kind-registry'
 reg_port='5000'
@@ -20,7 +28,7 @@ containerdConfigPatches:
     endpoint = ["http://${reg_name}:5000"]
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
     endpoint = ["http://${reg_name}:5000"]
-   
+
 networking:
   disableDefaultCNI: true
   podSubnet: "11.0.0.0/16,fd20::0/64"


### PR DESCRIPTION
This patch adds a 'make kind' directive that spins up a kind cluster, 
installs Calico, CalicoVPP from a local build VPP and the agent.