### PR TITLE
vpp-manager: defer uplink admin-up until full FIB and tap setup

### DIFF
--- a/vpp-manager/vpp_runner.go
+++ b/vpp-manager/vpp_runner.go
@@ -1014,15 +1014,6 @@ func (v *VppRunner) runVpp() (err error) {
 			return errors.Wrap(err, "Error creating uplink interface")
 		}
 
-		// Data interface configuration
-		err = v.vpp.Retry(2*time.Second, 10, v.vpp.InterfaceAdminUp, v.params.UplinksSpecs[idx].SwIfIndex)
-		if err != nil {
-			terminateVpp("Error setting uplink interface up: %v", err)
-			v.vpp.Close()
-			<-vppDeadChan
-			return errors.Wrap(err, "Error setting uplink interface up")
-		}
-
 		err = v.configureVppUplinkInterface(v.uplinkDriver[idx], v.conf[idx], v.params.UplinksSpecs[idx])
 
 		if err != nil {
@@ -1064,6 +1055,18 @@ func (v *VppRunner) runVpp() (err error) {
 	}
 
 	networkHook.ExecuteWithUserScript(hooks.HookVppRunning, config.HookScriptVppRunning, v.params)
+
+	// Bring all VPP uplinks admin-up now that RA suppression, CNAT, VRF binding,
+	// addresses and routes are all programmed, the host-side taps exist and are
+	// configured and v6 link-local addresses have been discovered and configured.
+	for idx := 0; idx < len(v.params.UplinksSpecs); idx++ {
+		err = v.vpp.InterfaceAdminUp(v.params.UplinksSpecs[idx].SwIfIndex)
+		if err != nil {
+			terminateVpp("Error setting uplink %d up: %v", v.params.UplinksSpecs[idx].SwIfIndex, err)
+			<-vppDeadChan
+			return errors.Wrapf(err, "Error setting uplink %d up", v.params.UplinksSpecs[idx].SwIfIndex)
+		}
+	}
 
 	// Set the TAP interfaces admin-up in VPP last, after all Linux-side
 	// configuration is complete.


### PR DESCRIPTION
### Summary
Defer bringing the VPP uplink interface admin-up until the very end of `runVpp()` after the full FIB has been programmed and the host-side taps have been configured. This eliminates a startup window during which RA processing and incomplete FIB state could cause incorrect forwarding or pollute the FIB.

### RCA
`runVpp()` previously set the uplink admin-up immediately after `CreateMainVppInterface()` and only then proceeded to configure RA suppression, CNAT features and VRF assignment. During that window:
- VPP could process RAs arriving on the wire and install unwanted default routes from upstream routers into the FIB.
- VPP could acquire SLAAC addresses on the uplink that it should not have.
- A less-specific route (e.g. a default GW installed first) could be hit before a more-specific connected prefix was installed, causing the first packets to be forwarded the wrong way.

### Fix
- Bring uplink admin-up at the end of `runVpp()`. Bringing the uplink up just before the tap means the moment the host sees its tap go up, the wire side is already live. This ensures early host-originated traffic (DHCPv6 SOLICIT, NS/NA, BGP keepalives, etc.) does not hit an admin-down uplink and get dropped in the FIB. VPP auto-generates the v6 link-local address at admin-up. Since `SetInterfaceVRF()` has already run, the link-local address is installed in the correct VRF.
- The `Retry(2*time.Second, 10, ...)` wrapper around `InterfaceAdminUp` is also dropped. By the time admin-up runs, many VPP API calls have already succeeded, so the binary API is demonstrably ready - the retry's old role as a VPP-readiness probe no longer applies.

#### Before
`CreateMainVppInterface` → `EnableInterfaceIP6` → **`InterfaceAdminUp` (uplinks)** → `configureVppUplinkInterface` (RA suppress, CNAT, VRF, addresses, routes) → tap setup → `configureLinuxTap` → `InterfaceAdminUp` (taps)
#### After
`CreateMainVppInterface` → `EnableInterfaceIP6` → `configureVppUplinkInterface` (RA suppress, CNAT, VRF, addresses, routes) → tap setup → `configureLinuxTap` → **`InterfaceAdminUp` (uplinks)** → `InterfaceAdminUp` (taps)