### PR TITLE
Fix the weird DHCP/DNS issue

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -171,7 +171,7 @@ func RunHook(hookScript *string, hookName string, params *VppManagerParams, log 
 		return
 	}
 
-	cmd := exec.Command("/bin/bash", "-c", template, hookName)
+	cmd := exec.Command("/bin/bash", "-c", template, hookName, params.UplinksSpecs[0].InterfaceName)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	err = cmd.Run()

--- a/config/default_hook.sh
+++ b/config/default_hook.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 HOOK="$0"
+INTERFACE_NAME="$1"
 chroot /host /bin/sh <<EOSCRIPT
 
 fix_dns () {
@@ -39,6 +40,50 @@ restart_network () {
     fi
 }
 
+save_network_file () {
+  if dmidecode -s bios-vendor | grep "Amazon EC2"; then
+    if systemctl status systemd-networkd > /dev/null 2>&1; then
+      if ip addr show "$INTERFACE_NAME" | grep -w inet | grep dynamic; then
+        if networkctl list | grep "$INTERFACE_NAME" | grep "configured"; then
+          networkctl status $INTERFACE_NAME | grep "Network File:" | sed "s/Network File: //" | xargs cat > /tmp/$INTERFACE_NAME.network.orig
+          cat /tmp/$INTERFACE_NAME.network.orig
+        fi
+      fi
+    fi
+  fi
+}
+
+tweak_network_file () {
+  if dmidecode -s bios-vendor | grep "Amazon EC2"; then
+    if systemctl status systemd-networkd > /dev/null 2>&1; then
+      if ip addr show "$INTERFACE_NAME" | grep -w inet | grep dynamic; then
+        if networkctl list | grep "$INTERFACE_NAME" | grep "unmanaged"; then
+          echo "default_hook: uplink interface, $INTERFACE_NAME, in unmanaged state; Fixing..."
+          echo "[Match]" > /tmp/$INTERFACE_NAME.network
+          echo "Name=$INTERFACE_NAME" >> /tmp/$INTERFACE_NAME.network
+          echo >> /tmp/$INTERFACE_NAME.network
+          sed "/^\[Match\]/,/^$/d" /tmp/$INTERFACE_NAME.network.orig >> /tmp/$INTERFACE_NAME.network
+          cp /tmp/$INTERFACE_NAME.network /etc/systemd/network/$INTERFACE_NAME.network
+          chmod 644 /etc/systemd/network/$INTERFACE_NAME.network
+          touch /var/run/vpp/network_file_tweaked
+          rm /tmp/$INTERFACE_NAME.network*
+          systemctl daemon-reload
+          systemctl restart systemd-networkd
+        fi
+      fi
+    fi
+  fi
+}
+
+remove_tweaked_network_file () {
+  if [ -f /var/run/vpp/network_file_tweaked ]; then
+    rm /etc/systemd/network/$INTERFACE_NAME.network
+    rm /var/run/vpp/network_file_tweaked
+    echo "default_hook: Deleting tweaked network file..."
+  fi
+}
+
+echo "default_hook: Uplink interface name=$INTERFACE_NAME"
 if which systemctl > /dev/null; then
     echo "default_hook: using systemctl..."
 else
@@ -48,13 +93,17 @@ fi
 
 if [ "$HOOK" = "BEFORE_VPP_RUN" ]; then
     fix_dns
+    save_network_file
 elif [ "$HOOK" = "VPP_RUNNING" ]; then
     restart_network
+    tweak_network_file
 elif [ "$HOOK" = "VPP_DONE_OK" ]; then
     undo_dns_fix
+    remove_tweaked_network_file
     restart_network
 elif [ "$HOOK" = "VPP_ERRORED" ]; then
     undo_dns_fix
+    remove_tweaked_network_file
     restart_network
 fi
 


### PR DESCRIPTION
When Calico/VPP is deployed, one of the things that happens is that the uplink interface vanishes from the root network namespace. Depending on the uplink driver used, it is either moved to a different network namespace or it vanishes completely from the kernel/os, and it gets replaced with a tap interface. This might cause an issue on systems where instead of the usual mac address or the interface name, systemd-networkd's [Match] section is configured with some parameter like the "permanent mac address" which is either not supported or not set for tap interfaces, thus, causing systemd-networkd to not manage the tap interface. This has the undesirable effect of the dhcp lease expiring and not getting renewed and bricking the system, and in additon also wiping out the DNS configuration.

With this fix, the [Match] section of the network file associated with the uplink interface is tweaked to use "Name=<interface name>".