### PR TITLE
Upgrade ci-builder img to ubnt24.04 go1.26

### DIFF
--- a/.ci/buildspec.yml
+++ b/.ci/buildspec.yml
@@ -32,7 +32,6 @@ phases:
       - make clean-vpp
       - make images
 
-      - make mdlint
       - make ci-lint
       - make ci-test
       - make ci-cov

--- a/Dockerfile.depend
+++ b/Dockerfile.depend
@@ -1,28 +1,28 @@
-ARG BASE_IMAGE
+#
+# Docker image with golang, dependancies and linters
+# use to build the code in a stable and cached environment
+#
+FROM ubuntu:24.04 AS dependencies
 
-#
-# Dependencies image
-#
-FROM ${BASE_IMAGE:-ubuntu:22.04} AS dependencies
+ENV GOVERSION=1.26.1
+ENV GOLANGCILINT_VERSION=v2.11.4
+ENV MARKDOWNLINT_VERSION=0.48.0
 
 ENV UNATTENDED=y
 
-RUN apt-get update \
- && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
-    apt-utils wget cmake curl git docker.io
+RUN apt-get update && \
+ 	DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
+        apt-utils wget cmake curl git docker.io && \
+    curl -sSfL https://deb.nodesource.com/setup_20.x | bash - && \
+    apt-get update -y -q && apt-get install -y -qq --no-install-recommends nodejs && \
+	npm install -g --no-progress markdownlint-cli@${MARKDOWNLINT_VERSION}
 
-ENV GOVERSION=1.24.0
-ENV GOROOT="/root/.go"
-ENV GOPATH="/root/go"
-ENV PATH=$GOROOT/bin:$PATH
-ENV PATH=$GOPATH/bin:$PATH
-
-RUN mkdir -p "${GOROOT}" &&\
-    mkdir -p "${GOPATH}"/src "${GOPATH}"/pkg "${GOPATH}"/bin
 RUN wget -nv "https://dl.google.com/go/go${GOVERSION}.linux-amd64.tar.gz" -O "/tmp/go.tar.gz" && \
-    tar -C "${GOROOT}" --strip-components=1 -xzf "/tmp/go.tar.gz" && \
+    tar -C /usr/local --strip-components=1 -xzf "/tmp/go.tar.gz" && \
     rm -f "/tmp/go.tar.gz" && \
-    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.1.6
+    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
+        | sh -s -- -b $(go env GOPATH)/bin ${GOLANGCILINT_VERSION}
+ENV PATH=$PATH:/root/go/bin/
 
 # Get modules used by the source code
 RUN mkdir -p /vpp-dataplane
@@ -30,4 +30,4 @@ RUN git config --global --add safe.directory /vpp-dataplane
 COPY go.mod /vpp-dataplane
 COPY go.sum /vpp-dataplane
 WORKDIR /vpp-dataplane
-RUN go get ./... && rm -fr /vpp-dataplane
+RUN go mod download && rm -fr /vpp-dataplane

--- a/Makefile
+++ b/Makefile
@@ -299,9 +299,15 @@ delete-multinet:
 
 .PHONY: lint
 lint:
-	gofmt -s -l . | grep -v binapi | grep -v vpp_build | diff -u /dev/null -
+	go mod tidy --diff || (echo -e "Please run\ngo mod tidy" && exit 1)
+	gofmt -s -l . | grep -vE '(binapi|vpp_build|vendor)' \
+		| diff -u /dev/null - \
+		|| (echo -e "Please run\ngofmt -w ." && exit 1)
 	test -d vpp-manager/vpp_build && touch vpp-manager/vpp_build/go.mod || true
 	golangci-lint run --color=never
+	markdownlint --dot \
+		--ignore vpp-manager/vpp_build \
+		--ignore vendor .
 
 .PHONY: cov-html
 cov-html:
@@ -326,20 +332,8 @@ cov:
 # remain stable.
 #
 
-BASE_IMAGE_BUILDER = ubuntu:22.04
-
-# Compute hash to detect any changes and rebuild/push the image
-DEPEND_HASH = $(shell echo \
-    "${BASE_IMAGE_BUILDER}-DOCKERFILE:$(shell md5sum \
-    	$(CURDIR)/Dockerfile.depend \
-    	$(CURDIR)/go.mod \
-    	$(CURDIR)/go.sum \
-    	| cut -f1 -d' ' \
-	)" | md5sum | cut -f1 -d' ')
-DEPEND_IMAGE = ${DEPEND_BASE}:${DEPEND_HASH}
-
 ifdef CI_BUILD
-PUSH_IMAGE = docker image push ${DEPEND_IMAGE}
+PUSH_IMAGE = docker image push ${CI_BUILDER_IMAGE}
 else
 PUSH_IMAGE = echo not pushing image
 endif
