### PR TITLE
[release v3.29] Fix CI vpp tarball caching issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -298,13 +298,14 @@ DEPEND_HASH = $(shell echo \
     	$(CURDIR)/Dockerfile.depend \
     	$(CURDIR)/go.mod \
     	$(CURDIR)/go.sum \
+    	| cut -f1 -d' ' \
 	)" | md5sum | cut -f1 -d' ')
 DEPEND_IMAGE = ${DEPEND_BASE}:${DEPEND_HASH}
 
 ifdef CI_BUILD
-	PUSH_IMAGE = docker image push ${DEPEND_IMAGE}
+PUSH_IMAGE = docker image push ${DEPEND_IMAGE}
 else
-	PUSH_IMAGE = echo not pushing image
+PUSH_IMAGE = echo not pushing image
 endif
 
 .PHONY: builder-image
@@ -331,3 +332,7 @@ go-check: builder-image
 
 .PHONY: go-lint
 go-lint: lint
+
+.PHONY: depend-image-hash
+depend-image-hash:
+	@echo $(DEPEND_IMAGE)

--- a/vpp-manager/Makefile
+++ b/vpp-manager/Makefile
@@ -35,9 +35,9 @@ PATCHES = $(sort $(wildcard $(VPPLINK_DIR)/generated/patches/*.patch))
 VPP_HASH = $(shell md5sum \
 	$(VPPLINK_DIR)/generated/vpp_clone_current.sh \
 	${PATCHES} \
-	<(echo '${VPP_DEB_LIST}') \
+	<(echo '$(subst $(VPP_DIR),,$(VPP_DEB_LIST))') \
 	<(echo '${BASE}') \
-	| md5sum | cut -f1 -d' ')
+	| cut -f1 -d' ' | md5sum | cut -f1 -d' ')
 VPP_TARBALL = vpp-${VPP_HASH}.tgz
 
 .PHONY: all


### PR DESCRIPTION
In the CI we were wrongly computing the hash of the tarball name containing the VPP build artifacts, as we included the path of the debs.

This patch addresses this issue and should restore the VPP tarball caching in CI.