### PR TITLE
User-local kind cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ test/scripts/.buildlogs
 multinet-monitor/version
 .coverage/
 bin/
+vendor/
+.tmp/

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,14 @@ image-kind: image
 	docker push localhost:5000/calicovpp/multinet-monitor:latest
 
 
+.PHONY: kind-cluster-name
+kind-cluster-name:
+	@echo $(CLUSTER_NAME)
+
+.PHONY: kind-rm-cluster
+kind-rm-cluster:
+	make -C test/kind rm-cluster
+
 .PHONY: kind-new-cluster
 kind-new-cluster:
 	make -C test/kind new-cluster

--- a/common.mk
+++ b/common.mk
@@ -52,3 +52,5 @@ TAG = $(shell git rev-parse HEAD)
 ifeq (${CODEBUILD_WEBHOOK_TRIGGER},branch/master)
 	ALSO_LATEST := y
 endif
+
+CLUSTER_NAME ?= kind-$(shell whoami)-$(shell git describe --always --abbrev=4)

--- a/docs/developper_guide.md
+++ b/docs/developper_guide.md
@@ -165,11 +165,11 @@ bash ./yaml/overlays/dev/kustomize.sh up
 
 ### Removing the CNI
 
-The outputed yaml is stored in `/tmp/calico-vpp.yaml`, you can uninstall by
-simply runnning :
+The outputed yaml is stored in `<this repo>/.tmp/calico-vpp.yaml`,
+you can uninstall by simply runnning :
 
 ````bash
-kubectl delete -f /tmp/calico-vpp.yaml
+kubectl delete -f .tmp/calico-vpp.yaml
 ````
 
 ## Setting up a VM (vagrant) based development cluster

--- a/test/kind/Makefile
+++ b/test/kind/Makefile
@@ -1,3 +1,5 @@
+include ../../common.mk
+
 TAG ?= latest # Tag images with :$(TAG)
 N_KIND_WORKERS ?= 2
 N_KIND_CONTROL_PLANES ?= 1
@@ -9,16 +11,19 @@ new-cluster:
 	@N_KIND_WORKERS=$(N_KIND_WORKERS) \
 		N_KIND_CONTROL_PLANES=$(N_KIND_CONTROL_PLANES) \
 		CPU_PINNING=$(CPU_PINNING) \
+		CLUSTER_NAME=$(CLUSTER_NAME) \
 		./new_cluster.sh
+	mkdir -p $(HOME)/.kube
+	kind get kubeconfig --name $(CLUSTER_NAME) > $(HOME)/.kube/config
 
 .PHONY: install-cni
 install-cni:
 	@./install_calico_vpp.sh
 
 
-.PHONY: delete-cluster
-delete-cluster:
-	kind delete cluster
+.PHONY: rm-cluster
+rm-cluster:
+	kind delete cluster --name $(CLUSTER_NAME)
 
 .PHONY: dev
 dev:

--- a/test/kind/new_cluster.sh
+++ b/test/kind/new_cluster.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -o errexit
 
-if [[ $(kind get clusters | grep -E '^kind$') == "kind" ]]; then
+if [[ $(kind get clusters | grep -E '^'${CLUSTER_NAME}'$') == "${CLUSTER_NAME}" ]]; then
 	echo "Cluster kind already exists"
 	exit 0
 fi