@@ -348,15 +342,13 @@ endif
 builder-image: ## Make dependencies image. (Not required normally; is implied in making any other container image).
 	# Try to pull an existing dependencies image; it's OK if none exists yet.
 	@echo Building depend image
-	docker image pull ${DEPEND_IMAGE} || /bin/true
-	docker image inspect ${DEPEND_IMAGE} >/dev/null 2>/dev/null \
+	docker image pull ${CI_BUILDER_IMAGE} || /bin/true
+	docker image inspect ${CI_BUILDER_IMAGE} >/dev/null 2>/dev/null \
 		  || ( docker image build \
 				-f ./Dockerfile.depend \
-				--build-arg BASE_IMAGE=${BASE_IMAGE_BUILDER} \
-				--tag ${DEPEND_IMAGE} \
+				--tag ${CI_BUILDER_IMAGE} \
 				$(CURDIR) \
 		   && ${PUSH_IMAGE} )
-	docker tag ${DEPEND_IMAGE} ${DEPEND_BASE}:latest
 
 # make test - runs the unit & VPP-integration tests
 # requiring sudo, this is useful in dev as this caches go deps.
@@ -401,7 +393,7 @@ ci-test: builder-image
 		--env VPP_BINARY=/usr/bin/vpp \
 		--env VPP_IMAGE=calicovpp/vpp:$(TAG) \
 		-w /vpp-dataplane \
-		${DEPEND_IMAGE} \
+		${CI_BUILDER_IMAGE} \
 		go test ./... \
 			-cover \
 			-covermode=atomic \
@@ -413,16 +405,10 @@ ci-test: builder-image
 ci-%: builder-image
 	docker run -t --rm \
 		-v $(CURDIR):/vpp-dataplane \
-		${DEPEND_IMAGE} \
+		${CI_BUILDER_IMAGE} \
 		make -C /vpp-dataplane $*
 
 .PHONY: depend-image-hash
 depend-image-hash:
-	@echo $(DEPEND_IMAGE)
+	@echo $(CI_BUILDER_IMAGE)
 
-.PHONY: mdlint
-mdlint:
-ifdef CI_BUILD
-	npm install -g markdownlint-cli
-endif
-	markdownlint --dot --ignore vpp-manager/vpp_build .

--- a/common.mk
+++ b/common.mk
@@ -1,7 +1,6 @@
 VPP_DATAPLANE_DIR = $(shell git rev-parse --show-toplevel)
 
-DEPEND_BASE = calicovpp/ci-builder
-VPP_BUCKET = calico-vpp-ci-artefacts
+VPP_CI_ARTIFACTS_BUCKET = calico-vpp-ci-artefacts
 
 export GOOS ?= linux
 
@@ -10,6 +9,16 @@ export GOOS ?= linux
 PUSH_DEP := image
 
 REGISTRIES := docker.io/
+
+# Compute hash to detect any changes and rebuild/push the image
+CI_BUILDER_IMAGE_HASH = $(shell echo \
+    "DOCKERFILE:$(shell md5sum \
+        $(VPP_DATAPLANE_DIR)/Dockerfile.depend \
+        $(VPP_DATAPLANE_DIR)/go.mod \
+        $(VPP_DATAPLANE_DIR)/go.sum \
+    	| cut -f1 -d' ' \
+	)" | md5sum | cut -f1 -d' ')
+CI_BUILDER_IMAGE = calicovpp/ci-builder:${CI_BUILDER_IMAGE_HASH}
 
 # CI specific variables
 ifdef CODEBUILD_BUILD_NUMBER
@@ -35,7 +44,7 @@ ifdef CI_BUILD
 	DOCKER_OPTS += --user $$(id -u):$$(id -g)
 	DOCKER_OPTS += -w /vpp-dataplane/$(shell git rev-parse --show-prefix)
 	DOCKER_OPTS += -v $(VPP_DATAPLANE_DIR):/vpp-dataplane
-	DOCKER_RUN = docker run -t --rm --name build_temp ${DOCKER_OPTS} calicovpp/ci-builder:latest
+	DOCKER_RUN = docker run -t --rm --name build_temp ${DOCKER_OPTS} ${CI_BUILDER_IMAGE}
 
 	PUSH_DEP :=
 

--- a/docs/install/systemd-networkd.md
+++ b/docs/install/systemd-networkd.md
@@ -49,14 +49,14 @@ $
 This can lead to two very undesirable consequences:
 
 1. DNS config is wiped off leading to DNS failures
-2. If uplink is configured using **dhcp** then upon lease expiry, since `systemd-networkd`
-   is not **managing** the interface, it will not do the dhcp lease renewal thus
-   ultimately **bricking** the node.
+2. If uplink is configured using **dhcp** then upon lease expiry, since
+   `systemd-networkd` is not **managing** the interface, it will not do the
+   dhcp lease renewal thus ultimately **bricking** the node.
 
 In order to prevent the above from happening, create a `.network` file for the
 tap interface under `/etc/systemd/network` and configure the `[Match]` section
