### PR TITLE
[refactor] Remove the prometheus dependency on pubsub

### DIFF
--- a/calico-vpp-agent/cmd/calico_vpp_dataplane.go
+++ b/calico-vpp-agent/cmd/calico_vpp_dataplane.go
@@ -39,7 +39,6 @@ import (
 	"github.com/projectcalico/vpp-dataplane/v3/calico-vpp-agent/connectivity"
 	"github.com/projectcalico/vpp-dataplane/v3/calico-vpp-agent/felix"
 	"github.com/projectcalico/vpp-dataplane/v3/calico-vpp-agent/health"
-	"github.com/projectcalico/vpp-dataplane/v3/calico-vpp-agent/prometheus"
 	"github.com/projectcalico/vpp-dataplane/v3/calico-vpp-agent/routing"
 	"github.com/projectcalico/vpp-dataplane/v3/calico-vpp-agent/services"
 	"github.com/projectcalico/vpp-dataplane/v3/calico-vpp-agent/watchers"
@@ -152,7 +151,6 @@ func main() {
 	netWatcher := watchers.NewNetWatcher(vpp, log.WithFields(logrus.Fields{"component": "net-watcher"}))
 	routingServer := routing.NewRoutingServer(vpp, bgpServer, log.WithFields(logrus.Fields{"component": "routing"}))
 	serviceServer := services.NewServiceServer(vpp, k8sclient, log.WithFields(logrus.Fields{"component": "services"}))
-	prometheusServer := prometheus.NewPrometheusServer(vpp, log.WithFields(logrus.Fields{"component": "prometheus"}))
 	localSIDWatcher := watchers.NewLocalSIDWatcher(vpp, clientv3, log.WithFields(logrus.Fields{"subcomponent": "localsid-watcher"}))
 	felixServer, err := felix.NewFelixServer(vpp, log.WithFields(logrus.Fields{"component": "felix"}))
 	if err != nil {
@@ -265,7 +263,6 @@ func main() {
 	Go(routingServer.ServeRouting)
 	Go(serviceServer.ServeService)
 	Go(cniServer.ServeCNI)
-	Go(prometheusServer.ServePrometheus)
 
 	// watch LocalSID if SRv6 is enabled
 	if *config.GetCalicoVppFeatureGates().SRv6Enabled {


### PR DESCRIPTION
## Overview
- This PR removes the Prometheus server's dependency on the pubsub infrastructure.
- The changes establish a direct communication channel between the Felix server and Prometheus for pod lifecycle events.
- The logic for tracking pod interfaces in Prometheus remains identical - only the invocation mechanism is changed from pubsub events to direct method calls.

## What Changed
**Before:**
- Prometheus subscribed to pod events via the pubsub infrastructure, listening to `common.PodAdded` and `common.PodDeleted` events on a channel.

**After:**
- Prometheus is directly owned by the Felix server and receives pod events through explicit method calls.
- Prometheus server is now instantiated directly in `NewFelixServer()`.
- `ServePrometheus()` is started as a goroutine within `ServeFelix()` using the tomb lifecycle manager.
- Direct calls to `s.prometheusServer.OnPodAdded()` and `s.prometheusServer.OnPodDeleted()` are now made for pod event handling.
- Public methods `OnPodAdded()` and `OnPodDeleted()` are added in `prometheus.go` that directly handle pod lifecycle events.

## Event Flow:
- CNI server adds/deletes a pod and publishes `PodAdded`/`PodDeleted` event to Felix's event channel.
- Felix's `handleFelixServerEvents()` processes the event.
- Felix calls `workloadAdded()`/`WorkloadRemoved()` to update policy state.
- Felix directly calls `s.prometheusServer.OnPodAdded()`/`s.prometheusServer.OnPodDeleted()` to notify Prometheus.
- Prometheus updates its internal pod interface tracking maps.