### PR TITLE
fix: correct BSID parsing and SR Policy SAFI matching in SRv6

### DIFF
--- a/calico-vpp-agent/connectivity/srv6.go
+++ b/calico-vpp-agent/connectivity/srv6.go
@@ -246,12 +246,23 @@ func (p *SRv6Provider) getPolicyNode(nodeip string, behavior types.SrBehavior) (
 	p.log.Infof("SRv6Provider getPolicyNode node: %s, with beahvior: %d", nodeip, behavior)
 	if p.nodePolices[nodeip] != nil {
 		var priority uint32
-		for _, tunnel := range p.nodePolices[nodeip].SRv6Tunnel {
-			if types.FromGoBGPSrBehavior(tunnel.Behavior) == behavior && tunnel.Priority >= priority {
+		p.log.Infof("SRv6Provider getPolicyNode: found %d tunnels for node %s", len(p.nodePolices[nodeip].SRv6Tunnel), nodeip)
+		for i, tunnel := range p.nodePolices[nodeip].SRv6Tunnel {
+			converted := types.FromGoBGPSrBehavior(tunnel.Behavior)
+			p.log.Infof("SRv6Provider getPolicyNode: tunnel[%d] behavior=%d converted=%d want=%d match=%v policy=%v",
+				i, tunnel.Behavior, converted, behavior, converted == behavior, tunnel.Policy != nil)
+			if converted == behavior && tunnel.Priority >= priority {
 				priority = tunnel.Priority
 				policy = tunnel.Policy
 			}
 		}
+	} else {
+		p.log.Infof("SRv6Provider getPolicyNode: nodePolices[%s] is nil", nodeip)
+	}
+	if policy == nil {
+		p.log.Infof("SRv6Provider getPolicyNode: no matching policy found")
+	} else {
+		p.log.Infof("SRv6Provider getPolicyNode: found policy bsid=%s", policy.Bsid.String())
 	}
 	return policy, err
 }

--- a/calico-vpp-agent/routing/bgp_watcher.go
+++ b/calico-vpp-agent/routing/bgp_watcher.go
@@ -22,7 +22,6 @@ import (
 
 	bgpapi "github.com/osrg/gobgp/v3/api"
 	"github.com/pkg/errors"
-	"google.golang.org/protobuf/types/known/anypb"
 	"gopkg.in/tomb.v2"
 
 	calicov3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
@@ -89,6 +88,12 @@ func (s *Server) injectRoute(path *bgpapi.Path) error {
 			}
 			vpn = true
 		} else {
+			// Fallback: handle SRPolicyNLRI that may not have been caught by the SAFI check
+			srnrli := &bgpapi.SRPolicyNLRI{}
+			if err := path.Nlri.UnmarshalTo(srnrli); err == nil {
+				s.log.Infof("injectRoute: SRPolicyNLRI fallback, redirecting to injectSRv6Policy")
+				return s.injectSRv6Policy(path)
+			}
 			return fmt.Errorf("cannot handle Nlri: %+v", path.Nlri)
 		}
 	}
@@ -147,13 +152,14 @@ func (s *Server) getSRPolicy(path *bgpapi.Path) (srv6Policy *types.SrPolicy, srv
 						}
 					}
 					// search for TunnelEncapSubTLVSRBindingSID
