### PR TITLE
fix unmarshalling issues

### DIFF
--- a/vpplink/types/ip_types.go
+++ b/vpplink/types/ip_types.go
@@ -51,6 +51,20 @@ func (proto *IPProto) UnmarshalText(text []byte) error {
 	return nil
 }
 
+func (proto *IPProto) UnmarshalJSON(text []byte) error {
+	switch string(text) {
+	case "tcp":
+		*proto = TCP
+	case "udp":
+		*proto = UDP
+	case "sctp":
+		*proto = SCTP
+	default:
+		*proto = TCP
+	}
+	return nil
+}
+
 type IPFlowHash uint8
 
 const (

--- a/vpplink/types/vpp_interface.go
+++ b/vpplink/types/vpp_interface.go
@@ -46,6 +46,22 @@ func (mode *RxMode) UnmarshalText(text []byte) error {
 	return nil
 }
 
+func (mode *RxMode) UnmarshalJSON(text []byte) error {
+	switch string(text) {
+	case "interrupt":
+		*mode = InterruptRxMode
+	case "polling":
+		*mode = PollingRxMode
+	case "adaptive":
+		*mode = AdaptativeRxMode
+	case "default":
+		*mode = DefaultRxMode
+	default:
+		*mode = UnknownRxMode
+	}
+	return nil
+}
+
 const (
 	InvalidInterface = interface_types.InterfaceIndex(^uint32(0))
 )


### PR DESCRIPTION
this fixes unmarshalling issues that happen at startup in rxmode and proto:
cannot unmarshal number into Go struct field InterfaceSpec.podSpecs.podAnnotations.ifSpec.rxMode of type types.RxMode, removing cache cannot unmarshal number into Go struct field LocalIfPortConfigs.podSpecs.podAnnotations.ifPortConfigs.Proto of type types.IPProto

The UnmarshalText doesn't seem to do the trick, we need UnmarshalJSON