### PR TITLE
Fix kind installation envvars default values

### DIFF
--- a/test/kind/install_calico_vpp.sh
+++ b/test/kind/install_calico_vpp.sh
@@ -19,6 +19,7 @@ fi
 export IMAGE_PULL_POLICY=Always # Always Never IfNotPresent
 export CALICOVPP_ENABLE_MEMIF=true
 export CALICOVPP_ENABLE_VCL=true
+export CALICOVPP_PROMETHEUS_ENABLED=true
 export CALICOVPP_LOG_LEVEL=debug
 
 # ---------------- interfaces ----------------

--- a/yaml/overlays/dev/kustomize.sh
+++ b/yaml/overlays/dev/kustomize.sh
@@ -115,7 +115,7 @@ function get_initial_config ()
       \"vppStartupSleepSeconds\": ${CALICOVPP_VPP_STARTUP_SLEEP:-0},
       \"corePattern\": \"${CALICOVPP_CORE_PATTERN:-/var/lib/vpp/vppcore.%e.%p}\",
       \"defaultGWs\": \"${CALICOVPP_DEFAULT_GW}\",
-      \"healthCheckPort\": ${CALICOVPP_HEALTHCHECK_PORT},
+      \"healthCheckPort\": ${CALICOVPP_HEALTHCHECK_PORT:-9090},
       \"redirectToHostRules\": [
       {
         \"proto\": \"${CALICOVPP_REDIRECT_PROTO:-udp}\",


### PR DESCRIPTION
This patch changes the default values of the environment variables used by kind to have
- `CALICOVPP_PROMETHEUS_ENABLED=true`
- `CALICOVPP_HEALTHCHECK_PORT=9090`