-					srbsids := &anypb.Any{}
-					if err := innerTlv.UnmarshalTo(srbsids); err == nil {
+					subTLVBsid := &bgpapi.TunnelEncapSubTLVSRBindingSID{}
+					if err := innerTlv.UnmarshalTo(subTLVBsid); err == nil {
 						s.log.Debugf("getSRPolicy TunnelEncapSubTLVSRBindingSID")
-						if err := srbsids.UnmarshalTo(srv6bsid); err != nil {
-							return nil, nil, nil, err
+						if subTLVBsid.Bsid != nil {
+							if err := subTLVBsid.Bsid.UnmarshalTo(srv6bsid); err != nil {
+								return nil, nil, nil, err
+							}
 						}
-
 					}
 
 					// search for TunnelEncapSubTLVSRPriority
@@ -193,11 +199,14 @@ func (s *Server) getSRPolicy(path *bgpapi.Path) (srv6Policy *types.SrPolicy, srv
 }
 
 func (s *Server) injectSRv6Policy(path *bgpapi.Path) error {
+	s.log.Infof("injectSRv6Policy called")
 	_, srv6tunnel, srnrli, err := s.getSRPolicy(path)
 
 	if err != nil {
 		return errors.Wrap(err, "error injectSRv6Policy")
 	}
+	s.log.Infof("injectSRv6Policy: endpoint=%s, dst=%s, behavior=%d, bsid=%s, sids=%v",
+		net.IP(srnrli.Endpoint), srv6tunnel.Dst, srv6tunnel.Behavior, srv6tunnel.Bsid, srv6tunnel.Sid)
 
 	cn := &common.NodeConnectivity{
 		Dst:              net.IPNet{},
@@ -249,7 +258,7 @@ func (s *Server) startBGPMonitoring() (func(), error) {
 						s.log.Debugf("Ignoring internal path")
 						continue
 					}
-					if *config.GetCalicoVppFeatureGates().SRv6Enabled && path.GetFamily() == &common.BgpFamilySRv6IPv6 {
+					if *config.GetCalicoVppFeatureGates().SRv6Enabled && path.GetFamily().GetSafi() == bgpapi.Family_SAFI_SR_POLICY {
 						s.log.Debugf("Path SRv6")
 						err := s.injectSRv6Policy(path)
 						if err != nil {

--- a/calico-vpp-agent/routing/bgp_watcher.go
+++ b/calico-vpp-agent/routing/bgp_watcher.go
@@ -22,7 +22,6 @@ import (
 
 	bgpapi "github.com/osrg/gobgp/v3/api"
 	"github.com/pkg/errors"
-	"google.golang.org/protobuf/types/known/anypb"
 	"gopkg.in/tomb.v2"
 
 	calicov3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
@@ -89,6 +88,12 @@ func (s *Server) injectRoute(path *bgpapi.Path) error {
 			}
 			vpn = true
 		} else {
+			// Fallback: handle SRPolicyNLRI that may not have been caught by the SAFI check
+			srnrli := &bgpapi.SRPolicyNLRI{}
+			if err := path.Nlri.UnmarshalTo(srnrli); err == nil {
+				s.log.Debugf("injectRoute: SRPolicyNLRI fallback, redirecting to injectSRv6Policy")
+				return s.injectSRv6Policy(path)
+			}
 			return fmt.Errorf("cannot handle Nlri: %+v", path.Nlri)
 		}
 	}
@@ -147,13 +152,14 @@ func (s *Server) getSRPolicy(path *bgpapi.Path) (srv6Policy *types.SrPolicy, srv
 						}
 					}
 					// search for TunnelEncapSubTLVSRBindingSID
-					srbsids := &anypb.Any{}
-					if err := innerTlv.UnmarshalTo(srbsids); err == nil {
+					subTLVBsid := &bgpapi.TunnelEncapSubTLVSRBindingSID{}
+					if err := innerTlv.UnmarshalTo(subTLVBsid); err == nil {
 						s.log.Debugf("getSRPolicy TunnelEncapSubTLVSRBindingSID")
-						if err := srbsids.UnmarshalTo(srv6bsid); err != nil {
-							return nil, nil, nil, err
+						if subTLVBsid.Bsid != nil {
+							if err := subTLVBsid.Bsid.UnmarshalTo(srv6bsid); err != nil {
+								return nil, nil, nil, err
+							}
 						}
-
 					}
 
 					// search for TunnelEncapSubTLVSRPriority
@@ -193,11 +199,14 @@ func (s *Server) getSRPolicy(path *bgpapi.Path) (srv6Policy *types.SrPolicy, srv
 }
 
 func (s *Server) injectSRv6Policy(path *bgpapi.Path) error {
+	s.log.Debugf("injectSRv6Policy called")
 	_, srv6tunnel, srnrli, err := s.getSRPolicy(path)
 
 	if err != nil {
 		return errors.Wrap(err, "error injectSRv6Policy")
 	}
+	s.log.Debugf("injectSRv6Policy: endpoint=%s, dst=%s, behavior=%d, bsid=%s, sids=%v",
+		net.IP(srnrli.Endpoint), srv6tunnel.Dst, srv6tunnel.Behavior, srv6tunnel.Bsid, srv6tunnel.Sid)
 
 	cn := &common.NodeConnectivity{
 		Dst:              net.IPNet{},
@@ -249,7 +258,7 @@ func (s *Server) startBGPMonitoring() (func(), error) {
 						s.log.Debugf("Ignoring internal path")
 						continue
 					}
-					if *config.GetCalicoVppFeatureGates().SRv6Enabled && path.GetFamily() == &common.BgpFamilySRv6IPv6 {
+					if *config.GetCalicoVppFeatureGates().SRv6Enabled && path.GetFamily().GetSafi() == bgpapi.Family_SAFI_SR_POLICY {
 						s.log.Debugf("Path SRv6")
 						err := s.injectSRv6Policy(path)
 						if err != nil {


### PR DESCRIPTION
## Summary
Fix three independent issues in SRv6 BGP path processing that together
prevent SR Policy from being installed correctly in VPP.

## Root Cause

**1. BSID parsing silently fails**
`getSRPolicy()` unmarshals the inner TLV into a raw `anypb.Any` and
then tries to unmarshal that into `SRBindingSID`. The first
`UnmarshalTo` fails with a type URL mismatch
(`TunnelEncapSubTLVSRBindingSID` vs. `google.protobuf.Any`), the
block is silently skipped, and `srv6bsid.Sid` stays `nil`. VPP ends
up with an SR Policy whose BSID is all zeros, so no traffic is
steered.

**2. SAFI check never matches**
`startBGPMonitoring()` compares `path.GetFamily() == &common.BgpFamilySRv6IPv6`.
Since both sides are pointers to distinct objects, the comparison is
always `false`. SR Policy paths bypass `injectSRv6Policy()` entirely
and fall through to `injectRoute()`, which emits `cannot handle Nlri`
and drops them.

**3. `injectRoute` has no path for `SRPolicyNLRI`**
Even if the SAFI check were to be bypassed for any reason,
`injectRoute()` only recognizes `IPAddressPrefix` and
`LabeledVPNIPAddressPrefix`, so SR Policy paths are lost.

## Fix
1. Unmarshal through `TunnelEncapSubTLVSRBindingSID` and its inner
   `.Bsid` Any, with a nil guard for the optional `Bsid` field.
2. Compare `path.GetFamily().GetSafi() == Family_SAFI_SR_POLICY`
   (enum-value compare, AFI-agnostic).
3. In `injectRoute()`, detect `SRPolicyNLRI` and redirect to
   `injectSRv6Policy()` as a defensive fallback.

Fixes #972