### PR TITLE
add virtio secondary mac support VPP patches

### DIFF
--- a/vpplink/generated/generate.log
+++ b/vpplink/generated/generate.log
@@ -1,11 +1,14 @@
-VPP Version                 : 26.06-rc0~258-ge8b69f3f8
+VPP Version                 : 26.06-rc0~261-g8be8db2e5
 Binapi-generator version    : v0.11.0
-VPP Base commit             : 461470599 gerrit:34726/3 interface: add buffer stats api
+VPP Base commit             : 1f413769c gerrit:34726/3 interface: add buffer stats api
 ------------------ Cherry picked commits --------------------
+npol: add matched rule id to acl trace
 ip-neighbor: preserve interface LL receive DPO for self link-local
 acl: acl-plugin custom policies
 cnat: [WIP] no k8s maglev from pods
 pbl: Port based balancer
+gerrit:44935/4 virtio: add support for secondary MAC filtering
+gerrit:44930/4 virtio: add support for MAC address change
 gerrit:45046/4 ip6-nd: add punt reason for neigh advs
 gerrit:45099/2 ip6-nd: add nd-proxy all dst
 gerrit:44966/5 ip-neighbor: fix missing solicited-node multicast MAC

--- a/vpplink/generated/vpp_clone_current.sh
+++ b/vpplink/generated/vpp_clone_current.sh
@@ -119,12 +119,14 @@ git_revert refs/changes/75/39675/5  # ip-neighbor: do not use sas to determine N
 # corresponding translation disappears
 git_cherry_pick refs/changes/69/43369/21 # 43369: cnat: converge new cnat implementation to support encaps (calico) https://gerrit.fd.io/r/c/vpp/+/43369
 
-# fix unicast NA handling in VPP ND proxy
+# IPv6 related fixes:
 git_cherry_pick refs/changes/50/44350/3 # 44350: vnet: fix unicast NA handling in ND proxy | https://gerrit.fd.io/r/c/vpp/+/44350
 git_cherry_pick refs/changes/03/44903/1 # 44903: vxlan: reset next_dpo on delete | https://gerrit.fd.io/r/c/vpp/+/44903
 git_cherry_pick refs/changes/66/44966/5 # 44966: ip-neighbor: fix missing solicited-node multicast MAC | https://gerrit.fd.io/r/c/vpp/+/44966
 git_cherry_pick refs/changes/99/45099/2 # 45099: ip6-nd: add nd-proxy all dst | https://gerrit.fd.io/r/c/vpp/+/45099
 git_cherry_pick refs/changes/46/45046/4 # 45046: ip6-nd: add punt reason for neigh advs | https://gerrit.fd.io/r/c/vpp/+/45046
+git_cherry_pick refs/changes/30/44930/4 # 44930: virtio: add support for MAC address change | https://gerrit.fd.io/r/c/vpp/+/44930
+git_cherry_pick refs/changes/35/44935/4 # 44935: virtio: add support for secondary MAC filtering | https://gerrit.fd.io/r/c/vpp/+/44935
 
 # --------------- private plugins ---------------
 # Generated with 'git format-patch --zero-commit -o ./patches/ HEAD^^^'


### PR DESCRIPTION
VPP `virtio` code lacked secondary MAC address support, which was recently added.
- https://gerrit.fd.io/r/c/vpp/+/44930
- https://gerrit.fd.io/r/c/vpp/+/44935

This PR cherry-picks those Gerrit patches so that we **do not run into missing solicited node secondary MAC address issues** on `virtio` interfaces on IPv6-enabled cluster.