-with either the interface **Name** or **MACAddress** key. For example, say, the uplink
-interface is `ens5` and its `.network` file is `/run/systemd/network/10-netplan-ens5.network`
+with either the interface **Name** or **MACAddress** key. For example, say, the
+uplink interface is `ens5` and its `.network` file is `/run/systemd/network/10-netplan-ens5.network`
 then first copy this file to `/etc/systemd/network` and rename it:
 
 ```bash

--- a/docs/install/udevd.md
+++ b/docs/install/udevd.md
@@ -1,8 +1,8 @@
 # Introduction
 
 Calico/VPP deployment replaces the uplink interface with a tap interface which
-has the same name, mac address and other attributes. Most of the time there are no
-issues.
+has the same name, mac address and other attributes. Most of the time there are
+no issues.
 
 However, with certain NICs (Intel **E810**, for example) and when **multiple workers**
 are configured in `VPP` and when **MACAddressPolicy=persistent** is set in the

--- a/test/yaml/raw-envoy/README.md
+++ b/test/yaml/raw-envoy/README.md
@@ -1,6 +1,7 @@
 # Envoy TLS proxy perf test
 
-This directory contains a setup for testing host to host proxy performance with envoy
+This directory contains a setup for testing host to host proxy performance
+with envoy
 
 ## Test conditions
 

--- a/vpp-manager/Makefile
+++ b/vpp-manager/Makefile
@@ -185,7 +185,7 @@ vpp: clone-vpp vpp-build-env version-file
 	rm -rf $(CURDIR)/artifacts
 ifdef CI_BUILD
 	aws s3api put-object \
-		--bucket ${VPP_BUCKET} \
+		--bucket ${VPP_CI_ARTIFACTS_BUCKET} \
 		--key ${VPP_TARBALL} \
 		--body ${VPP_TARBALL}
 endif
@@ -193,7 +193,7 @@ endif
 ${VPP_TARBALL}:
 ifdef CI_BUILD
 	aws s3api get-object \
-		--bucket ${VPP_BUCKET} \
+		--bucket ${VPP_CI_ARTIFACTS_BUCKET} \
 		--key ${VPP_TARBALL} \
 		${VPP_TARBALL} \
 	|| $(MAKE) vpp

--- a/vpp-manager/hooks/network_manager_hook.go
+++ b/vpp-manager/hooks/network_manager_hook.go
@@ -638,19 +638,19 @@ func (h *NetworkManagerHook) createUdevNetNameRules() error {
 		// Each interface gets its own rule line.
 		// systemd-networkd uses ID_NET_NAME_* (via net_get_persistent_name) for DHCPv6 IAID
 		// computation; without these properties it falls back to a MAC-derived IAID.
-		ruleBuilder.WriteString(fmt.Sprintf("SUBSYSTEM==\"net\", ATTR{address}==\"%s\"", props.MacAddress))
+		fmt.Fprintf(&ruleBuilder, "SUBSYSTEM==\"net\", ATTR{address}==\"%s\"", props.MacAddress)
 
 		if props.IDNetNameOnboard != "" {
-			ruleBuilder.WriteString(fmt.Sprintf(", ENV{ID_NET_NAME_ONBOARD}:=\"%s\"", props.IDNetNameOnboard))
+			fmt.Fprintf(&ruleBuilder, ", ENV{ID_NET_NAME_ONBOARD}:=\"%s\"", props.IDNetNameOnboard)
 		}
 		if props.IDNetNameSlot != "" {
-			ruleBuilder.WriteString(fmt.Sprintf(", ENV{ID_NET_NAME_SLOT}:=\"%s\"", props.IDNetNameSlot))
+			fmt.Fprintf(&ruleBuilder, ", ENV{ID_NET_NAME_SLOT}:=\"%s\"", props.IDNetNameSlot)
 		}
 		if props.IDNetNamePath != "" {
-			ruleBuilder.WriteString(fmt.Sprintf(", ENV{ID_NET_NAME_PATH}:=\"%s\"", props.IDNetNamePath))
+			fmt.Fprintf(&ruleBuilder, ", ENV{ID_NET_NAME_PATH}:=\"%s\"", props.IDNetNamePath)
 		}
 		if props.IDNetNameMac != "" {
-			ruleBuilder.WriteString(fmt.Sprintf(", ENV{ID_NET_NAME_MAC}:=\"%s\"", props.IDNetNameMac))
+			fmt.Fprintf(&ruleBuilder, ", ENV{ID_NET_NAME_MAC}:=\"%s\"", props.IDNetNameMac)
 		}
 		ruleBuilder.WriteString("\n")
 		rulesAdded++


### PR DESCRIPTION
This patch upgrades the ci-builder image to ubuntu 24.04 golang 1.26.1.
It also upgrades the golangcilint version and includes markdown lint into the ci bundle