### PR TITLE
fix(cnat): make SNAT policy remove idempotent on ENOENT

### DIFF
--- a/vpplink/cnat.go
+++ b/vpplink/cnat.go
@@ -18,6 +18,7 @@ package vpplink
 import (
 	"fmt"
 	"net"
+	"strings"
 
 	"github.com/projectcalico/vpp-dataplane/v3/vpplink/generated/bindings/cnat"
 	"github.com/projectcalico/vpp-dataplane/v3/vpplink/generated/bindings/interface_types"
@@ -165,6 +166,14 @@ func (v *VppLink) cnatSnatPolicyAddDelPodInterface(swIfIndex uint32, isAdd bool,
 		Table:     table,
 	})
 	if err != nil {
+		// On remove (isAdd=false), the agent iterates over all (interface, family)
+		// combinations from podInterfaceMap on every IpamConfChanged event. For an
+		// IPv6 single-stack cluster, IPv4 SNAT was never registered on Pod
+		// interfaces, so VPP replies "No such entry (-6)" when the agent tries
+		// to remove it. Swallow the ENOENT to keep the reconciliation loop alive.
+		if !isAdd && strings.Contains(err.Error(), "No such entry") {
+			return nil
+		}
 		return fmt.Errorf("cnatSnatPolicyAddDelIf %+v failed: %w", swIfIndex, err)
 	}
 	return nil


### PR DESCRIPTION
## Problem

On an IPv6 single-stack cluster, `calico-vpp-node` crashes with:

```
cnatSnatPolicyAddDelIf 4 failed: VPPApiError: No such entry (-6)
```

The error propagates through the agent's tomb and tears the whole DaemonSet into `CrashLoopBackOff`.

### Reproduction

- kubeadm init with `--pod-network-cidr=fd20::/64 --service-cidr=fd30::/108`
- `Installation` CR with a single IPv6 `ipPools` entry
- Create any workload Pod; the agent crashes on the next `IpamConfChanged` event

## Root cause

`IpamConfChanged` reconciles SNAT for each pod interface × each IP family by calling `EnableDisableCnatSNAT(swIfIndex, isIP6, desiredState)` (`calico-vpp-agent/cni/cni_server.go:354`). The reconciliation is intentionally declarative:

```go
for _, podSpec := range s.podInterfaceMap {
    for _, swIfIndex := range []uint32{podSpec.LoopbackSwIfIndex, podSpec.TunTapSwIfIndex, podSpec.MemifSwIfIndex} {
        if swIfIndex != vpplink.InvalidID {
            for _, ipFamily := range vpplink.IPFamilies {
                err := s.vpp.EnableDisableCnatSNAT(swIfIndex, ipFamily.IsIP6, podSpec.NeedsSnat(...))
                ...
            }
        }
    }
}
```

For IPv6-only Pods only the v6 SNAT entry is ever registered on the interface, so the v4 state is "not present". When `NeedsSnat(v4) == false` and the agent calls `disable` on that interface, VPP replies with `No such entry (-6)` because there is nothing to remove. The agent treats it as a fatal error and `tomb.Dying` tears down every reconciliation goroutine.

In dual-stack clusters both families are always registered at Pod creation, so the remove path always hits an existing entry and this bug never surfaces.

## Fix

Make `cnatSnatPolicyAddDelPodInterface` tolerate `ENOENT` on the remove path: if the desired state ("not present") already matches the actual state, treat it as a no-op.

```go
if !isAdd && strings.Contains(err.Error(), "No such entry") {
    return nil
}
```

`add` continues to return errors so duplicate-add regressions remain visible.

## Why this shape

Proper state tracking on the agent side (remember which family was registered per interface and only toggle that) would be a larger refactor. Given the failure mode is just "agent over-reconciles in a way VPP dislikes", pushing the idempotency into the vpplink wrapper is the smallest safe change that keeps the reconcile loop alive.

## Verification

### Before

All `calico-vpp-node` Pods in `CrashLoopBackOff` on an IPv6 single-stack cluster; agent logs end with:

```
Tomb exited with Error enabling/disabling ip6 snat:
cnatSnatPolicyAddDelIf 4 failed: VPPApiError: No such entry (-6)
```

### After

With this patch (plus #973 for SRv6 BGP parsing) applied:

```
$ kubectl -n calico-vpp-dataplane get pods
NAME                    READY   STATUS    RESTARTS   AGE
calico-vpp-node-j4lp7   2/2     Running   0          30m
calico-vpp-node-mkjp2   2/2     Running   0          30m
calico-vpp-node-psp7d   2/2     Running   0          30m

$ kubectl -n calico-vpp-dataplane exec <vpp-pod> -c vpp -- vppctl show sr policies
[0].- BSID: cafe::183 ...
[1].- BSID: cafe::c3  ...
```

Pod-to-Pod traffic over SRv6 working end-to-end on the test cluster.

## Related

- #973 (merged) — BSID / SAFI parsing fix for SRv6 BGP, which made SR Policy install work end-to-end. This PR addresses a different layer of the same `IPv6 single-stack` story: keeping the agent alive when it reconciles SNAT on Pod interfaces.
