### PR TITLE
Cherrypick hoststack fix for connectionless UDP

### DIFF
--- a/vpplink/generated/generate.log
+++ b/vpplink/generated/generate.log
@@ -1,4 +1,4 @@
-VPP Version                 : 25.06.0-19~g354a6aabf
+VPP Version                 : 25.06.0-21~g12e58733f
 Binapi-generator version    : v0.11.0
 VPP Base commit             : 47505bc21 misc: Initial changes for stable/2506 branch
 ------------------ Cherry picked commits --------------------
@@ -6,6 +6,7 @@ capo: Calico Policies plugin
 acl: acl-plugin custom policies
 cnat: [WIP] no k8s maglev from pods
 pbl: Port based balancer
+gerrit:43690/2 session: track app session index for cl sessions
 gerrit:42876/10 gso: add support for ipip tso for phyiscal interfaces
 gerrit:42598/12 pg: add support for checksum offload
 gerrit:43336/3 gso: fix ip fragment support for gso packet
@@ -20,6 +21,7 @@ gerrit:42186/6 tap: enable IPv4 checksum offload on interface
 gerrit:42185/6 vnet: add assert for offload flags in debug mode
 gerrit:42184/6 interface: add a new cap for virtual interfaces
 gerrit:revert:39675/5 Revert "ip-neighbor: do not use sas to determine NS source address"
+gerrit:42343/2 vcl: LDP default to regular option
 gerrit:34726/3 interface: add buffer stats api
 misc: VPP 25.06 Release Notes
 hsa: http client init wrk->vlib_main in setup

--- a/vpplink/generated/vpp_clone_current.sh
+++ b/vpplink/generated/vpp_clone_current.sh
@@ -139,6 +139,7 @@ git_cherry_pick refs/changes/36/43336/3  # gso: fix ip fragment support for gso 
 
 git_cherry_pick refs/changes/98/42598/12  # pg: add support for checksum offload
 git_cherry_pick refs/changes/76/42876/10  # gso: add support for ipip tso for phyiscal interfaces
+git_cherry_pick refs/changes/90/43690/2 # session: track app session index for cl sessions
 
 # --------------- private plugins ---------------
 # Generated with 'git format-patch --zero-commit -o ./patches/ HEAD^^^'


### PR DESCRIPTION
This patch cherry picks the following VPP patch [0] that addresses an issue preventing Connectionless UDP to receive packets when using the hoststack with VCL from a pod.

[0] https://gerrit.fd.io/r/c/vpp/+/43690