### PR TITLE
[release/v3.30] Cherry pick hoststack patches fixing session reuse

### DIFF
--- a/vpplink/generated/generate.log
+++ b/vpplink/generated/generate.log
@@ -1,4 +1,4 @@
-VPP Version                 : 25.06.0-21~g12e58733f
+VPP Version                 : 25.06.0-25~ge62b1ebaa
 Binapi-generator version    : v0.11.0
 VPP Base commit             : 47505bc21 misc: Initial changes for stable/2506 branch
 ------------------ Cherry picked commits --------------------
@@ -6,6 +6,10 @@ capo: Calico Policies plugin
 acl: acl-plugin custom policies
 cnat: [WIP] no k8s maglev from pods
 pbl: Port based balancer
+gerrit:43723/3 session svm: fix session migrate attach data corruption
+gerrit:43139/5 udp: regrab connected session after transport clone
+gerrit:43714/5 session: fix handling of closed during migration
+gerrit:43107/4 vcl: fix fifo private vpp sh on migration
 gerrit:43690/2 session: track app session index for cl sessions
 gerrit:42876/10 gso: add support for ipip tso for phyiscal interfaces
 gerrit:42598/12 pg: add support for checksum offload

--- a/vpplink/generated/vpp_clone_current.sh
+++ b/vpplink/generated/vpp_clone_current.sh
@@ -141,6 +141,11 @@ git_cherry_pick refs/changes/98/42598/12  # pg: add support for checksum offload
 git_cherry_pick refs/changes/76/42876/10  # gso: add support for ipip tso for phyiscal interfaces
 git_cherry_pick refs/changes/90/43690/2 # session: track app session index for cl sessions
 
+git_cherry_pick refs/changes/07/43107/4 # 43107: vcl: fix fifo private vpp sh on migration | https://gerrit.fd.io/r/c/vpp/+/43107
+git_cherry_pick refs/changes/14/43714/5 # 43714: session: fix handling of closed during migration | https://gerrit.fd.io/r/c/vpp/+/43714
+git_cherry_pick refs/changes/39/43139/5 # 43139: udp: regrab connected session after transport clone | https://gerrit.fd.io/r/c/vpp/+/43139
+git_cherry_pick refs/changes/23/43723/3 # 43723: session svm: fix session migrate attach data corruption | https://gerrit.fd.io/r/c/vpp/+/43723
+
 # --------------- private plugins ---------------
 # Generated with 'git format-patch --zero-commit -o ./patches/ HEAD^^^'
 git_apply_private 0001-pbl-Port-based-balancer.patch


### PR DESCRIPTION
This patch cherry-picks the following VPP fixes that addressed some VCL issues related to UDP & TCP session establishement.

- 43107: vcl: fix fifo private vpp sh on migration | https://gerrit.fd.io/r/c/vpp/+/43107
- 43714: session: fix handling of closed during migration | https://gerrit.fd.io/r/c/vpp/+/43714
- 43139: udp: regrab connected session after transport clone | https://gerrit.fd.io/r/c/vpp/+/43139
- 43723: session svm: fix session migrate attach data corruption | https://gerrit.fd.io/r/c/vpp/+/43723