### PR TITLE
cherrypick - fix eks breakage in AL2023

### DIFF
--- a/yaml/generated/calico-vpp-eks-dpdk-multinet.yaml
+++ b/yaml/generated/calico-vpp-eks-dpdk-multinet.yaml
@@ -203,7 +203,7 @@ data:
       },
       "uplinkInterfaces": [
         {
-          "interfaceName": "eth0",
+          "interfaceName": "ens5",
           "vppDriver": "dpdk"
         }
       ]
@@ -258,17 +258,17 @@ spec:
     spec:
       containers:
       - env:
-        - name: CALICOVPP_HOOK_BEFORE_VPP_RUN
-          value: echo 'sudo systemctl stop network ; sudo systemctl kill network'
-            | chroot /host
         - name: CALICOVPP_HOOK_VPP_RUNNING
-          value: echo 'sudo systemctl start network' | chroot /host
+          value: echo "sudo cp /usr/lib/systemd/network/80-ec2.network /etc/systemd/network/ens5.network;
+            sudo sed -i 's/Driver=.*/Name=ens5/' /etc/systemd/network/ens5.network;
+            sudo systemctl daemon-reload; sudo systemctl restart systemd-networkd"
+            | chroot /host
         - name: CALICOVPP_HOOK_VPP_DONE_OK
-          value: echo 'sudo systemctl stop network ; sudo systemctl kill network ;
-            sudo systemctl start network' | chroot /host
+          value: echo 'sudo rm /etc/systemd/network/ens5.network; systemctl daemon-reload;
+            sudo systemctl restart systemd-networkd' | chroot /host
         - name: CALICOVPP_HOOK_VPP_ERRORED
-          value: echo 'sudo systemctl stop network ; sudo systemctl kill network ;
-            sudo systemctl start network' | chroot /host
+          value: echo 'sudo rm /etc/systemd/network/ens5.network; systemctl daemon-reload;
+            sudo systemctl restart systemd-networkd' | chroot /host
         - name: DATASTORE_TYPE
           value: kubernetes
         - name: WAIT_FOR_DATASTORE

--- a/yaml/generated/calico-vpp-eks-dpdk.yaml
+++ b/yaml/generated/calico-vpp-eks-dpdk.yaml
@@ -179,7 +179,7 @@ data:
       },
       "uplinkInterfaces": [
         {
-          "interfaceName": "eth0",
+          "interfaceName": "ens5",
           "vppDriver": "dpdk"
         }
       ]
@@ -208,17 +208,17 @@ spec:
     spec:
       containers:
       - env:
-        - name: CALICOVPP_HOOK_BEFORE_VPP_RUN
-          value: echo 'sudo systemctl stop network ; sudo systemctl kill network'
-            | chroot /host
         - name: CALICOVPP_HOOK_VPP_RUNNING
-          value: echo 'sudo systemctl start network' | chroot /host
+          value: echo "sudo cp /usr/lib/systemd/network/80-ec2.network /etc/systemd/network/ens5.network;
+            sudo sed -i 's/Driver=.*/Name=ens5/' /etc/systemd/network/ens5.network;
+            sudo systemctl daemon-reload; sudo systemctl restart systemd-networkd"
+            | chroot /host
         - name: CALICOVPP_HOOK_VPP_DONE_OK
-          value: echo 'sudo systemctl stop network ; sudo systemctl kill network ;
-            sudo systemctl start network' | chroot /host
+          value: echo 'sudo rm /etc/systemd/network/ens5.network; systemctl daemon-reload;
+            sudo systemctl restart systemd-networkd' | chroot /host
         - name: CALICOVPP_HOOK_VPP_ERRORED
-          value: echo 'sudo systemctl stop network ; sudo systemctl kill network ;
-            sudo systemctl start network' | chroot /host
+          value: echo 'sudo rm /etc/systemd/network/ens5.network; systemctl daemon-reload;
+            sudo systemctl restart systemd-networkd' | chroot /host
         - name: DATASTORE_TYPE
           value: kubernetes
         - name: WAIT_FOR_DATASTORE

--- a/yaml/generated/calico-vpp-eks-multinet.yaml
+++ b/yaml/generated/calico-vpp-eks-multinet.yaml
@@ -203,7 +203,7 @@ data:
       },
       "uplinkInterfaces": [
         {
-          "interfaceName": "eth0",
+          "interfaceName": "ens5",
           "vppDriver": "af_packet"
         }
       ]
@@ -258,17 +258,17 @@ spec:
     spec:
       containers:
       - env:
-        - name: CALICOVPP_HOOK_BEFORE_VPP_RUN
-          value: echo 'sudo systemctl stop network ; sudo systemctl kill network'
-            | chroot /host
         - name: CALICOVPP_HOOK_VPP_RUNNING
-          value: echo 'sudo systemctl start network' | chroot /host
+          value: echo "sudo cp /usr/lib/systemd/network/80-ec2.network /etc/systemd/network/ens5.network;
+            sudo sed -i 's/Driver=.*/Name=ens5/' /etc/systemd/network/ens5.network;
+            sudo systemctl daemon-reload; sudo systemctl restart systemd-networkd"
+            | chroot /host
         - name: CALICOVPP_HOOK_VPP_DONE_OK
