### PR TITLE
doc/install: installation pre-requisites

### DIFF
--- a/docs/install/NetworkManager.md
+++ b/docs/install/NetworkManager.md
@@ -1,0 +1,3 @@
+# Weird DHCP/DNS issue - NetworkManager
+
+TODO

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -2,7 +2,25 @@
 
 The generally recommanded installation for CalicoVPP is
 with an operator. There is extensive documentation and
-platform specific guides available on the [Calico documentation](https://docs.tigera.io/calico/latest/getting-started/kubernetes/vpp/getting-started)
+platform specific guides available on the [Calico documentation](https://docs.tigera.io/calico/latest/getting-started/kubernetes/vpp/getting-started).
+
+## Node requirements
+
+When Calico/VPP is deployed, one of the things that happens is that the
+uplink interface vanishes from the root network namespace. Depending on the
+uplink driver used, it is either moved to a different network namespace or it
+vanishes completely from the kernel/os, and it gets replaced with a tap
+interface with the same name, mac address and other attributes. This **Houdini Act**
+may confuse the likes of `systemd-udevd`, `systemd-networkd` and `NetworkManager`
+and produce undesirable effects impacting the deployment and/or the functioning
+of the cluster.
+
+Therefore, for successful deployment and functioning, Calico/VPP may require
+some changes in the configuration of system services pertaining to networking:
+
+- [udevd](udevd.md)
+- [systemd-networkd](systemd-networkd.md)
+- [NetworkManager](NetworkManager.md)
 
 ## Special installation usecases
 

--- a/docs/install/systemd-networkd.md
+++ b/docs/install/systemd-networkd.md
@@ -1,0 +1,92 @@
+# Weird DHCP/DNS issue - systemd-networkd
+
+Usually, the `[Match]` section of the `.network` file is configured with either
+the **MACAddress** or the interface **Name** keys:
+
+```bash
+[Match]
+MACAddress=0a:bb:f2:cf:bb:01
+```
+
+```bash
+[Match]
+Name=ens5
+```
+
+So, when the uplink interface gets replaced with the tap interface and since the
+tap interface has the same attributes as the uplink interface, `systemd-networkd`
+is happy and things are ok.
+
+But when the `[Match]` section is configured with something like
+**PermanentMACAddress** key
+
+```bash
+[Match]
+PermanentMACAddress=0a:bb:f2:cf:bb:01
+```
+
+which is not supported with virtual interfaces like tap/tun
+
+```bash
+$ ethtool -P ens5
+Permanent address: not set
+$
+```
+
+then the match will fail and `systemd-networkd` will not **manage** the tap interface,
+
+```bash
+$ networkctl
+IDX LINK    TYPE     OPERATIONAL SETUP
+  1 lo      loopback carrier     unmanaged
+  3 docker0 bridge   no-carrier  unmanaged
+  4 ens5    ether    routable    unmanaged
+
+3 links listed.
+$
+```
+
+This can lead to two very undesirable consequences:
+
+1. DNS config is wiped off leading to DNS failures
+2. If uplink is configured using **dhcp** then upon lease expiry, since `systemd-networkd`
+   is not **managing** the interface, it will not do the dhcp lease renewal thus
+   ultimately **bricking** the node.
+
+In order to prevent the above from happening, create a `.network` file for the
+tap interface under `/etc/systemd/network` and configure the `[Match]` section
+with either the interface **Name** or **MACAddress** key. For example, say, the uplink
+interface is `ens5` and its `.network` file is `/run/systemd/network/10-netplan-ens5.network`
+then first copy this file to `/etc/systemd/network` and rename it:
+
+```bash
+sudo cp /run/systemd/network/10-netplan-ens5.network /etc/systemd/network/ens5.network
+```
+
+Secondly, in the file `/etc/systemd/network/ens5.network`, remove the
+**PermanentMACAddress** key in the `[Match]` section and add the **Name** key
+if not present already:
+
+```bash
+$ sdiff /run/systemd/network/10-netplan-ens5.network    /etc/systemd/network/ens5.network
+
+[Match]                            [Match]
+PermanentMACAddress=0a:bb:f2:cf:bb:01         <
+Name=ens5                           Name=ens5
+
+[Network]                           [Network]
+DHCP=ipv4                           DHCP=ipv4
+LinkLocalAddressing=ipv6                 LinkLocalAddressing=ipv6
+
+[DHCP]                            [DHCP]
+RouteMetric=100                       RouteMetric=100
+UseMTU=true                           UseMTU=true
+$
+```
+
+And then
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl restart systemd-networkd
+```

--- a/docs/install/udevd.md
+++ b/docs/install/udevd.md
@@ -1,0 +1,88 @@
+# Introduction
+
+Calico/VPP deployment replaces the uplink interface with a tap interface which
+has the same name, mac address and other attributes. Most of the time there are no
+issues.
+
+However, with certain NICs (Intel **E810**, for example) and when **multiple workers**
+are configured in `VPP` and when **MACAddressPolicy=persistent** is set in the
+`.link` file, then there's a potential race condition between `udevd` and `VPP`
+in setting the mac address of the tap interface which causes network connectivity
+issues ultimately leading to cluster deployment failure.
+
+## Pre-requisite conditions for the race condition
+
+- uplink interface of cluster uses problematic NIC (eg, Intel **E810**)
+- `VPP` configured with multiple workers, for e.g.,
+
+   ```bash
+   cpu { workers 2 }
+   ```
+
+- **MACAddressPolicy=persistent** in the NIC's or the system default `.link`
+  file, for e.g.,
+
+  ```bash
+  $ cat /usr/lib/systemd/network/99-default.link
+  [Match]
+  OriginalName=*
+
+  [Link]
+  NamePolicy=keep kernel database onboard slot path
+  AlternativeNamesPolicy=database onboard slot path
+  MACAddressPolicy=persistent
+  $
+  ```
+
+## Race-condition
+
+During Calico/VPP deployment, when `VPP` gets to run first, it sets the mac
+address of the tap interface and then `udevd` runs and sees that mac address is
+already set and it prods along and the cluster comes up fine:
+
+```text
+Nov 04 14:24:59 vpp-m7-9 systemd-udevd[43843]: ens2f0: MAC on the device
+already set by userspace
+```
+
+But when `udevd` runs first, **MACAddressPolicy=persistent** causes it to
+generate a **persistent** mac address for the tap interface:
+
+```text
+Nov 04 14:26:51 vpp-m7-9 systemd-udevd[44477]: ens2f0: Using generated
+persistent MAC address
+```
+
+Now, the udevd generated mac address is different from the uplink's original
+mac address which is programmed inside `VPP` and this mis-match causes packets
+to be dropped resulting in network connectivity failure.
+
+## What needs to be done?
+
+Setting the **MACAddressPolicy=none** for the problematic NIC prevents `udevd`
+from trying to generate mac address preventing the race-condition.
+
+Create a `.link` file for the NIC under `/etc/systemd/network/` dir with
+**MACAddressPolicy=none** and **Driver=tun** under the `[Match]` section. For
+  e.g.,
+
+  ```bash
+  $ sudo cat /etc/systemd/network/10-ens2f0.link
+   [Match]
+   Driver=tun
+
+   [Link]
+   NamePolicy=keep
+   MACAddressPolicy=none
+  $
+  ```
+
+And finally,
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl restart systemd-udevd
+```
+
+**Note:** The **MACAddressPolicy=persistent** was not present in Ubuntu 20.04
+and seems to have been introduced from Ubuntu 22.04.


### PR DESCRIPTION
When Calico/VPP is deployed, one of the things that happens is that the uplink interface vanishes from the root network namespace. Depending on the uplink driver used, it is either moved to a different network namespace or it vanishes completely from the kernel/os, and it gets replaced with a tap interface with the same name, mac address and other attributes. This Houdini Act may confuse the likes of `systemd-udevd`, `systemd-networkd` and `NetworkManager` and produce undesirable effects impacting the deployment and/or the functioning of the cluster.

Therefore, for successful deployment and functioning, Calico/VPP may require some changes in the configuration of system services pertaining to networking:
- udevd
- systemd-networkd
- NetworkManager

Adding documentation describing the issues and what needs to be done to circumvent them.