@@ -22,6 +22,7 @@ fi
 config=$(cat <<EOF
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+name: ${CLUSTER_NAME}
 containerdConfigPatches:
 - |-
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${reg_port}"]

--- a/test/scripts/cases_util.sh
+++ b/test/scripts/cases_util.sh
@@ -117,15 +117,15 @@ function configure_nodessh_ip6 () {
 }
 
 function start_iperf4 () {
-	ssh $NODESSH -t "nohup bash -c 'iperf -s -B 20.0.0.2 > /tmp/iperf.log 2>&1 &'" > /dev/null 2>&1
+	ssh $NODESSH -t "nohup bash -c 'iperf -s -B 20.0.0.2 > ${TMP}/iperf.log 2>&1 &'" > /dev/null 2>&1
 }
 
 function start_iperf6 () {
-	ssh $NODESSH -t "nohup bash -c 'iperf -s -V -B fd11::2 > /tmp/iperf.log 2>&1 &'" > /dev/null 2>&1
+	ssh $NODESSH -t "nohup bash -c 'iperf -s -V -B fd11::2 > ${TMP}/iperf.log 2>&1 &'" > /dev/null 2>&1
 }
 
 function stop_iperf () {
-	ssh $NODESSH -t "sudo pkill iperf ; cat /tmp/iperf.log" > $LAST_TEST_LOGFILE 2> /dev/null
+	ssh $NODESSH -t "sudo pkill iperf ; cat ${TMP}/iperf.log" > $LAST_TEST_LOGFILE 2> /dev/null
 }
 
 function sshtest () {

--- a/test/scripts/ci_util.sh
+++ b/test/scripts/ci_util.sh
@@ -85,7 +85,7 @@ function start_calico () {
 }
 
 function stop_calico () {
-  kubectl delete -f /tmp/calico-vpp.yaml > $CALICODOWN_LOG 2>&1
+  kubectl delete -f ${TMP}/calico-vpp.yaml > $CALICODOWN_LOG 2>&1
 }
 
 

--- a/test/scripts/mngmt.sh
+++ b/test/scripts/mngmt.sh
@@ -21,7 +21,7 @@ if [ -e $BUILD_LOG_DIR/conf ]; then
     source $BUILD_LOG_DIR/conf
 fi
 
-VPP_DATAPLANE_DIRECTORY=${VPP_DATAPLANE_DIRECTORY:=/tmp/vpp-dataplane/}
+VPP_DATAPLANE_DIRECTORY=${VPP_DATAPLANE_DIRECTORY:=${HOME}/.tmp/vpp-dataplane/}
 REPO_URL=${REPO_URL:=https://github.com/projectcalico/vpp-dataplane.git}
 BRANCH_NAME=${BRANCH_NAME:=origin/master}
 TAG=${TAG:=latest}

--- a/test/scripts/provision.sh
+++ b/test/scripts/provision.sh
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+TMP=$(git rev-parse --show-toplevel)/.tmp
+mkdir -p ${TMP}
 
 function is_ip6 () {
   if [[ $1 =~ .*:.* ]]; then
@@ -128,7 +130,7 @@ function raw_create_cluster_conf ()
 	export DNS_TYPE=$DNS_TYPE
 	export IS_DUAL=$IS_DUAL
 	export K8_VERSION=${K8_VERSION:=v1.31.0}
-    cat $1 | envsubst | sudo tee /tmp/ClusterConf.yaml > /dev/null
+    cat $1 | envsubst | sudo tee ${TMP}/ClusterConf.yaml > /dev/null
 }
 
 function raw_create_master_k8 ()
@@ -136,9 +138,9 @@ function raw_create_master_k8 ()
 	calico_if_linux_setup
 	raw_create_cluster_conf $SCRIPTDIR/kubeadm/ClusterNewConfiguration.template.yaml
 	if [ x$VERBOSE = xyes ]; then
-		sudo kubeadm init -v 100 --config /tmp/ClusterConf.yaml $@
+		sudo kubeadm init -v 100 --config ${TMP}/ClusterConf.yaml $@
 	else
-		sudo kubeadm init --config /tmp/ClusterConf.yaml $@
+		sudo kubeadm init --config ${TMP}/ClusterConf.yaml $@
 	fi
     rm -rf $HOME/.kube
 	mkdir -p $HOME/.kube
@@ -152,9 +154,9 @@ function raw_join_master_k8 ()
 	calico_if_linux_setup
 	raw_create_cluster_conf $SCRIPTDIR/kubeadm/ClusterJoinConfiguration.template.yaml
 	if [ x$VERBOSE = xyes ]; then
-		sudo kubeadm join -v 100 $MAIN_NODE_IP:6443 --config /tmp/ClusterConf.yaml $@
+		sudo kubeadm join -v 100 $MAIN_NODE_IP:6443 --config ${TMP}/ClusterConf.yaml $@
 	else
-		sudo kubeadm join $MAIN_NODE_IP:6443 --config /tmp/ClusterConf.yaml $@
+		sudo kubeadm join $MAIN_NODE_IP:6443 --config ${TMP}/ClusterConf.yaml $@
 	fi
 }
 

--- a/test/scripts/shared.sh
+++ b/test/scripts/shared.sh
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+TMP=$(git rev-parse --show-toplevel)/.tmp
+mkdir -p ${TMP}
 
 if [[ "$X" != "" ]]; then set -x ; fi
 
@@ -21,7 +23,7 @@ ORCH=$SCRIPTDIR/../scripts/orch.sh
 CASES=$SCRIPTDIR/../scripts/cases.sh
 KUST=$SCRIPTDIR/../../yaml/overlays/dev/kustomize.sh
 
-LOG_DIR=/tmp/calicovppci
+LOG_DIR=${TMP}/calicovppci
 ORCHUP_LOG=$LOG_DIR/orchup.log
 IPERFUP_LOG=$LOG_DIR/iperfup.log
 CALICOUP_LOG=$LOG_DIR/calicoup.log

--- a/test/scripts/test.sh
+++ b/test/scripts/test.sh
@@ -28,8 +28,8 @@ VPP_STATS=${VPP_STATS:=n}
 
 k_delete_namespace ()
 {
-  TMP=$(kubectl get namespace $1 2> /dev/null | wc -l)
-  if [ x$TMP = x0 ]; then
+  NAMESPACE_COUNT=$(kubectl get namespace $1 2> /dev/null | wc -l)
+  if [ x$NAMESPACE_COUNT = x0 ]; then
 	  echo "namespace $1 doesnt exist"
   else
 	  kubectl delete namespace $1
@@ -38,8 +38,8 @@ k_delete_namespace ()
 
 k_create_namespace ()
 {
-  TMP=$(kubectl get namespace $1 2> /dev/null | wc -l)
-  if [ x$TMP = x0 ]; then
+  NAMESPACE_COUNT=$(kubectl get namespace $1 2> /dev/null | wc -l)
+  if [ x$NAMESPACE_COUNT = x0 ]; then
 	  kubectl create namespace $1
   else
 	  echo "namespace $1 already exists"
@@ -199,7 +199,7 @@ setup_test_WRK1 ()
 		exit 1
 	fi
 
-	scp $OTHERHOST:/tmp/calico-vpp.yaml $DIR/cni.yaml
+	scp $OTHERHOST:${TMP}/calico-vpp.yaml $DIR/cni.yaml
 	CLUSTER_IP=$( kubectl get svc -n nginx nginx-service-${TEST_N} -o go-template --template='{{printf "%s\n" .spec.clusterIP}}' )
 	ssh $OTHERHOST "sudo conntrack -F"
 	while (( "$(netstat -tn4 | grep $CLUSTER_IP:80 | wc -l)" )); do
@@ -211,7 +211,7 @@ setup_test_WRK1 ()
 setup_test_class_WRK2 () { return; }
 setup_test_WRK2 ()
 {
-	cp /tmp/calico-vpp.yaml $DIR/cni.yaml
+	cp ${TMP}/calico-vpp.yaml $DIR/cni.yaml
 	sudo conntrack -F
 
 	while (( "$( $SCRIPTDIR/vppdev.sh vppctl node2 sh cnat session | grep "active elements" | awk '{print $1}' )" > 50 )); do
@@ -224,7 +224,7 @@ setup_test_class_IPERF () { return; }
 setup_test_IPERF ()
 {
 	N_FLOWS=${N_FLOWS:=4}
-	cp /tmp/calico-vpp.yaml $DIR/cni.yaml
+	cp ${TMP}/calico-vpp.yaml $DIR/cni.yaml
 }
 
 run_test_IPERF ()
@@ -240,7 +240,7 @@ setup_test_class_IPERF3 () { return; }
 setup_test_IPERF3 ()
 {
 	N_FLOWS=${N_FLOWS:=4}
-	cp /tmp/calico-vpp.yaml $DIR/cni.yaml
+	cp ${TMP}/calico-vpp.yaml $DIR/cni.yaml
 }
 
 run_test_IPERF3 ()
@@ -256,7 +256,7 @@ setup_test_class_IPERF3_VCL () { return; }
 setup_test_IPERF3_VCL ()
 {
 	N_FLOWS=${N_FLOWS:=4}
-	cp /tmp/calico-vpp.yaml $DIR/cni.yaml
+	cp ${TMP}/calico-vpp.yaml $DIR/cni.yaml
 }
 
 run_test_IPERF3_VCL ()
@@ -273,7 +273,7 @@ setup_test_IPERF3_VCL_TLS ()
 {
 	N_FLOWS=${N_FLOWS:=4}
 	TLS_ENGINE=${TLS_ENGINE:=4}
-	cp /tmp/calico-vpp.yaml $DIR/cni.yaml
+	cp ${TMP}/calico-vpp.yaml $DIR/cni.yaml
 }
 
 set +x
@@ -289,7 +289,7 @@ run_test_IPERF3_VCL_TLS ()
 setup_test_class_MEMIF () { return; }
 setup_test_MEMIF ()
 {
-	cp /tmp/calico-vpp.yaml $DIR/cni.yaml
+	cp ${TMP}/calico-vpp.yaml $DIR/cni.yaml
 	$SCRIPTDIR/vppdev.sh vppctl node1 cnat session purge
 }
 
@@ -332,7 +332,7 @@ run_test_WRK1 ()
 
 setup_test_ENVOY ()
 {
-	cp /tmp/calico-vpp.yaml $DIR/cni.yaml
+	cp ${TMP}/calico-vpp.yaml $DIR/cni.yaml
 	if [ x$ISVPP = xyes ]; then
 		$SCRIPTDIR/vppdev.sh vppctl node1 cnat session purge
 	else

--- a/yaml/overlays/dev/kustomize.sh
+++ b/yaml/overlays/dev/kustomize.sh
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+TMP=$(git rev-parse --show-toplevel)/.tmp
+mkdir -p ${TMP}
 
 function is_ip6 () {
   if [[ $1 =~ .*:.*/.* ]]; then
@@ -278,7 +280,7 @@ ${CALICOVPP_DISABLE_HUGEPAGES:+  - calico-vpp-nohuge.yaml}
 EOF
 
   kubectl kustomize . | envsubst | \
-	tee /tmp/calico-vpp.yaml > /dev/null
+	tee ${TMP}/calico-vpp.yaml > /dev/null
 
   rm kustomization.yaml
 }
@@ -295,9 +297,9 @@ function calico_up_cni ()
     kubectl patch ds -n kube-system kube-proxy -p '{"spec":{"template":{"spec":{"nodeSelector":{"non-calico": "true"}}}}}'
   fi
   if [ -t 1 ]; then
-	kubectl apply -f /tmp/calico-vpp.yaml
+	kubectl apply -f ${TMP}/calico-vpp.yaml
   else
-  	cat /tmp/calico-vpp.yaml
+  	cat ${TMP}/calico-vpp.yaml
   fi
 }
 
@@ -307,7 +309,7 @@ function calico_down_cni ()
   if [ x$DISABLE_KUBE_PROXY = xy ]; then
     kubectl patch ds -n kube-system kube-proxy --type merge -p '{"spec":{"template":{"spec":{"nodeSelector":{"non-calico": null}}}}}'
   fi
-  kubectl delete -f /tmp/calico-vpp.yaml
+  kubectl delete -f ${TMP}/calico-vpp.yaml
 }
 
 function print_usage_and_exit ()


### PR DESCRIPTION
This patch allows to use multiple clusters on the same machine.
It names each cluster 'kind-(whoami)-(repohash)' and uses <repo>/.tmp/ to
 store the calico-vpp.yaml and other installation scripts