-          value: echo 'sudo systemctl stop network ; sudo systemctl kill network ;
-            sudo systemctl start network' | chroot /host
+          value: echo 'sudo rm /etc/systemd/network/ens5.network; systemctl daemon-reload;
+            sudo systemctl restart systemd-networkd' | chroot /host
         - name: CALICOVPP_HOOK_VPP_ERRORED
-          value: echo 'sudo systemctl stop network ; sudo systemctl kill network ;
-            sudo systemctl start network' | chroot /host
+          value: echo 'sudo rm /etc/systemd/network/ens5.network; systemctl daemon-reload;
+            sudo systemctl restart systemd-networkd' | chroot /host
         - name: DATASTORE_TYPE
           value: kubernetes
         - name: WAIT_FOR_DATASTORE

--- a/yaml/generated/calico-vpp-eks.yaml
+++ b/yaml/generated/calico-vpp-eks.yaml
@@ -179,7 +179,7 @@ data:
       },
       "uplinkInterfaces": [
         {
-          "interfaceName": "eth0",
+          "interfaceName": "ens5",
           "vppDriver": "af_packet"
         }
       ]
@@ -208,17 +208,17 @@ spec:
     spec:
       containers:
       - env:
-        - name: CALICOVPP_HOOK_BEFORE_VPP_RUN
-          value: echo 'sudo systemctl stop network ; sudo systemctl kill network'
-            | chroot /host
         - name: CALICOVPP_HOOK_VPP_RUNNING
-          value: echo 'sudo systemctl start network' | chroot /host
+          value: echo "sudo cp /usr/lib/systemd/network/80-ec2.network /etc/systemd/network/ens5.network;
+            sudo sed -i 's/Driver=.*/Name=ens5/' /etc/systemd/network/ens5.network;
+            sudo systemctl daemon-reload; sudo systemctl restart systemd-networkd"
+            | chroot /host
         - name: CALICOVPP_HOOK_VPP_DONE_OK
-          value: echo 'sudo systemctl stop network ; sudo systemctl kill network ;
-            sudo systemctl start network' | chroot /host
+          value: echo 'sudo rm /etc/systemd/network/ens5.network; systemctl daemon-reload;
+            sudo systemctl restart systemd-networkd' | chroot /host
         - name: CALICOVPP_HOOK_VPP_ERRORED
-          value: echo 'sudo systemctl stop network ; sudo systemctl kill network ;
-            sudo systemctl start network' | chroot /host
+          value: echo 'sudo rm /etc/systemd/network/ens5.network; systemctl daemon-reload;
+            sudo systemctl restart systemd-networkd' | chroot /host
         - name: DATASTORE_TYPE
           value: kubernetes
         - name: WAIT_FOR_DATASTORE

--- a/yaml/overlays/eks-dpdk/eks-config.yaml
+++ b/yaml/overlays/eks-dpdk/eks-config.yaml
@@ -17,7 +17,7 @@ data:  # Configuration template for VPP in EKS
       },
       "uplinkInterfaces": [
         {
-          "interfaceName": "eth0",
+          "interfaceName": "ens5",
           "vppDriver": "dpdk"
         }
       ]

--- a/yaml/overlays/eks/eks-config.yaml
+++ b/yaml/overlays/eks/eks-config.yaml
@@ -18,7 +18,7 @@ data:  # Configuration template for VPP in EKS
       },
       "uplinkInterfaces": [
         {
-          "interfaceName": "eth0",
+          "interfaceName": "ens5",
           "vppDriver": "af_packet"
         }
       ]
@@ -35,11 +35,9 @@ spec:
       containers:
         - name: vpp
           env:
-            - name: CALICOVPP_HOOK_BEFORE_VPP_RUN
-              value: "echo 'sudo systemctl stop network ; sudo systemctl kill network' | chroot /host"
             - name: CALICOVPP_HOOK_VPP_RUNNING
-              value: "echo 'sudo systemctl start network' | chroot /host"
+              value: echo "sudo cp /usr/lib/systemd/network/80-ec2.network /etc/systemd/network/ens5.network; sudo sed -i 's/Driver=.*/Name=ens5/' /etc/systemd/network/ens5.network; sudo systemctl daemon-reload; sudo systemctl restart systemd-networkd" | chroot /host
             - name: CALICOVPP_HOOK_VPP_DONE_OK
-              value: "echo 'sudo systemctl stop network ; sudo systemctl kill network ; sudo systemctl start network' | chroot /host"
+              value: echo 'sudo rm /etc/systemd/network/ens5.network; systemctl daemon-reload; sudo systemctl restart systemd-networkd' | chroot /host
             - name: CALICOVPP_HOOK_VPP_ERRORED
-              value: "echo 'sudo systemctl stop network ; sudo systemctl kill network ; sudo systemctl start network' | chroot /host"
+              value: echo 'sudo rm /etc/systemd/network/ens5.network; systemctl daemon-reload; sudo systemctl restart systemd-networkd' | chroot /host


### PR DESCRIPTION
Amazon Linux 2 (AL2) has been deprecated and in its place has come Amazon Linux 2023 (AL2023). AL2023 has many improvements and many more changes and sadly it breaks the deployment of Calico/VPP in eks. Calico/VPP causes the uplink interface to vanish from the root network namespace which confuses systemd-networkd and it reacts by wiping out the DNS config and refusing to configure/manage the tuntap interface created in place of the original uplink interface which in turn causes the kernel to purge the tuntap interface at the expiry of the 1 hour DHCP lease.