### PR TITLE
bump VPP commit to latest master to fix VPP kube test failures

### DIFF
--- a/vpplink/generated/bindings/acl/acl.ba.go
+++ b/vpplink/generated/bindings/acl/acl.ba.go
@@ -27,12 +27,6 @@ const (
 	VersionCrc = 0x5133bba0
 )
 
-// Replace an existing ACL in-place or create a new ACL
-//   - acl_index - an existing ACL entry (0..0xfffffffe) to replace, or 0xffffffff to make new ACL
-//   - tag - a string value stored along with the ACL, for descriptive purposes
-//   - count - number of ACL rules
-//     @r - Rules for this access-list
-//
 // ACLAddReplace defines message 'acl_add_replace'.
 type ACLAddReplace struct {
 	ACLIndex uint32              `binapi:"u32,name=acl_index" json:"acl_index,omitempty"`
@@ -133,10 +127,6 @@ func (m *ACLAddReplace) Unmarshal(b []byte) error {
 	return nil
 }
 
-// Reply to add/replace ACL
-//   - acl_index - index of the updated or newly created ACL
-//   - retval 0 - no error
-//
 // ACLAddReplaceReply defines message 'acl_add_replace_reply'.
 type ACLAddReplaceReply struct {
 	ACLIndex uint32 `binapi:"u32,name=acl_index" json:"acl_index,omitempty"`
@@ -174,9 +164,6 @@ func (m *ACLAddReplaceReply) Unmarshal(b []byte) error {
 	return nil
 }
 
-// Delete an ACL
-//   - acl_index - ACL index to delete
-//
 // ACLDel defines message 'acl_del'.
 type ACLDel struct {
 	ACLIndex uint32 `binapi:"u32,name=acl_index" json:"acl_index,omitempty"`
@@ -243,12 +230,6 @@ func (m *ACLDelReply) Unmarshal(b []byte) error {
 	return nil
 }
 
-// Details about a single ACL contents
-//   - acl_index - ACL index whose contents are being sent in this message
-//   - tag - Descriptive tag value which was supplied at ACL creation
-//   - count - Number of rules in this ACL
-//   - r - Array of rules within this ACL
-//
 // ACLDetails defines message 'acl_details'.
 type ACLDetails struct {
 	ACLIndex uint32              `binapi:"u32,name=acl_index" json:"acl_index,omitempty"`
@@ -349,9 +330,6 @@ func (m *ACLDetails) Unmarshal(b []byte) error {
 	return nil
 }
 
-// Dump the specific ACL contents or all of the ACLs' contents
-//   - acl_index - ACL index to dump, ~0 to dump all ACLs
-//
 // ACLDump defines message 'acl_dump'.
 type ACLDump struct {
 	ACLIndex uint32 `binapi:"u32,name=acl_index" json:"acl_index,omitempty"`
@@ -385,14 +363,6 @@ func (m *ACLDump) Unmarshal(b []byte) error {
 	return nil
 }
 
-// Use acl_interface_set_acl_list instead
-//
-//	Append/remove an ACL index to/from the list of ACLs checked for an interface
-//	- is_add - add or delete the ACL index from the list
-//	- is_input - check the ACL on input (1) or output (0)
-//	- sw_if_index - the interface to alter the list of ACLs on
-//	- acl_index - index of ACL for the operation
-//
 // ACLInterfaceAddDel defines message 'acl_interface_add_del'.
 type ACLInterfaceAddDel struct {
 	IsAdd     bool                           `binapi:"bool,name=is_add,default=true" json:"is_add,omitempty"`
@@ -471,12 +441,6 @@ func (m *ACLInterfaceAddDelReply) Unmarshal(b []byte) error {
 	return nil
 }
 
-// Details about ethertype whitelist on a single interface
-//   - sw_if_index - interface for which the list of MACIP ACLs is applied
-//   - count - total number of whitelisted ethertypes in the vector
-//   - n_input - this many first elements correspond to input whitelisted ethertypes, the rest - output
-//   - whitelist - vector of whitelisted ethertypes
-//
 // ACLInterfaceEtypeWhitelistDetails defines message 'acl_interface_etype_whitelist_details'.
 type ACLInterfaceEtypeWhitelistDetails struct {
 	SwIfIndex interface_types.InterfaceIndex `binapi:"interface_index,name=sw_if_index" json:"sw_if_index,omitempty"`
@@ -533,9 +497,6 @@ func (m *ACLInterfaceEtypeWhitelistDetails) Unmarshal(b []byte) error {
 	return nil
 }
 
-// Dump the list(s) of Ethertype whitelists applied to specific or all interfaces
-//   - sw_if_index - interface to dump the ethertype whitelist for
-//
 // ACLInterfaceEtypeWhitelistDump defines message 'acl_interface_etype_whitelist_dump'.
 type ACLInterfaceEtypeWhitelistDump struct {
 	SwIfIndex interface_types.InterfaceIndex `binapi:"interface_index,name=sw_if_index" json:"sw_if_index,omitempty"`
@@ -571,12 +532,6 @@ func (m *ACLInterfaceEtypeWhitelistDump) Unmarshal(b []byte) error {
 	return nil
 }
 
-// Details about a single ACL contents
-//   - sw_if_index - interface for which the list of ACLs is applied
-//   - count - total length of acl indices vector
-//   - n_input - this many of indices in the beginning are input ACLs, the rest - output
-//   - acls - the vector of ACL indices
-//
 // ACLInterfaceListDetails defines message 'acl_interface_list_details'.
 type ACLInterfaceListDetails struct {
 	SwIfIndex interface_types.InterfaceIndex `binapi:"interface_index,name=sw_if_index" json:"sw_if_index,omitempty"`
@@ -631,9 +586,6 @@ func (m *ACLInterfaceListDetails) Unmarshal(b []byte) error {
 	return nil
 }
 
-// Dump the list(s) of ACL applied to specific or all interfaces
-//   - sw_if_index - interface for which to dump the ACL list. Default: 0xffffffff (All interfaces)
-//
 // ACLInterfaceListDump defines message 'acl_interface_list_dump'.
 type ACLInterfaceListDump struct {
 	SwIfIndex interface_types.InterfaceIndex `binapi:"interface_index,name=sw_if_index,default=4294967295" json:"sw_if_index,omitempty"`
@@ -667,12 +619,6 @@ func (m *ACLInterfaceListDump) Unmarshal(b []byte) error {
 	return nil
 }
 
-// Set the vector of input/output ACLs checked for an interface
-//   - sw_if_index - the interface to alter the list of ACLs on
-//   - count - total number of ACL indices in the vector
-//   - n_input - this many first elements correspond to input ACLs, the rest - output
-//   - acls - vector of ACL indices
-//
 // ACLInterfaceSetACLList defines message 'acl_interface_set_acl_list'.
 type ACLInterfaceSetACLList struct {
 	SwIfIndex interface_types.InterfaceIndex `binapi:"interface_index,name=sw_if_index" json:"sw_if_index,omitempty"`
@@ -762,12 +708,6 @@ func (m *ACLInterfaceSetACLListReply) Unmarshal(b []byte) error {
 	return nil
 }
 
-// Set the ethertype whitelists on an interface. Takes effect when applying ACLs on the interface, so must be given prior.
-//   - sw_if_index - the interface to alter the list of ACLs on
-//   - count - total number of whitelisted ethertypes in the vector
-//   - n_input - this many first elements correspond to input whitelisted ethertypes, the rest - output
-//   - whitelist - vector of whitelisted ethertypes
-//
 // ACLInterfaceSetEtypeWhitelist defines message 'acl_interface_set_etype_whitelist'.
 type ACLInterfaceSetEtypeWhitelist struct {
 	SwIfIndex interface_types.InterfaceIndex `binapi:"interface_index,name=sw_if_index" json:"sw_if_index,omitempty"`
@@ -932,7 +872,6 @@ func (m *ACLPluginControlPingReply) Unmarshal(b []byte) error {
 	return nil
 }
 
-// Get Connection table max entries
 // ACLPluginGetConnTableMaxEntries defines message 'acl_plugin_get_conn_table_max_entries'.
 type ACLPluginGetConnTableMaxEntries struct{}
 
@@ -1000,7 +939,6 @@ func (m *ACLPluginGetConnTableMaxEntriesReply) Unmarshal(b []byte) error {
 	return nil
 }
 
-// Get the plugin version
 // ACLPluginGetVersion defines message 'acl_plugin_get_version'.
 type ACLPluginGetVersion struct{}
 
@@ -1028,10 +966,6 @@ func (m *ACLPluginGetVersion) Unmarshal(b []byte) error {
 	return nil
 }
 
-// Reply to get the plugin version
-//   - major - Incremented every time a known breaking behavior change is introduced
-//   - minor - Incremented with small changes, may be used to avoid buggy versions
-//
 // ACLPluginGetVersionReply defines message 'acl_plugin_get_version_reply'.
 type ACLPluginGetVersionReply struct {
 	Major uint32 `binapi:"u32,name=major" json:"major,omitempty"`
@@ -1069,7 +1003,6 @@ func (m *ACLPluginGetVersionReply) Unmarshal(b []byte) error {
 	return nil
 }
 
-// Get if the hash-based ACL lookups are enabled (default) or not (use linear search)
 // ACLPluginUseHashLookupGet defines message 'acl_plugin_use_hash_lookup_get'.
 // InProgress: the message form may change in the future versions
 type ACLPluginUseHashLookupGet struct{}
@@ -1098,9 +1031,6 @@ func (m *ACLPluginUseHashLookupGet) Unmarshal(b []byte) error {
 	return nil
 }
 
-// Reply with the previous state of the hash lookup
-//   - prev_enable - previous state of the hash lookup use
-//
 // ACLPluginUseHashLookupGetReply defines message 'acl_plugin_use_hash_lookup_get_reply'.
 // InProgress: the message form may change in the future versions
 type ACLPluginUseHashLookupGetReply struct {
@@ -1137,9 +1067,6 @@ func (m *ACLPluginUseHashLookupGetReply) Unmarshal(b []byte) error {
 	return nil
 }
 
-// Enable hash-based ACL lookups (default) or disable them (use linear search)
-//   - enable - whether to enable or disable the usage of hash lookup algorithm
-//
 // ACLPluginUseHashLookupSet defines message 'acl_plugin_use_hash_lookup_set'.
 // InProgress: the message form may change in the future versions
 type ACLPluginUseHashLookupSet struct {
@@ -1210,9 +1137,6 @@ func (m *ACLPluginUseHashLookupSetReply) Unmarshal(b []byte) error {
 	return nil
 }
 
-// Enable or disable incrementing ACL counters in stats segment by interface processing
-//   - enable - whether to enable or disable incrementing the counters
-//
 // ACLStatsIntfCountersEnable defines message 'acl_stats_intf_counters_enable'.
 type ACLStatsIntfCountersEnable struct {
 	Enable bool `binapi:"bool,name=enable" json:"enable,omitempty"`
@@ -1281,11 +1205,6 @@ func (m *ACLStatsIntfCountersEnableReply) Unmarshal(b []byte) error {
 	return nil
 }
 
-// Add a MACIP ACL
-//   - tag - descriptive value for this MACIP ACL
-//   - count - number of rules in this MACIP ACL
-//   - r - vector of MACIP ACL rules
-//
 // MacipACLAdd defines message 'macip_acl_add'.
 type MacipACLAdd struct {
 	Tag   string                   `binapi:"string[64],name=tag" json:"tag,omitempty"`
@@ -1358,12 +1277,6 @@ func (m *MacipACLAdd) Unmarshal(b []byte) error {
 	return nil
 }
 
-// Add/Replace a MACIP ACL
-//   - acl_index - an existing MACIP ACL entry (0..0xfffffffe) to replace, or 0xffffffff to make new MACIP ACL Default: 0xffffffff
-//   - tag - descriptive value for this MACIP ACL
-//   - count - number of rules in this MACIP ACL
-//   - r - vector of MACIP ACL rules
-//
 // MacipACLAddReplace defines message 'macip_acl_add_replace'.
 type MacipACLAddReplace struct {
 	ACLIndex uint32                   `binapi:"u32,name=acl_index,default=4294967295" json:"acl_index,omitempty"`
@@ -1440,10 +1353,6 @@ func (m *MacipACLAddReplace) Unmarshal(b []byte) error {
 	return nil
 }
 
-// Reply to add/replace MACIP ACL
-//   - acl_index - index of the newly created MACIP ACL
-//   - retval 0 - no error
-//
 // MacipACLAddReplaceReply defines message 'macip_acl_add_replace_reply'.
 type MacipACLAddReplaceReply struct {
 	ACLIndex uint32 `binapi:"u32,name=acl_index" json:"acl_index,omitempty"`
@@ -1481,10 +1390,6 @@ func (m *MacipACLAddReplaceReply) Unmarshal(b []byte) error {
 	return nil
 }
 
-// Reply to add MACIP ACL
-//   - acl_index - index of the newly created MACIP ACL
-//   - retval 0 - no error
-//
 // MacipACLAddReply defines message 'macip_acl_add_reply'.
 type MacipACLAddReply struct {
 	ACLIndex uint32 `binapi:"u32,name=acl_index" json:"acl_index,omitempty"`
@@ -1522,9 +1427,6 @@ func (m *MacipACLAddReply) Unmarshal(b []byte) error {
 	return nil
 }
 
-// Delete a MACIP ACL
-//   - acl_index - MACIP ACL index to delete
-//
 // MacipACLDel defines message 'macip_acl_del'.
 type MacipACLDel struct {
 	ACLIndex uint32 `binapi:"u32,name=acl_index" json:"acl_index,omitempty"`
@@ -1591,12 +1493,6 @@ func (m *MacipACLDelReply) Unmarshal(b []byte) error {
 	return nil
 }
 
-// Details about one MACIP ACL
-//   - acl_index - index of this MACIP ACL
-//   - tag - descriptive tag which was supplied during the creation
-//   - count - length of the vector of MACIP ACL rules
-//   - r - rules comprising this MACIP ACL
-//
 // MacipACLDetails defines message 'macip_acl_details'.
 type MacipACLDetails struct {
 	ACLIndex uint32                   `binapi:"u32,name=acl_index" json:"acl_index,omitempty"`
@@ -1673,9 +1569,6 @@ func (m *MacipACLDetails) Unmarshal(b []byte) error {
 	return nil
 }
 
-// Dump one or all defined MACIP ACLs
-//   - acl_index - MACIP ACL index or ~0 to dump all MACIP ACLs Default: 0xffffffff
-//
 // MacipACLDump defines message 'macip_acl_dump'.
 type MacipACLDump struct {
 	ACLIndex uint32 `binapi:"u32,name=acl_index,default=4294967295" json:"acl_index,omitempty"`
@@ -1709,11 +1602,6 @@ func (m *MacipACLDump) Unmarshal(b []byte) error {
 	return nil
 }
 
-// Add or delete a MACIP ACL to/from interface
-//   - is_add - add (1) or delete (0) MACIP ACL from being used on an interface
-//   - sw_if_index - interface to apply the action to
-//   - acl_index - MACIP ACL index
-//
 // MacipACLInterfaceAddDel defines message 'macip_acl_interface_add_del'.
 type MacipACLInterfaceAddDel struct {
 	IsAdd     bool                           `binapi:"bool,name=is_add,default=true" json:"is_add,omitempty"`
@@ -1790,7 +1678,6 @@ func (m *MacipACLInterfaceAddDelReply) Unmarshal(b []byte) error {
 	return nil
 }
 
-// Get the vector of MACIP ACL IDs applied to the interfaces
 // MacipACLInterfaceGet defines message 'macip_acl_interface_get'.
 type MacipACLInterfaceGet struct{}
 
@@ -1818,10 +1705,6 @@ func (m *MacipACLInterfaceGet) Unmarshal(b []byte) error {
 	return nil
 }
 
-// Reply with the vector of MACIP ACLs by sw_if_index
-//   - count - total number of elements in the vector
-//   - acls - the vector of active MACIP ACL indices per sw_if_index
-//
 // MacipACLInterfaceGetReply defines message 'macip_acl_interface_get_reply'.
 type MacipACLInterfaceGetReply struct {
 	Count uint32   `binapi:"u32,name=count" json:"-"`
@@ -1868,11 +1751,6 @@ func (m *MacipACLInterfaceGetReply) Unmarshal(b []byte) error {
 	return nil
 }
 
-// Details about a single MACIP ACL contents
-//   - sw_if_index - interface for which the list of MACIP ACLs is applied
-//   - count - total length of acl indices vector
-//   - acls - the vector of MACIP ACL indices
-//
 // MacipACLInterfaceListDetails defines message 'macip_acl_interface_list_details'.
 type MacipACLInterfaceListDetails struct {
 	SwIfIndex interface_types.InterfaceIndex `binapi:"interface_index,name=sw_if_index" json:"sw_if_index,omitempty"`
@@ -1925,9 +1803,6 @@ func (m *MacipACLInterfaceListDetails) Unmarshal(b []byte) error {
 	return nil
 }
 
-// Dump the list(s) of MACIP ACLs applied to specific or all interfaces
-//   - sw_if_index - interface to dump the MACIP ACL list for
-//
 // MacipACLInterfaceListDump defines message 'macip_acl_interface_list_dump'.
 type MacipACLInterfaceListDump struct {
 	SwIfIndex interface_types.InterfaceIndex `binapi:"interface_index,name=sw_if_index" json:"sw_if_index,omitempty"`

--- a/vpplink/generated/bindings/af_xdp/af_xdp.ba.go
+++ b/vpplink/generated/bindings/af_xdp/af_xdp.ba.go
@@ -100,17 +100,6 @@ func (x AfXdpFlag) String() string {
 	return s
 }
 
-// - client_index - opaque cookie to identify the sender
-//   - host_if - Linux netdev interface name
-//   - name - new af_xdp interface name (optional)
-//   - rxq_num - number of receive queues. 65535 can be used as special value to request all available queues (optional)
-//   - rxq_size - receive queue size (optional)
-//   - txq_size - transmit queue size (optional)
-//   - mode - operation mode (optional)
-//   - flags - flags (optional)
-//   - prog - eBPF program path (optional)
-//   - netns - netns of nic (optional)
-//
 // AfXdpCreateV3 defines message 'af_xdp_create_v3'.
 type AfXdpCreateV3 struct {
 	HostIf  string    `binapi:"string[64],name=host_if" json:"host_if,omitempty"`
@@ -176,10 +165,6 @@ func (m *AfXdpCreateV3) Unmarshal(b []byte) error {
 	return nil
 }
 
-// - context - sender context, to match reply w/ request
-//   - retval - return value for request
-//   - sw_if_index - software index for the new af_xdp interface
-//
 // AfXdpCreateV3Reply defines message 'af_xdp_create_v3_reply'.
 type AfXdpCreateV3Reply struct {
 	Retval    int32                          `binapi:"i32,name=retval" json:"retval,omitempty"`

--- a/vpplink/generated/bindings/cnat/cnat.ba.go
+++ b/vpplink/generated/bindings/cnat/cnat.ba.go
@@ -700,7 +700,6 @@ func (m *CnatSetSnatAddressesV2Reply) Unmarshal(b []byte) error {
 	return nil
 }
 
-// /* A snat policy controls what traffic is srcNATed
 // CnatSetSnatPolicy defines message 'cnat_set_snat_policy'.
 type CnatSetSnatPolicy struct {
 	Policy CnatSnatPolicies `binapi:"cnat_snat_policies,name=policy" json:"policy,omitempty"`
@@ -1219,10 +1218,6 @@ func (m *CnatTranslationDump) Unmarshal(b []byte) error {
 	return nil
 }
 
-// /* An enpoint is either
-//   - An IP & a port
-//   - An interface, an address familiy and a port
-//
 // CnatTranslationUpdate defines message 'cnat_translation_update'.
 type CnatTranslationUpdate struct {
 	Translation CnatTranslation `binapi:"cnat_translation,name=translation" json:"translation,omitempty"`

--- a/vpplink/generated/bindings/ikev2/ikev2.ba.go
+++ b/vpplink/generated/bindings/ikev2/ikev2.ba.go
@@ -23,7 +23,7 @@ const _ = api.GoVppAPIPackageIsVersion2
 const (
 	APIFile    = "ikev2"
 	APIVersion = "1.0.1"
-	VersionCrc = 0xfdeb2617
+	VersionCrc = 0x934066d2
 )
 
 // Child SA details
@@ -807,11 +807,6 @@ func (m *Ikev2NonceGet) Unmarshal(b []byte) error {
 	return nil
 }
 
-// reply on specific nonce
-//   - retval - return code
-//   - data_len - nonce length
-//   - nonce - nonce data
-//
 // Ikev2NonceGetReply defines message 'ikev2_nonce_get_reply'.
 // InProgress: the message form may change in the future versions
 type Ikev2NonceGetReply struct {
@@ -1082,7 +1077,7 @@ type Ikev2ProfileDetails struct {
 
 func (m *Ikev2ProfileDetails) Reset()               { *m = Ikev2ProfileDetails{} }
 func (*Ikev2ProfileDetails) GetMessageName() string { return "ikev2_profile_details" }
-func (*Ikev2ProfileDetails) GetCrcString() string   { return "670d01d9" }
+func (*Ikev2ProfileDetails) GetCrcString() string   { return "3e3e895b" }
 func (*Ikev2ProfileDetails) GetMessageType() api.MessageType {
 	return api.ReplyMessage
 }
@@ -1124,6 +1119,7 @@ func (m *Ikev2ProfileDetails) Size() (size int) {
 	size += 1                            // m.Profile.IkeTs.CryptoAlg
 	size += 4                            // m.Profile.IkeTs.CryptoKeySize
 	size += 1                            // m.Profile.IkeTs.IntegAlg
+	size += 1                            // m.Profile.IkeTs.PrfAlg
 	size += 1                            // m.Profile.IkeTs.DhGroup
 	size += 1                            // m.Profile.EspTs.CryptoAlg
 	size += 4                            // m.Profile.EspTs.CryptoKeySize
@@ -1180,6 +1176,7 @@ func (m *Ikev2ProfileDetails) Marshal(b []byte) ([]byte, error) {
 	buf.EncodeUint8(m.Profile.IkeTs.CryptoAlg)
 	buf.EncodeUint32(m.Profile.IkeTs.CryptoKeySize)
 	buf.EncodeUint8(m.Profile.IkeTs.IntegAlg)
+	buf.EncodeUint8(m.Profile.IkeTs.PrfAlg)
 	buf.EncodeUint8(m.Profile.IkeTs.DhGroup)
 	buf.EncodeUint8(m.Profile.EspTs.CryptoAlg)
 	buf.EncodeUint32(m.Profile.EspTs.CryptoKeySize)
@@ -1233,6 +1230,7 @@ func (m *Ikev2ProfileDetails) Unmarshal(b []byte) error {
 	m.Profile.IkeTs.CryptoAlg = buf.DecodeUint8()
 	m.Profile.IkeTs.CryptoKeySize = buf.DecodeUint32()
 	m.Profile.IkeTs.IntegAlg = buf.DecodeUint8()
+	m.Profile.IkeTs.PrfAlg = buf.DecodeUint8()
 	m.Profile.IkeTs.DhGroup = buf.DecodeUint8()
 	m.Profile.EspTs.CryptoAlg = buf.DecodeUint8()
 	m.Profile.EspTs.CryptoKeySize = buf.DecodeUint32()
@@ -2725,7 +2723,7 @@ type Ikev2SetIkeTransforms struct {
 
 func (m *Ikev2SetIkeTransforms) Reset()               { *m = Ikev2SetIkeTransforms{} }
 func (*Ikev2SetIkeTransforms) GetMessageName() string { return "ikev2_set_ike_transforms" }
-func (*Ikev2SetIkeTransforms) GetCrcString() string   { return "076d7378" }
+func (*Ikev2SetIkeTransforms) GetCrcString() string   { return "aa99fec0" }
 func (*Ikev2SetIkeTransforms) GetMessageType() api.MessageType {
 	return api.RequestMessage
 }
@@ -2738,6 +2736,7 @@ func (m *Ikev2SetIkeTransforms) Size() (size int) {
 	size += 1  // m.Tr.CryptoAlg
 	size += 4  // m.Tr.CryptoKeySize
 	size += 1  // m.Tr.IntegAlg
+	size += 1  // m.Tr.PrfAlg
 	size += 1  // m.Tr.DhGroup
 	return size
 }
@@ -2750,6 +2749,7 @@ func (m *Ikev2SetIkeTransforms) Marshal(b []byte) ([]byte, error) {
 	buf.EncodeUint8(m.Tr.CryptoAlg)
 	buf.EncodeUint32(m.Tr.CryptoKeySize)
 	buf.EncodeUint8(m.Tr.IntegAlg)
+	buf.EncodeUint8(m.Tr.PrfAlg)
 	buf.EncodeUint8(m.Tr.DhGroup)
 	return buf.Bytes(), nil
 }
@@ -2759,6 +2759,7 @@ func (m *Ikev2SetIkeTransforms) Unmarshal(b []byte) error {
 	m.Tr.CryptoAlg = buf.DecodeUint8()
 	m.Tr.CryptoKeySize = buf.DecodeUint32()
 	m.Tr.IntegAlg = buf.DecodeUint8()
+	m.Tr.PrfAlg = buf.DecodeUint8()
 	m.Tr.DhGroup = buf.DecodeUint8()
 	return nil
 }
@@ -3199,10 +3200,6 @@ func (m *Ikev2SetTunnelInterfaceReply) Unmarshal(b []byte) error {
 	return nil
 }
 
-// details on specific traffic selector
-//   - retval - return code
-//   - ts - traffic selector data
-//
 // Ikev2TrafficSelectorDetails defines message 'ikev2_traffic_selector_details'.
 // InProgress: the message form may change in the future versions
 type Ikev2TrafficSelectorDetails struct {
@@ -3268,11 +3265,6 @@ func (m *Ikev2TrafficSelectorDetails) Unmarshal(b []byte) error {
 	return nil
 }
 
-// dump traffic selectors
-//   - is_initiator - specify type initiator|responder of nonce
-//   - sa_index - index of specific sa
-//   - child_sa_index - index of specific sa child of specific sa
-//
 // Ikev2TrafficSelectorDump defines message 'ikev2_traffic_selector_dump'.
 // InProgress: the message form may change in the future versions
 type Ikev2TrafficSelectorDump struct {
@@ -3339,7 +3331,7 @@ func file_ikev2_binapi_init() {
 	api.RegisterMessage((*Ikev2PluginSetSleepIntervalReply)(nil), "ikev2_plugin_set_sleep_interval_reply_e8d4e804")
 	api.RegisterMessage((*Ikev2ProfileAddDel)(nil), "ikev2_profile_add_del_2c925b55")
 	api.RegisterMessage((*Ikev2ProfileAddDelReply)(nil), "ikev2_profile_add_del_reply_e8d4e804")
-	api.RegisterMessage((*Ikev2ProfileDetails)(nil), "ikev2_profile_details_670d01d9")
+	api.RegisterMessage((*Ikev2ProfileDetails)(nil), "ikev2_profile_details_3e3e895b")
 	api.RegisterMessage((*Ikev2ProfileDisableNatt)(nil), "ikev2_profile_disable_natt_ebf79a66")
 	api.RegisterMessage((*Ikev2ProfileDisableNattReply)(nil), "ikev2_profile_disable_natt_reply_e8d4e804")
 	api.RegisterMessage((*Ikev2ProfileDump)(nil), "ikev2_profile_dump_51077d14")
@@ -3363,7 +3355,7 @@ func file_ikev2_binapi_init() {
 	api.RegisterMessage((*Ikev2SaV3Dump)(nil), "ikev2_sa_v3_dump_51077d14")
 	api.RegisterMessage((*Ikev2SetEspTransforms)(nil), "ikev2_set_esp_transforms_a63dc205")
 	api.RegisterMessage((*Ikev2SetEspTransformsReply)(nil), "ikev2_set_esp_transforms_reply_e8d4e804")
-	api.RegisterMessage((*Ikev2SetIkeTransforms)(nil), "ikev2_set_ike_transforms_076d7378")
+	api.RegisterMessage((*Ikev2SetIkeTransforms)(nil), "ikev2_set_ike_transforms_aa99fec0")
 	api.RegisterMessage((*Ikev2SetIkeTransformsReply)(nil), "ikev2_set_ike_transforms_reply_e8d4e804")
 	api.RegisterMessage((*Ikev2SetLocalKey)(nil), "ikev2_set_local_key_799b69ec")
 	api.RegisterMessage((*Ikev2SetLocalKeyReply)(nil), "ikev2_set_local_key_reply_e8d4e804")

--- a/vpplink/generated/bindings/ikev2_types/ikev2_types.ba.go
+++ b/vpplink/generated/bindings/ikev2_types/ikev2_types.ba.go
@@ -24,7 +24,7 @@ const _ = api.GoVppAPIPackageIsVersion2
 const (
 	APIFile    = "ikev2_types"
 	APIVersion = "1.0.0"
-	VersionCrc = 0x64c72418
+	VersionCrc = 0x67a53a36
 )
 
 // Ikev2State defines enum 'ikev2_state'.
@@ -124,6 +124,7 @@ type Ikev2IkeTransforms struct {
 	CryptoAlg     uint8  `binapi:"u8,name=crypto_alg" json:"crypto_alg,omitempty"`
 	CryptoKeySize uint32 `binapi:"u32,name=crypto_key_size" json:"crypto_key_size,omitempty"`
 	IntegAlg      uint8  `binapi:"u8,name=integ_alg" json:"integ_alg,omitempty"`
+	PrfAlg        uint8  `binapi:"u8,name=prf_alg" json:"prf_alg,omitempty"`
 	DhGroup       uint8  `binapi:"u8,name=dh_group" json:"dh_group,omitempty"`
 }
 

--- a/vpplink/generated/bindings/interface/interface.ba.go
+++ b/vpplink/generated/bindings/interface/interface.ba.go
@@ -3,7 +3,7 @@
 // Package interfaces contains generated bindings for API file interface.api.
 //
 // Contents:
-// - 74 messages
+// - 78 messages
 package interfaces
 
 import (
@@ -22,8 +22,8 @@ const _ = api.GoVppAPIPackageIsVersion2
 
 const (
 	APIFile    = "interface"
-	APIVersion = "3.2.3"
-	VersionCrc = 0x2c32eb46
+	APIVersion = "3.2.4"
+	VersionCrc = 0x6bc9fe33
 )
 
 // Enable or disable detailed interface stats
@@ -1710,6 +1710,79 @@ func (m *SwInterfaceEvent) Unmarshal(b []byte) error {
 	return nil
 }
 
+// Get the global default rx-mode for newly created interfaces
+// SwInterfaceGetDefaultRxMode defines message 'sw_interface_get_default_rx_mode'.
+type SwInterfaceGetDefaultRxMode struct{}
+
+func (m *SwInterfaceGetDefaultRxMode) Reset() { *m = SwInterfaceGetDefaultRxMode{} }
+func (*SwInterfaceGetDefaultRxMode) GetMessageName() string {
+	return "sw_interface_get_default_rx_mode"
+}
+func (*SwInterfaceGetDefaultRxMode) GetCrcString() string { return "51077d14" }
+func (*SwInterfaceGetDefaultRxMode) GetMessageType() api.MessageType {
+	return api.RequestMessage
+}
+
+func (m *SwInterfaceGetDefaultRxMode) Size() (size int) {
+	if m == nil {
+		return 0
+	}
+	return size
+}
+func (m *SwInterfaceGetDefaultRxMode) Marshal(b []byte) ([]byte, error) {
+	if b == nil {
+		b = make([]byte, m.Size())
+	}
+	buf := codec.NewBuffer(b)
+	return buf.Bytes(), nil
+}
+func (m *SwInterfaceGetDefaultRxMode) Unmarshal(b []byte) error {
+	return nil
+}
+
+// Reply for sw_interface_get_default_rx_mode
+//   - retval - return value
+//   - mode - polling=1, interrupt=2, adaptive=3
+//
+// SwInterfaceGetDefaultRxModeReply defines message 'sw_interface_get_default_rx_mode_reply'.
+type SwInterfaceGetDefaultRxModeReply struct {
+	Retval int32                  `binapi:"i32,name=retval" json:"retval,omitempty"`
+	Mode   interface_types.RxMode `binapi:"rx_mode,name=mode" json:"mode,omitempty"`
+}
+
+func (m *SwInterfaceGetDefaultRxModeReply) Reset() { *m = SwInterfaceGetDefaultRxModeReply{} }
+func (*SwInterfaceGetDefaultRxModeReply) GetMessageName() string {
+	return "sw_interface_get_default_rx_mode_reply"
+}
+func (*SwInterfaceGetDefaultRxModeReply) GetCrcString() string { return "2339da5a" }
+func (*SwInterfaceGetDefaultRxModeReply) GetMessageType() api.MessageType {
+	return api.ReplyMessage
+}
+
+func (m *SwInterfaceGetDefaultRxModeReply) Size() (size int) {
+	if m == nil {
+		return 0
+	}
+	size += 4 // m.Retval
+	size += 4 // m.Mode
+	return size
+}
+func (m *SwInterfaceGetDefaultRxModeReply) Marshal(b []byte) ([]byte, error) {
+	if b == nil {
+		b = make([]byte, m.Size())
+	}
+	buf := codec.NewBuffer(b)
+	buf.EncodeInt32(m.Retval)
+	buf.EncodeUint32(uint32(m.Mode))
+	return buf.Bytes(), nil
+}
+func (m *SwInterfaceGetDefaultRxModeReply) Unmarshal(b []byte) error {
+	buf := codec.NewBuffer(b)
+	m.Retval = buf.DecodeInt32()
+	m.Mode = interface_types.RxMode(buf.DecodeUint32())
+	return nil
+}
+
 // Get interface's MAC address
 //   - sw_if_index - the interface whose MAC will be returned
 //
@@ -1966,6 +2039,79 @@ func (m *SwInterfaceRxPlacementDump) Marshal(b []byte) ([]byte, error) {
 func (m *SwInterfaceRxPlacementDump) Unmarshal(b []byte) error {
 	buf := codec.NewBuffer(b)
 	m.SwIfIndex = interface_types.InterfaceIndex(buf.DecodeUint32())
+	return nil
+}
+
+// Set the global default rx-mode for newly created interfaces
+//   - mode - polling=1, interrupt=2, adaptive=3
+//
+// SwInterfaceSetDefaultRxMode defines message 'sw_interface_set_default_rx_mode'.
+type SwInterfaceSetDefaultRxMode struct {
+	Mode interface_types.RxMode `binapi:"rx_mode,name=mode" json:"mode,omitempty"`
+}
+
+func (m *SwInterfaceSetDefaultRxMode) Reset() { *m = SwInterfaceSetDefaultRxMode{} }
+func (*SwInterfaceSetDefaultRxMode) GetMessageName() string {
+	return "sw_interface_set_default_rx_mode"
+}
+func (*SwInterfaceSetDefaultRxMode) GetCrcString() string { return "776b4837" }
+func (*SwInterfaceSetDefaultRxMode) GetMessageType() api.MessageType {
+	return api.RequestMessage
+}
+
+func (m *SwInterfaceSetDefaultRxMode) Size() (size int) {
+	if m == nil {
+		return 0
+	}
+	size += 4 // m.Mode
+	return size
+}
+func (m *SwInterfaceSetDefaultRxMode) Marshal(b []byte) ([]byte, error) {
+	if b == nil {
+		b = make([]byte, m.Size())
+	}
+	buf := codec.NewBuffer(b)
+	buf.EncodeUint32(uint32(m.Mode))
+	return buf.Bytes(), nil
+}
+func (m *SwInterfaceSetDefaultRxMode) Unmarshal(b []byte) error {
+	buf := codec.NewBuffer(b)
+	m.Mode = interface_types.RxMode(buf.DecodeUint32())
+	return nil
+}
+
+// SwInterfaceSetDefaultRxModeReply defines message 'sw_interface_set_default_rx_mode_reply'.
+type SwInterfaceSetDefaultRxModeReply struct {
+	Retval int32 `binapi:"i32,name=retval" json:"retval,omitempty"`
+}
+
+func (m *SwInterfaceSetDefaultRxModeReply) Reset() { *m = SwInterfaceSetDefaultRxModeReply{} }
+func (*SwInterfaceSetDefaultRxModeReply) GetMessageName() string {
+	return "sw_interface_set_default_rx_mode_reply"
+}
+func (*SwInterfaceSetDefaultRxModeReply) GetCrcString() string { return "e8d4e804" }
+func (*SwInterfaceSetDefaultRxModeReply) GetMessageType() api.MessageType {
+	return api.ReplyMessage
+}
+
+func (m *SwInterfaceSetDefaultRxModeReply) Size() (size int) {
+	if m == nil {
+		return 0
+	}
+	size += 4 // m.Retval
+	return size
+}
+func (m *SwInterfaceSetDefaultRxModeReply) Marshal(b []byte) ([]byte, error) {
+	if b == nil {
+		b = make([]byte, m.Size())
+	}
+	buf := codec.NewBuffer(b)
+	buf.EncodeInt32(m.Retval)
+	return buf.Bytes(), nil
+}
+func (m *SwInterfaceSetDefaultRxModeReply) Unmarshal(b []byte) error {
+	buf := codec.NewBuffer(b)
+	m.Retval = buf.DecodeInt32()
 	return nil
 }
 
@@ -3223,12 +3369,16 @@ func file_interfaces_binapi_init() {
 	api.RegisterMessage((*SwInterfaceDetails)(nil), "sw_interface_details_6c221fc7")
 	api.RegisterMessage((*SwInterfaceDump)(nil), "sw_interface_dump_aa610c27")
 	api.RegisterMessage((*SwInterfaceEvent)(nil), "sw_interface_event_2d3d95a7")
+	api.RegisterMessage((*SwInterfaceGetDefaultRxMode)(nil), "sw_interface_get_default_rx_mode_51077d14")
+	api.RegisterMessage((*SwInterfaceGetDefaultRxModeReply)(nil), "sw_interface_get_default_rx_mode_reply_2339da5a")
 	api.RegisterMessage((*SwInterfaceGetMacAddress)(nil), "sw_interface_get_mac_address_f9e6675e")
 	api.RegisterMessage((*SwInterfaceGetMacAddressReply)(nil), "sw_interface_get_mac_address_reply_40ef2c08")
 	api.RegisterMessage((*SwInterfaceGetTable)(nil), "sw_interface_get_table_2d033de4")
 	api.RegisterMessage((*SwInterfaceGetTableReply)(nil), "sw_interface_get_table_reply_a6eb0109")
 	api.RegisterMessage((*SwInterfaceRxPlacementDetails)(nil), "sw_interface_rx_placement_details_9e44a7ce")
 	api.RegisterMessage((*SwInterfaceRxPlacementDump)(nil), "sw_interface_rx_placement_dump_f9e6675e")
+	api.RegisterMessage((*SwInterfaceSetDefaultRxMode)(nil), "sw_interface_set_default_rx_mode_776b4837")
+	api.RegisterMessage((*SwInterfaceSetDefaultRxModeReply)(nil), "sw_interface_set_default_rx_mode_reply_e8d4e804")
 	api.RegisterMessage((*SwInterfaceSetFlags)(nil), "sw_interface_set_flags_f5aec1b8")
 	api.RegisterMessage((*SwInterfaceSetFlagsReply)(nil), "sw_interface_set_flags_reply_e8d4e804")
 	api.RegisterMessage((*SwInterfaceSetInterfaceName)(nil), "sw_interface_set_interface_name_45a1d548")
@@ -3302,12 +3452,16 @@ func AllMessages() []api.Message {
 		(*SwInterfaceDetails)(nil),
 		(*SwInterfaceDump)(nil),
 		(*SwInterfaceEvent)(nil),
+		(*SwInterfaceGetDefaultRxMode)(nil),
+		(*SwInterfaceGetDefaultRxModeReply)(nil),
 		(*SwInterfaceGetMacAddress)(nil),
 		(*SwInterfaceGetMacAddressReply)(nil),
 		(*SwInterfaceGetTable)(nil),
 		(*SwInterfaceGetTableReply)(nil),
 		(*SwInterfaceRxPlacementDetails)(nil),
 		(*SwInterfaceRxPlacementDump)(nil),
+		(*SwInterfaceSetDefaultRxMode)(nil),
+		(*SwInterfaceSetDefaultRxModeReply)(nil),
 		(*SwInterfaceSetFlags)(nil),
 		(*SwInterfaceSetFlagsReply)(nil),
 		(*SwInterfaceSetInterfaceName)(nil),

--- a/vpplink/generated/bindings/interface/interface_rpc.ba.go
+++ b/vpplink/generated/bindings/interface/interface_rpc.ba.go
@@ -32,9 +32,11 @@ type RPCService interface {
 	SwInterfaceAddressReplaceEnd(ctx context.Context, in *SwInterfaceAddressReplaceEnd) (*SwInterfaceAddressReplaceEndReply, error)
 	SwInterfaceClearStats(ctx context.Context, in *SwInterfaceClearStats) (*SwInterfaceClearStatsReply, error)
 	SwInterfaceDump(ctx context.Context, in *SwInterfaceDump) (RPCService_SwInterfaceDumpClient, error)
+	SwInterfaceGetDefaultRxMode(ctx context.Context, in *SwInterfaceGetDefaultRxMode) (*SwInterfaceGetDefaultRxModeReply, error)
 	SwInterfaceGetMacAddress(ctx context.Context, in *SwInterfaceGetMacAddress) (*SwInterfaceGetMacAddressReply, error)
 	SwInterfaceGetTable(ctx context.Context, in *SwInterfaceGetTable) (*SwInterfaceGetTableReply, error)
 	SwInterfaceRxPlacementDump(ctx context.Context, in *SwInterfaceRxPlacementDump) (RPCService_SwInterfaceRxPlacementDumpClient, error)
+	SwInterfaceSetDefaultRxMode(ctx context.Context, in *SwInterfaceSetDefaultRxMode) (*SwInterfaceSetDefaultRxModeReply, error)
 	SwInterfaceSetFlags(ctx context.Context, in *SwInterfaceSetFlags) (*SwInterfaceSetFlagsReply, error)
 	SwInterfaceSetInterfaceName(ctx context.Context, in *SwInterfaceSetInterfaceName) (*SwInterfaceSetInterfaceNameReply, error)
 	SwInterfaceSetIPDirectedBroadcast(ctx context.Context, in *SwInterfaceSetIPDirectedBroadcast) (*SwInterfaceSetIPDirectedBroadcastReply, error)
@@ -264,6 +266,15 @@ func (c *serviceClient_SwInterfaceDumpClient) Recv() (*SwInterfaceDetails, error
 	}
 }
 
+func (c *serviceClient) SwInterfaceGetDefaultRxMode(ctx context.Context, in *SwInterfaceGetDefaultRxMode) (*SwInterfaceGetDefaultRxModeReply, error) {
+	out := new(SwInterfaceGetDefaultRxModeReply)
+	err := c.conn.Invoke(ctx, in, out)
+	if err != nil {
+		return nil, err
+	}
+	return out, api.RetvalToVPPApiError(out.Retval)
+}
+
 func (c *serviceClient) SwInterfaceGetMacAddress(ctx context.Context, in *SwInterfaceGetMacAddress) (*SwInterfaceGetMacAddressReply, error) {
 	out := new(SwInterfaceGetMacAddressReply)
 	err := c.conn.Invoke(ctx, in, out)
@@ -323,6 +334,15 @@ func (c *serviceClient_SwInterfaceRxPlacementDumpClient) Recv() (*SwInterfaceRxP
 	default:
 		return nil, fmt.Errorf("unexpected message: %T %v", m, m)
 	}
+}
+
+func (c *serviceClient) SwInterfaceSetDefaultRxMode(ctx context.Context, in *SwInterfaceSetDefaultRxMode) (*SwInterfaceSetDefaultRxModeReply, error) {
+	out := new(SwInterfaceSetDefaultRxModeReply)
+	err := c.conn.Invoke(ctx, in, out)
+	if err != nil {
+		return nil, err
+	}
+	return out, api.RetvalToVPPApiError(out.Retval)
 }
 
 func (c *serviceClient) SwInterfaceSetFlags(ctx context.Context, in *SwInterfaceSetFlags) (*SwInterfaceSetFlagsReply, error) {

--- a/vpplink/generated/bindings/ip/ip.ba.go
+++ b/vpplink/generated/bindings/ip/ip.ba.go
@@ -1011,28 +1011,6 @@ func (m *IPLocalReassGetReply) Unmarshal(b []byte) error {
 	return nil
 }
 
-// Add / del route request
-//
-//	Adds a route, consisting both of the MFIB entry to match packets
-//	(which may already exist) and a path to send those packets down.
-//	Routes can be entered repeatedly to add multiple paths.  Deletions are
-//	per-path.
-//	- table_id - fib table /vrf associated with the route
-//	- is_add - true if adding a route; false if deleting one
-//	- is_ipv6 - true iff all the addresses are v6
-//	- entry_flags - see fib_entry_flag_t
-//	- itf_flags - see mfib_entry_flags_t
-//	- next_hop_afi - see dpo_proto_t; the type of destination description
-//	- src_address - the source of the packet
-//	- grp_address - the group the packet is destined to
-//	- nh_address - the nexthop to forward the packet to
-//	- next_hop_sw_if_index - interface to emit packet on
-//	BIER AFIs use the BIER imposition ID.  v4 and v6 AFIs use either the
-//	interface or the nexthop address.
-//	Note that if the route is source-specific (S is supplied, not all 0s),
-//	the prefix match is treated as exact (prefixlen /32 or /128).
-//	FIXME not complete yet
-//
 // IPMrouteAddDel defines message 'ip_mroute_add_del'.
 type IPMrouteAddDel struct {
 	IsAdd       bool     `binapi:"bool,name=is_add,default=true" json:"is_add,omitempty"`
@@ -1688,14 +1666,6 @@ func (m *IPPathMtuReplaceEndReply) Unmarshal(b []byte) error {
 	return nil
 }
 
-// @brief Set a Path MTU value. i.e. a MTU value for a given neighbour.
-//
-//	       The neighbour can be described as attached (w/ interface and next-hop)
-//	       or remote (w/ table_id and next-hop);
-//	- table_id - table-ID for next-hop
-//	- nh - Next hop
-//	- path_mtu - value to set, 0 is disable.
-//
 // IPPathMtuUpdate defines message 'ip_path_mtu_update'.
 type IPPathMtuUpdate struct {
 	Pmtu IPPathMtu `binapi:"ip_path_mtu,name=pmtu" json:"pmtu,omitempty"`
@@ -4532,16 +4502,6 @@ func (m *SetIPFlowHashRouterIDReply) Unmarshal(b []byte) error {
 	return nil
 }
 
-// @brief flow hash settings for an IP table
-//   - src - include src in flow hash
-//   - dst - include dst in flow hash
-//   - sport - include sport in flow hash
-//   - dport - include dport in flow hash
-//   - proto - include proto in flow hash
-//   - reverse - include reverse in flow hash
-//   - symmetric - include symmetry in flow hash
-//   - flowlabel - include flowlabel in flow hash
-//
 // SetIPFlowHashV2 defines message 'set_ip_flow_hash_v2'.
 type SetIPFlowHashV2 struct {
 	TableID        uint32                 `binapi:"u32,name=table_id" json:"table_id,omitempty"`
@@ -4616,17 +4576,6 @@ func (m *SetIPFlowHashV2Reply) Unmarshal(b []byte) error {
 	return nil
 }
 
-// @brief flow hash settings for an IP table
-//   - src - include src in flow hash
-//   - dst - include dst in flow hash
-//   - sport - include sport in flow hash
-//   - dport - include dport in flow hash
-//   - proto - include proto in flow hash
-//   - reverse - include reverse in flow hash
-//   - symmetric - include symmetry in flow hash
-//   - flowlabel - include flowlabel in flow hash
-//   - gtpv1teid - include gtpv1teid in flow hash
-//
 // SetIPFlowHashV3 defines message 'set_ip_flow_hash_v3'.
 // InProgress: the message form may change in the future versions
 type SetIPFlowHashV3 struct {

--- a/vpplink/generated/bindings/ip_session_redirect/ip_session_redirect.ba.go
+++ b/vpplink/generated/bindings/ip_session_redirect/ip_session_redirect.ba.go
@@ -26,15 +26,6 @@ const (
 	VersionCrc = 0x54be863a
 )
 
-// Add or update a session redirection
-//   - table_index - classifier table index
-//   - opaque_index - classifier session opaque index
-//   - match_len - classifier session match length in bytes (max is 80-bytes)
-//   - match - classifier session match
-//   - is_punt - true = punted traffic, false = forwarded traffic
-//   - n_paths - number of paths
-//   - paths - the paths of the redirect
-//
 // IPSessionRedirectAdd defines message 'ip_session_redirect_add'.
 // Deprecated: the message will be removed in the future versions
 type IPSessionRedirectAdd struct {
@@ -198,16 +189,6 @@ func (m *IPSessionRedirectAddReply) Unmarshal(b []byte) error {
 	return nil
 }
 
-// Add or update a session redirection - version 2
-//   - table_index - classifier table index
-//   - opaque_index - classifier session opaque index
-//   - proto - protocol of forwarded packets (default autodetect from path nh)
-//   - is_punt - true = punted traffic, false = forwarded traffic
-//   - match_len - classifier session match length in bytes (max is 80-bytes)
-//   - match - classifier session match
-//   - n_paths - number of paths
-//   - paths - the paths of the redirect
-//
 // IPSessionRedirectAddV2 defines message 'ip_session_redirect_add_v2'.
 // InProgress: the message form may change in the future versions
 type IPSessionRedirectAddV2 struct {
@@ -377,11 +358,6 @@ func (m *IPSessionRedirectAddV2Reply) Unmarshal(b []byte) error {
 	return nil
 }
 
-// Delete a session redirection
-//   - table_index - classifier table index
-//   - match_len - classifier session match length in bytes (max is 80-bytes)
-//   - match - classifier session match
-//
 // IPSessionRedirectDel defines message 'ip_session_redirect_del'.
 // InProgress: the message form may change in the future versions
 type IPSessionRedirectDel struct {
@@ -459,16 +435,6 @@ func (m *IPSessionRedirectDelReply) Unmarshal(b []byte) error {
 	return nil
 }
 
-// Session redirection operational state response
-//   - table_index - classifier table index
-//   - opaque_index - classifier session opaque index
-//   - is_punt - true = punted traffic, false = forwarded traffic
-//   - is_ip6 - true = payload proto is ip6, false = payload proto is ip4
-//   - match_len - classifier session match length in bytes (max is 80-bytes)
-//   - match - classifier session match
-//   - n_paths - number of paths
-//   - paths - the paths of the redirect
-//
 // IPSessionRedirectDetails defines message 'ip_session_redirect_details'.
 type IPSessionRedirectDetails struct {
 	Retval      int32               `binapi:"i32,name=retval" json:"retval,omitempty"`
@@ -605,9 +571,6 @@ func (m *IPSessionRedirectDetails) Unmarshal(b []byte) error {
 	return nil
 }
 
-// Dump available session redirections
-//   - table_index - classifier table index
-//
 // IPSessionRedirectDump defines message 'ip_session_redirect_dump'.
 type IPSessionRedirectDump struct {
 	TableIndex uint32 `binapi:"u32,name=table_index" json:"table_index,omitempty"`

--- a/vpplink/generated/bindings/ipsec/ipsec.ba.go
+++ b/vpplink/generated/bindings/ipsec/ipsec.ba.go
@@ -123,11 +123,6 @@ func (m *IpsecBackendDump) Unmarshal(b []byte) error {
 	return nil
 }
 
-// IPsec: Add/delete SPD from interface
-//   - is_add - add security mode if non-zero, else delete
-//   - sw_if_index - index of the interface
-//   - spd_id - SPD instance id to use for lookups
-//
 // IpsecInterfaceAddDelSpd defines message 'ipsec_interface_add_del_spd'.
 type IpsecInterfaceAddDelSpd struct {
 	IsAdd     bool                           `binapi:"bool,name=is_add" json:"is_add,omitempty"`
@@ -2403,10 +2398,6 @@ func (m *IpsecSetAsyncModeReply) Unmarshal(b []byte) error {
 	return nil
 }
 
-// IPsec: Add/delete Security Policy Database
-//   - is_add - add SPD if non-zero, else delete
-//   - spd_id - SPD instance id (control plane allocated)
-//
 // IpsecSpdAddDel defines message 'ipsec_spd_add_del'.
 type IpsecSpdAddDel struct {
 	IsAdd bool   `binapi:"bool,name=is_add" json:"is_add,omitempty"`
@@ -3192,43 +3183,6 @@ func (m *IpsecTunnelProtectDump) Unmarshal(b []byte) error {
 	return nil
 }
 
-// Add or Update Protection for a tunnel with IPSEC
-//
-//	Tunnel protection directly associates an SA with all packets
-//	ingress and egress on the tunnel. This could also be achieved by
-//	assigning an SPD to the tunnel, but that would incur an unnessccary
-//	SPD entry lookup.
-//	For tunnels the ESP acts on the post-encapsulated packet. So if this
-//	packet:
-//	  +---------+------+
-//	  | Payload | O-IP |
-//	  +---------+------+
-//	where O-IP is the overlay IP addrees that was routed into the tunnel,
-//	the resulting encapsulated packet will be:
-//	  +---------+------+------+
-//	  | Payload | O-IP | T-IP |
-//	  +---------+------+------+
-//	where T-IP is the tunnel's src.dst IP addresses.
-//	If the SAs used for protection are in transport mode then the ESP is
-//	inserted before T-IP, i.e.:
-//	  +---------+------+-----+------+
-//	  | Payload | O-IP | ESP | T-IP |
-//	  +---------+------+-----+------+
-//	If the SAs used for protection are in tunnel mode then another
-//	encapsulation occurs, i.e.:
-//	  +---------+------+------+-----+------+
-//	  | Payload | O-IP | T-IP | ESP | C-IP |
-//	  +---------+------+------+-----+------+
-//	where C-IP are the crypto endpoint IP addresses defined as the tunnel
-//	endpoints in the SA.
-//	The mode for the inbound and outbound SA must be the same.
-//	- sw_id_index - Tunnel interface to protect
-//	- nh - The peer/next-hop on the tunnel to which the traffic
-//	            should be protected. For a P2P interface set this to the
-//	            all 0s address.
-//	- sa_in - The ID [set] of inbound SAs
-//	- sa_out - The ID of outbound SA
-//
 // IpsecTunnelProtectUpdate defines message 'ipsec_tunnel_protect_update'.
 type IpsecTunnelProtectUpdate struct {
 	Tunnel IpsecTunnelProtect `binapi:"ipsec_tunnel_protect,name=tunnel" json:"tunnel,omitempty"`

--- a/vpplink/generated/bindings/memclnt/memclnt.ba.go
+++ b/vpplink/generated/bindings/memclnt/memclnt.ba.go
@@ -38,9 +38,6 @@ type ModuleVersion struct {
 	Name  string `binapi:"string[64],name=name" json:"name,omitempty"`
 }
 
-// /*
-//   - Get API version table (includes built-in and plugins)
-//
 // APIVersions defines message 'api_versions'.
 type APIVersions struct{}
 
@@ -1149,11 +1146,6 @@ func (m *SockclntDeleteReply) Unmarshal(b []byte) error {
 	return nil
 }
 
-// /*
-//   - Trace the plugin message-id allocator
-//   - so we stand a chance of dealing with different sets of plugins
-//   - at api trace replay time
-//
 // TracePluginMsgIds defines message 'trace_plugin_msg_ids'.
 type TracePluginMsgIds struct {
 	PluginName string `binapi:"string[128],name=plugin_name" json:"plugin_name,omitempty"`

--- a/vpplink/generated/bindings/npol/npol.ba.go
+++ b/vpplink/generated/bindings/npol/npol.ba.go
@@ -472,7 +472,6 @@ func (m *NpolConfigurePoliciesReply) Unmarshal(b []byte) error {
 	return nil
 }
 
-// Get the plugin version
 // NpolGetVersion defines message 'npol_get_version'.
 type NpolGetVersion struct{}
 
@@ -500,10 +499,6 @@ func (m *NpolGetVersion) Unmarshal(b []byte) error {
 	return nil
 }
 
-// Reply to get the plugin version
-//   - major - Incremented every time a known breaking behavior change is introduced
-//   - minor - Incremented with small changes, may be used to avoid buggy versions
-//
 // NpolGetVersionReply defines message 'npol_get_version_reply'.
 type NpolGetVersionReply struct {
 	Major uint32 `binapi:"u32,name=major" json:"major,omitempty"`
@@ -1025,7 +1020,6 @@ func (m *NpolPolicyUpdateReply) Unmarshal(b []byte) error {
 	return nil
 }
 
-// // where the packet only needs to match one entry in either category
 // NpolRuleCreate defines message 'npol_rule_create'.
 type NpolRuleCreate struct {
 	Rule NpolRule `binapi:"npol_rule,name=rule" json:"rule,omitempty"`

--- a/vpplink/generated/bindings/pbl/pbl.ba.go
+++ b/vpplink/generated/bindings/pbl/pbl.ba.go
@@ -314,11 +314,6 @@ func (m *PblClientDump) Unmarshal(b []byte) error {
 	return nil
 }
 
-// \file
-//
-//	This file defines the vpp control-plane API messages
-//	used to control the PBL plugin
-//
 // PblClientUpdate defines message 'pbl_client_update'.
 type PblClientUpdate struct {
 	Client PblClient `binapi:"pbl_client,name=client" json:"client,omitempty"`

--- a/vpplink/generated/bindings/rdma/rdma.ba.go
+++ b/vpplink/generated/bindings/rdma/rdma.ba.go
@@ -123,14 +123,6 @@ func (x RdmaRss6) String() string {
 	return "RdmaRss6(" + strconv.Itoa(int(x)) + ")"
 }
 
-// - client_index - opaque cookie to identify the sender
-//   - host_if - Linux netdev interface name
-//   - name - new rdma interface name
-//   - rxq_num - number of receive queues (optional)
-//   - rxq_size - receive queue size (optional)
-//   - txq_size - transmit queue size (optional)
-//   - mode - operation mode (optional)
-//
 // RdmaCreate defines message 'rdma_create'.
 // Deprecated: 21.01
 type RdmaCreate struct {
@@ -185,10 +177,6 @@ func (m *RdmaCreate) Unmarshal(b []byte) error {
 	return nil
 }
 
-// - context - sender context, to match reply w/ request
-//   - retval - return value for request
-//   - sw_if_index - software index for the new rdma interface
-//
 // RdmaCreateReply defines message 'rdma_create_reply'.
 // Deprecated: the message will be removed in the future versions
 type RdmaCreateReply struct {
@@ -227,16 +215,6 @@ func (m *RdmaCreateReply) Unmarshal(b []byte) error {
 	return nil
 }
 
-// - client_index - opaque cookie to identify the sender
-//   - host_if - Linux netdev interface name
-//   - name - new rdma interface name
-//   - rxq_num - number of receive queues (optional)
-//   - rxq_size - receive queue size (optional)
-//   - txq_size - transmit queue size (optional)
-//   - mode - operation mode (optional)
-//   - no_multi_seg (optional) - disable chained buffer RX
-//   - max_pktlen (optional) - maximal RX packet size.
-//
 // RdmaCreateV2 defines message 'rdma_create_v2'.
 // Deprecated: the message will be removed in the future versions
 type RdmaCreateV2 struct {
@@ -299,10 +277,6 @@ func (m *RdmaCreateV2) Unmarshal(b []byte) error {
 	return nil
 }
 
-// - context - sender context, to match reply w/ request
-//   - retval - return value for request
-//   - sw_if_index - software index for the new rdma interface
-//
 // RdmaCreateV2Reply defines message 'rdma_create_v2_reply'.
 // Deprecated: the message will be removed in the future versions
 type RdmaCreateV2Reply struct {
@@ -341,18 +315,6 @@ func (m *RdmaCreateV2Reply) Unmarshal(b []byte) error {
 	return nil
 }
 
-// Same as v4, just not an autoendian (expect buggy handling of flag values).
-//   - host_if - Linux netdev interface name
-//   - name - new rdma interface name
-//   - rxq_num - number of receive queues (optional)
-//   - rxq_size - receive queue size (optional)
-//   - txq_size - transmit queue size (optional)
-//   - mode - operation mode (optional)
-//   - no_multi_seg (optional) - disable chained buffer RX
-//   - max_pktlen (optional) - maximal RX packet size.
-//   - rss4 (optional) - IPv4 RSS
-//   - rss6 (optional) - IPv6 RSS
-//
 // RdmaCreateV3 defines message 'rdma_create_v3'.
 // Deprecated: the message will be removed in the future versions
 type RdmaCreateV3 struct {
@@ -423,9 +385,6 @@ func (m *RdmaCreateV3) Unmarshal(b []byte) error {
 	return nil
 }
 
-// - client_index - opaque cookie to identify the sender
-//   - sw_if_index - interface index
-//
 // RdmaCreateV3Reply defines message 'rdma_create_v3_reply'.
 type RdmaCreateV3Reply struct {
 	Retval    int32                          `binapi:"i32,name=retval" json:"retval,omitempty"`
@@ -463,18 +422,6 @@ func (m *RdmaCreateV3Reply) Unmarshal(b []byte) error {
 	return nil
 }
 
-// - client_index - opaque cookie to identify the sender
-//   - host_if - Linux netdev interface name
-//   - name - new rdma interface name
-//   - rxq_num - number of receive queues (optional)
-//   - rxq_size - receive queue size (optional)
-//   - txq_size - transmit queue size (optional)
-//   - mode - operation mode (optional)
-//   - no_multi_seg (optional) - disable chained buffer RX
-//   - max_pktlen (optional) - maximal RX packet size.
-//   - rss4 (optional) - IPv4 RSS
-//   - rss6 (optional) - IPv6 RSS
-//
 // RdmaCreateV4 defines message 'rdma_create_v4'.
 type RdmaCreateV4 struct {
 	HostIf     string   `binapi:"string[64],name=host_if" json:"host_if,omitempty"`
@@ -544,9 +491,6 @@ func (m *RdmaCreateV4) Unmarshal(b []byte) error {
 	return nil
 }
 
-// - client_index - opaque cookie to identify the sender
-//   - sw_if_index - interface index
-//
 // RdmaCreateV4Reply defines message 'rdma_create_v4_reply'.
 type RdmaCreateV4Reply struct {
 	Retval    int32                          `binapi:"i32,name=retval" json:"retval,omitempty"`
@@ -584,9 +528,6 @@ func (m *RdmaCreateV4Reply) Unmarshal(b []byte) error {
 	return nil
 }
 
-// - client_index - opaque cookie to identify the sender
-//   - sw_if_index - interface index
-//
 // RdmaDelete defines message 'rdma_delete'.
 type RdmaDelete struct {
 	SwIfIndex interface_types.InterfaceIndex `binapi:"interface_index,name=sw_if_index" json:"sw_if_index,omitempty"`

--- a/vpplink/generated/bindings/sr/sr.ba.go
+++ b/vpplink/generated/bindings/sr/sr.ba.go
@@ -82,7 +82,7 @@ type Srv6SidListWithSlIndex struct {
 //   - behavior Type of behavior (function) for this localsid
 //   - sw_if_index Only for L2/L3 xconnect. OIF. In VRF variant the
 //     fib_table. Default:0xffffffff
-//   - vlan_index Only for L2 xconnect. Outgoing VLAN tag.
+//   - vlan_index Unused, will be ignored.
 //   - fib_table  FIB table in which we should install the localsid entry
 //   - nh_addr Next Hop IPv46 address. Only for L2/L3 xconnect.
 //

--- a/vpplink/generated/bindings/vlib/vlib.ba.go
+++ b/vpplink/generated/bindings/vlib/vlib.ba.go
@@ -526,12 +526,6 @@ func (m *GetNodeGraph) Unmarshal(b []byte) error {
 	return nil
 }
 
-// get_node_graph_reply
-//   - retval - return code
-//   - reply_in_shmem - result from vlib_node_serialize, in shared
-//     memory. Process with vlib_node_unserialize, remember to switch
-//     heaps and free the result.
-//
 // GetNodeGraphReply defines message 'get_node_graph_reply'.
 type GetNodeGraphReply struct {
 	Retval       int32  `binapi:"i32,name=retval" json:"retval,omitempty"`

--- a/vpplink/generated/bindings/vmxnet3/vmxnet3.ba.go
+++ b/vpplink/generated/bindings/vmxnet3/vmxnet3.ba.go
@@ -220,19 +220,6 @@ func (m *SwVmxnet3InterfaceDump) Unmarshal(b []byte) error {
 	return nil
 }
 
-// - client_index - opaque cookie to identify the sender
-//   - pci_addr - pci address as unsigned 32bit integer:
-//     0-15 domain, 16-23 bus, 24-28 slot, 29-31 function
-//     ddddddddddddddddbbbbbbbbsssssfff
-//   - enable_elog - turn on elog (optional - default is off)
-//   - rxq_size - receive queue size (optional - default is 1024)
-//   - rxq_num - number of receive queues (optional - default is 1)
-//   - txq_size - transmit queue size (optional - default is 1024)
-//   - txq_num - number of transmit queues (optional - default is 1)
-//   - bind - automatically bind PCI to vfio-pci module
-//     (optional - default is 0)
-//   - enable_gso - enable gso (optional - default is 0)
-//
 // Vmxnet3Create defines message 'vmxnet3_create'.
 type Vmxnet3Create struct {
 	PciAddr    uint32 `binapi:"u32,name=pci_addr" json:"pci_addr,omitempty"`
@@ -294,10 +281,6 @@ func (m *Vmxnet3Create) Unmarshal(b []byte) error {
 	return nil
 }
 
-// - context - sender context, to match reply w/ request
-//   - retval - return value for request
-//   - sw_if_index - software index for the new vmxnet3 interface
-//
 // Vmxnet3CreateReply defines message 'vmxnet3_create_reply'.
 type Vmxnet3CreateReply struct {
 	Retval    int32                          `binapi:"i32,name=retval" json:"retval,omitempty"`
@@ -335,9 +318,6 @@ func (m *Vmxnet3CreateReply) Unmarshal(b []byte) error {
 	return nil
 }
 
-// - client_index - opaque cookie to identify the sender
-//   - sw_if_index - interface index
-//
 // Vmxnet3Delete defines message 'vmxnet3_delete'.
 type Vmxnet3Delete struct {
 	SwIfIndex interface_types.InterfaceIndex `binapi:"interface_index,name=sw_if_index" json:"sw_if_index,omitempty"`

--- a/vpplink/generated/bindings/wireguard/wireguard.ba.go
+++ b/vpplink/generated/bindings/wireguard/wireguard.ba.go
@@ -4,8 +4,8 @@
 //
 // Contents:
 // -  1 enum
-// -  2 structs
-// - 17 messages
+// -  3 structs
+// - 21 messages
 package wireguard
 
 import (
@@ -25,8 +25,8 @@ const _ = api.GoVppAPIPackageIsVersion2
 
 const (
 	APIFile    = "wireguard"
-	APIVersion = "1.3.0"
-	VersionCrc = 0x5d8f9252
+	APIVersion = "1.4.0"
+	VersionCrc = 0x709f48a6
 )
 
 // WireguardPeerFlags defines enum 'wireguard_peer_flags'.
@@ -88,6 +88,22 @@ type WireguardInterface struct {
 // WireguardPeer defines type 'wireguard_peer'.
 type WireguardPeer struct {
 	PeerIndex           uint32                         `binapi:"u32,name=peer_index" json:"peer_index,omitempty"`
+	PublicKey           []byte                         `binapi:"u8[32],name=public_key" json:"public_key,omitempty"`
+	Port                uint16                         `binapi:"u16,name=port" json:"port,omitempty"`
+	PersistentKeepalive uint16                         `binapi:"u16,name=persistent_keepalive" json:"persistent_keepalive,omitempty"`
+	TableID             uint32                         `binapi:"u32,name=table_id" json:"table_id,omitempty"`
+	Endpoint            ip_types.Address               `binapi:"address,name=endpoint" json:"endpoint,omitempty"`
+	SwIfIndex           interface_types.InterfaceIndex `binapi:"interface_index,name=sw_if_index" json:"sw_if_index,omitempty"`
+	Flags               WireguardPeerFlags             `binapi:"wireguard_peer_flags,name=flags" json:"flags,omitempty"`
+	NAllowedIps         uint8                          `binapi:"u8,name=n_allowed_ips" json:"-"`
+	AllowedIps          []ip_types.Prefix              `binapi:"prefix[n_allowed_ips],name=allowed_ips" json:"allowed_ips,omitempty"`
+}
+
+// WireguardPeerV2 defines type 'wireguard_peer_v2'.
+type WireguardPeerV2 struct {
+	PeerIndex           uint32                         `binapi:"u32,name=peer_index" json:"peer_index,omitempty"`
+	PresharedKey        []byte                         `binapi:"u8[32],name=preshared_key" json:"preshared_key,omitempty"`
+	PresharedKeySet     bool                           `binapi:"bool,name=preshared_key_set" json:"preshared_key_set,omitempty"`
 	PublicKey           []byte                         `binapi:"u8[32],name=public_key" json:"public_key,omitempty"`
 	Port                uint16                         `binapi:"u16,name=port" json:"port,omitempty"`
 	PersistentKeepalive uint16                         `binapi:"u16,name=persistent_keepalive" json:"persistent_keepalive,omitempty"`
@@ -517,6 +533,7 @@ func (m *WireguardInterfaceDump) Unmarshal(b []byte) error {
 //   - peer - peer to create
 //
 // WireguardPeerAdd defines message 'wireguard_peer_add'.
+// Deprecated: the message will be removed in the future versions
 type WireguardPeerAdd struct {
 	Peer WireguardPeer `binapi:"wireguard_peer,name=peer" json:"peer,omitempty"`
 }
@@ -607,6 +624,7 @@ func (m *WireguardPeerAdd) Unmarshal(b []byte) error {
 //   - peer_index - Created or existing peer pool index
 //
 // WireguardPeerAddReply defines message 'wireguard_peer_add_reply'.
+// Deprecated: the message will be removed in the future versions
 type WireguardPeerAddReply struct {
 	Retval    int32  `binapi:"i32,name=retval" json:"retval,omitempty"`
 	PeerIndex uint32 `binapi:"u32,name=peer_index" json:"peer_index,omitempty"`
@@ -637,6 +655,138 @@ func (m *WireguardPeerAddReply) Marshal(b []byte) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 func (m *WireguardPeerAddReply) Unmarshal(b []byte) error {
+	buf := codec.NewBuffer(b)
+	m.Retval = buf.DecodeInt32()
+	m.PeerIndex = buf.DecodeUint32()
+	return nil
+}
+
+// WireguardPeerAddV2 defines message 'wireguard_peer_add_v2'.
+// InProgress: the message form may change in the future versions
+type WireguardPeerAddV2 struct {
+	Peer WireguardPeerV2 `binapi:"wireguard_peer_v2,name=peer" json:"peer,omitempty"`
+}
+
+func (m *WireguardPeerAddV2) Reset()               { *m = WireguardPeerAddV2{} }
+func (*WireguardPeerAddV2) GetMessageName() string { return "wireguard_peer_add_v2" }
+func (*WireguardPeerAddV2) GetCrcString() string   { return "4a07ba90" }
+func (*WireguardPeerAddV2) GetMessageType() api.MessageType {
+	return api.RequestMessage
+}
+
+func (m *WireguardPeerAddV2) Size() (size int) {
+	if m == nil {
+		return 0
+	}
+	size += 4      // m.Peer.PeerIndex
+	size += 1 * 32 // m.Peer.PresharedKey
+	size += 1      // m.Peer.PresharedKeySet
+	size += 1 * 32 // m.Peer.PublicKey
+	size += 2      // m.Peer.Port
+	size += 2      // m.Peer.PersistentKeepalive
+	size += 4      // m.Peer.TableID
+	size += 1      // m.Peer.Endpoint.Af
+	size += 1 * 16 // m.Peer.Endpoint.Un
+	size += 4      // m.Peer.SwIfIndex
+	size += 1      // m.Peer.Flags
+	size += 1      // m.Peer.NAllowedIps
+	for j2 := 0; j2 < len(m.Peer.AllowedIps); j2++ {
+		var s2 ip_types.Prefix
+		_ = s2
+		if j2 < len(m.Peer.AllowedIps) {
+			s2 = m.Peer.AllowedIps[j2]
+		}
+		size += 1      // s2.Address.Af
+		size += 1 * 16 // s2.Address.Un
+		size += 1      // s2.Len
+	}
+	return size
+}
+func (m *WireguardPeerAddV2) Marshal(b []byte) ([]byte, error) {
+	if b == nil {
+		b = make([]byte, m.Size())
+	}
+	buf := codec.NewBuffer(b)
+	buf.EncodeUint32(m.Peer.PeerIndex)
+	buf.EncodeBytes(m.Peer.PresharedKey, 32)
+	buf.EncodeBool(m.Peer.PresharedKeySet)
+	buf.EncodeBytes(m.Peer.PublicKey, 32)
+	buf.EncodeUint16(m.Peer.Port)
+	buf.EncodeUint16(m.Peer.PersistentKeepalive)
+	buf.EncodeUint32(m.Peer.TableID)
+	buf.EncodeUint8(uint8(m.Peer.Endpoint.Af))
+	buf.EncodeBytes(m.Peer.Endpoint.Un.XXX_UnionData[:], 16)
+	buf.EncodeUint32(uint32(m.Peer.SwIfIndex))
+	buf.EncodeUint8(uint8(m.Peer.Flags))
+	buf.EncodeUint8(uint8(len(m.Peer.AllowedIps)))
+	for j1 := 0; j1 < len(m.Peer.AllowedIps); j1++ {
+		var v1 ip_types.Prefix // AllowedIps
+		if j1 < len(m.Peer.AllowedIps) {
+			v1 = m.Peer.AllowedIps[j1]
+		}
+		buf.EncodeUint8(uint8(v1.Address.Af))
+		buf.EncodeBytes(v1.Address.Un.XXX_UnionData[:], 16)
+		buf.EncodeUint8(v1.Len)
+	}
+	return buf.Bytes(), nil
+}
+func (m *WireguardPeerAddV2) Unmarshal(b []byte) error {
+	buf := codec.NewBuffer(b)
+	m.Peer.PeerIndex = buf.DecodeUint32()
+	m.Peer.PresharedKey = make([]byte, 32)
+	copy(m.Peer.PresharedKey, buf.DecodeBytes(len(m.Peer.PresharedKey)))
+	m.Peer.PresharedKeySet = buf.DecodeBool()
+	m.Peer.PublicKey = make([]byte, 32)
+	copy(m.Peer.PublicKey, buf.DecodeBytes(len(m.Peer.PublicKey)))
+	m.Peer.Port = buf.DecodeUint16()
+	m.Peer.PersistentKeepalive = buf.DecodeUint16()
+	m.Peer.TableID = buf.DecodeUint32()
+	m.Peer.Endpoint.Af = ip_types.AddressFamily(buf.DecodeUint8())
+	copy(m.Peer.Endpoint.Un.XXX_UnionData[:], buf.DecodeBytes(16))
+	m.Peer.SwIfIndex = interface_types.InterfaceIndex(buf.DecodeUint32())
+	m.Peer.Flags = WireguardPeerFlags(buf.DecodeUint8())
+	m.Peer.NAllowedIps = buf.DecodeUint8()
+	m.Peer.AllowedIps = make([]ip_types.Prefix, m.Peer.NAllowedIps)
+	for j1 := 0; j1 < len(m.Peer.AllowedIps); j1++ {
+		m.Peer.AllowedIps[j1].Address.Af = ip_types.AddressFamily(buf.DecodeUint8())
+		copy(m.Peer.AllowedIps[j1].Address.Un.XXX_UnionData[:], buf.DecodeBytes(16))
+		m.Peer.AllowedIps[j1].Len = buf.DecodeUint8()
+	}
+	return nil
+}
+
+// WireguardPeerAddV2Reply defines message 'wireguard_peer_add_v2_reply'.
+// InProgress: the message form may change in the future versions
+type WireguardPeerAddV2Reply struct {
+	Retval    int32  `binapi:"i32,name=retval" json:"retval,omitempty"`
+	PeerIndex uint32 `binapi:"u32,name=peer_index" json:"peer_index,omitempty"`
+}
+
+func (m *WireguardPeerAddV2Reply) Reset()               { *m = WireguardPeerAddV2Reply{} }
+func (*WireguardPeerAddV2Reply) GetMessageName() string { return "wireguard_peer_add_v2_reply" }
+func (*WireguardPeerAddV2Reply) GetCrcString() string   { return "084a0cd3" }
+func (*WireguardPeerAddV2Reply) GetMessageType() api.MessageType {
+	return api.ReplyMessage
+}
+
+func (m *WireguardPeerAddV2Reply) Size() (size int) {
+	if m == nil {
+		return 0
+	}
+	size += 4 // m.Retval
+	size += 4 // m.PeerIndex
+	return size
+}
+func (m *WireguardPeerAddV2Reply) Marshal(b []byte) ([]byte, error) {
+	if b == nil {
+		b = make([]byte, m.Size())
+	}
+	buf := codec.NewBuffer(b)
+	buf.EncodeInt32(m.Retval)
+	buf.EncodeUint32(m.PeerIndex)
+	return buf.Bytes(), nil
+}
+func (m *WireguardPeerAddV2Reply) Unmarshal(b []byte) error {
 	buf := codec.NewBuffer(b)
 	m.Retval = buf.DecodeInt32()
 	m.PeerIndex = buf.DecodeUint32()
@@ -762,6 +912,7 @@ func (m *WireguardPeerRemoveReply) Unmarshal(b []byte) error {
 //   - peer - peer details
 //
 // WireguardPeersDetails defines message 'wireguard_peers_details'.
+// Deprecated: the message will be removed in the future versions
 type WireguardPeersDetails struct {
 	Peer WireguardPeer `binapi:"wireguard_peer,name=peer" json:"peer,omitempty"`
 }
@@ -851,6 +1002,7 @@ func (m *WireguardPeersDetails) Unmarshal(b []byte) error {
 //   - peer_index - peer index to be dumped.  If 0xFFFFFFFF dumps all peers
 //
 // WireguardPeersDump defines message 'wireguard_peers_dump'.
+// Deprecated: the message will be removed in the future versions
 type WireguardPeersDump struct {
 	PeerIndex uint32 `binapi:"u32,name=peer_index,default=4294967295" json:"peer_index,omitempty"`
 }
@@ -883,6 +1035,134 @@ func (m *WireguardPeersDump) Unmarshal(b []byte) error {
 	return nil
 }
 
+// WireguardPeersV2Details defines message 'wireguard_peers_v2_details'.
+// InProgress: the message form may change in the future versions
+type WireguardPeersV2Details struct {
+	Peer WireguardPeerV2 `binapi:"wireguard_peer_v2,name=peer" json:"peer,omitempty"`
+}
+
+func (m *WireguardPeersV2Details) Reset()               { *m = WireguardPeersV2Details{} }
+func (*WireguardPeersV2Details) GetMessageName() string { return "wireguard_peers_v2_details" }
+func (*WireguardPeersV2Details) GetCrcString() string   { return "f5b86f42" }
+func (*WireguardPeersV2Details) GetMessageType() api.MessageType {
+	return api.ReplyMessage
+}
+
+func (m *WireguardPeersV2Details) Size() (size int) {
+	if m == nil {
+		return 0
+	}
+	size += 4      // m.Peer.PeerIndex
+	size += 1 * 32 // m.Peer.PresharedKey
+	size += 1      // m.Peer.PresharedKeySet
+	size += 1 * 32 // m.Peer.PublicKey
+	size += 2      // m.Peer.Port
+	size += 2      // m.Peer.PersistentKeepalive
+	size += 4      // m.Peer.TableID
+	size += 1      // m.Peer.Endpoint.Af
+	size += 1 * 16 // m.Peer.Endpoint.Un
+	size += 4      // m.Peer.SwIfIndex
+	size += 1      // m.Peer.Flags
+	size += 1      // m.Peer.NAllowedIps
+	for j2 := 0; j2 < len(m.Peer.AllowedIps); j2++ {
+		var s2 ip_types.Prefix
+		_ = s2
+		if j2 < len(m.Peer.AllowedIps) {
+			s2 = m.Peer.AllowedIps[j2]
+		}
+		size += 1      // s2.Address.Af
+		size += 1 * 16 // s2.Address.Un
+		size += 1      // s2.Len
+	}
+	return size
+}
+func (m *WireguardPeersV2Details) Marshal(b []byte) ([]byte, error) {
+	if b == nil {
+		b = make([]byte, m.Size())
+	}
+	buf := codec.NewBuffer(b)
+	buf.EncodeUint32(m.Peer.PeerIndex)
+	buf.EncodeBytes(m.Peer.PresharedKey, 32)
+	buf.EncodeBool(m.Peer.PresharedKeySet)
+	buf.EncodeBytes(m.Peer.PublicKey, 32)
+	buf.EncodeUint16(m.Peer.Port)
+	buf.EncodeUint16(m.Peer.PersistentKeepalive)
+	buf.EncodeUint32(m.Peer.TableID)
+	buf.EncodeUint8(uint8(m.Peer.Endpoint.Af))
+	buf.EncodeBytes(m.Peer.Endpoint.Un.XXX_UnionData[:], 16)
+	buf.EncodeUint32(uint32(m.Peer.SwIfIndex))
+	buf.EncodeUint8(uint8(m.Peer.Flags))
+	buf.EncodeUint8(uint8(len(m.Peer.AllowedIps)))
+	for j1 := 0; j1 < len(m.Peer.AllowedIps); j1++ {
+		var v1 ip_types.Prefix // AllowedIps
+		if j1 < len(m.Peer.AllowedIps) {
+			v1 = m.Peer.AllowedIps[j1]
+		}
+		buf.EncodeUint8(uint8(v1.Address.Af))
+		buf.EncodeBytes(v1.Address.Un.XXX_UnionData[:], 16)
+		buf.EncodeUint8(v1.Len)
+	}
+	return buf.Bytes(), nil
+}
+func (m *WireguardPeersV2Details) Unmarshal(b []byte) error {
+	buf := codec.NewBuffer(b)
+	m.Peer.PeerIndex = buf.DecodeUint32()
+	m.Peer.PresharedKey = make([]byte, 32)
+	copy(m.Peer.PresharedKey, buf.DecodeBytes(len(m.Peer.PresharedKey)))
+	m.Peer.PresharedKeySet = buf.DecodeBool()
+	m.Peer.PublicKey = make([]byte, 32)
+	copy(m.Peer.PublicKey, buf.DecodeBytes(len(m.Peer.PublicKey)))
+	m.Peer.Port = buf.DecodeUint16()
+	m.Peer.PersistentKeepalive = buf.DecodeUint16()
+	m.Peer.TableID = buf.DecodeUint32()
+	m.Peer.Endpoint.Af = ip_types.AddressFamily(buf.DecodeUint8())
+	copy(m.Peer.Endpoint.Un.XXX_UnionData[:], buf.DecodeBytes(16))
+	m.Peer.SwIfIndex = interface_types.InterfaceIndex(buf.DecodeUint32())
+	m.Peer.Flags = WireguardPeerFlags(buf.DecodeUint8())
+	m.Peer.NAllowedIps = buf.DecodeUint8()
+	m.Peer.AllowedIps = make([]ip_types.Prefix, m.Peer.NAllowedIps)
+	for j1 := 0; j1 < len(m.Peer.AllowedIps); j1++ {
+		m.Peer.AllowedIps[j1].Address.Af = ip_types.AddressFamily(buf.DecodeUint8())
+		copy(m.Peer.AllowedIps[j1].Address.Un.XXX_UnionData[:], buf.DecodeBytes(16))
+		m.Peer.AllowedIps[j1].Len = buf.DecodeUint8()
+	}
+	return nil
+}
+
+// WireguardPeersV2Dump defines message 'wireguard_peers_v2_dump'.
+// InProgress: the message form may change in the future versions
+type WireguardPeersV2Dump struct {
+	PeerIndex uint32 `binapi:"u32,name=peer_index,default=4294967295" json:"peer_index,omitempty"`
+}
+
+func (m *WireguardPeersV2Dump) Reset()               { *m = WireguardPeersV2Dump{} }
+func (*WireguardPeersV2Dump) GetMessageName() string { return "wireguard_peers_v2_dump" }
+func (*WireguardPeersV2Dump) GetCrcString() string   { return "3b74607a" }
+func (*WireguardPeersV2Dump) GetMessageType() api.MessageType {
+	return api.RequestMessage
+}
+
+func (m *WireguardPeersV2Dump) Size() (size int) {
+	if m == nil {
+		return 0
+	}
+	size += 4 // m.PeerIndex
+	return size
+}
+func (m *WireguardPeersV2Dump) Marshal(b []byte) ([]byte, error) {
+	if b == nil {
+		b = make([]byte, m.Size())
+	}
+	buf := codec.NewBuffer(b)
+	buf.EncodeUint32(m.PeerIndex)
+	return buf.Bytes(), nil
+}
+func (m *WireguardPeersV2Dump) Unmarshal(b []byte) error {
+	buf := codec.NewBuffer(b)
+	m.PeerIndex = buf.DecodeUint32()
+	return nil
+}
+
 func init() { file_wireguard_binapi_init() }
 func file_wireguard_binapi_init() {
 	api.RegisterMessage((*WantWireguardPeerEvents)(nil), "want_wireguard_peer_events_3bc666c8")
@@ -897,11 +1177,15 @@ func file_wireguard_binapi_init() {
 	api.RegisterMessage((*WireguardInterfaceDump)(nil), "wireguard_interface_dump_2c954158")
 	api.RegisterMessage((*WireguardPeerAdd)(nil), "wireguard_peer_add_9b8aad61")
 	api.RegisterMessage((*WireguardPeerAddReply)(nil), "wireguard_peer_add_reply_084a0cd3")
+	api.RegisterMessage((*WireguardPeerAddV2)(nil), "wireguard_peer_add_v2_4a07ba90")
+	api.RegisterMessage((*WireguardPeerAddV2Reply)(nil), "wireguard_peer_add_v2_reply_084a0cd3")
 	api.RegisterMessage((*WireguardPeerEvent)(nil), "wireguard_peer_event_4e1b5d67")
 	api.RegisterMessage((*WireguardPeerRemove)(nil), "wireguard_peer_remove_3b74607a")
 	api.RegisterMessage((*WireguardPeerRemoveReply)(nil), "wireguard_peer_remove_reply_e8d4e804")
 	api.RegisterMessage((*WireguardPeersDetails)(nil), "wireguard_peers_details_6a9f6bc3")
 	api.RegisterMessage((*WireguardPeersDump)(nil), "wireguard_peers_dump_3b74607a")
+	api.RegisterMessage((*WireguardPeersV2Details)(nil), "wireguard_peers_v2_details_f5b86f42")
+	api.RegisterMessage((*WireguardPeersV2Dump)(nil), "wireguard_peers_v2_dump_3b74607a")
 }
 
 // Messages returns list of all messages in this module.
@@ -919,10 +1203,14 @@ func AllMessages() []api.Message {
 		(*WireguardInterfaceDump)(nil),
 		(*WireguardPeerAdd)(nil),
 		(*WireguardPeerAddReply)(nil),
+		(*WireguardPeerAddV2)(nil),
+		(*WireguardPeerAddV2Reply)(nil),
 		(*WireguardPeerEvent)(nil),
 		(*WireguardPeerRemove)(nil),
 		(*WireguardPeerRemoveReply)(nil),
 		(*WireguardPeersDetails)(nil),
 		(*WireguardPeersDump)(nil),
+		(*WireguardPeersV2Details)(nil),
+		(*WireguardPeersV2Dump)(nil),
 	}
 }

--- a/vpplink/generated/bindings/wireguard/wireguard_rpc.ba.go
+++ b/vpplink/generated/bindings/wireguard/wireguard_rpc.ba.go
@@ -19,8 +19,10 @@ type RPCService interface {
 	WireguardInterfaceDelete(ctx context.Context, in *WireguardInterfaceDelete) (*WireguardInterfaceDeleteReply, error)
 	WireguardInterfaceDump(ctx context.Context, in *WireguardInterfaceDump) (RPCService_WireguardInterfaceDumpClient, error)
 	WireguardPeerAdd(ctx context.Context, in *WireguardPeerAdd) (*WireguardPeerAddReply, error)
+	WireguardPeerAddV2(ctx context.Context, in *WireguardPeerAddV2) (*WireguardPeerAddV2Reply, error)
 	WireguardPeerRemove(ctx context.Context, in *WireguardPeerRemove) (*WireguardPeerRemoveReply, error)
 	WireguardPeersDump(ctx context.Context, in *WireguardPeersDump) (RPCService_WireguardPeersDumpClient, error)
+	WireguardPeersV2Dump(ctx context.Context, in *WireguardPeersV2Dump) (RPCService_WireguardPeersV2DumpClient, error)
 }
 
 type serviceClient struct {
@@ -119,6 +121,15 @@ func (c *serviceClient) WireguardPeerAdd(ctx context.Context, in *WireguardPeerA
 	return out, api.RetvalToVPPApiError(out.Retval)
 }
 
+func (c *serviceClient) WireguardPeerAddV2(ctx context.Context, in *WireguardPeerAddV2) (*WireguardPeerAddV2Reply, error) {
+	out := new(WireguardPeerAddV2Reply)
+	err := c.conn.Invoke(ctx, in, out)
+	if err != nil {
+		return nil, err
+	}
+	return out, api.RetvalToVPPApiError(out.Retval)
+}
+
 func (c *serviceClient) WireguardPeerRemove(ctx context.Context, in *WireguardPeerRemove) (*WireguardPeerRemoveReply, error) {
 	out := new(WireguardPeerRemoveReply)
 	err := c.conn.Invoke(ctx, in, out)
@@ -159,6 +170,49 @@ func (c *serviceClient_WireguardPeersDumpClient) Recv() (*WireguardPeersDetails,
 	}
 	switch m := msg.(type) {
 	case *WireguardPeersDetails:
+		return m, nil
+	case *memclnt.ControlPingReply:
+		err = c.Stream.Close()
+		if err != nil {
+			return nil, err
+		}
+		return nil, io.EOF
+	default:
+		return nil, fmt.Errorf("unexpected message: %T %v", m, m)
+	}
+}
+
+func (c *serviceClient) WireguardPeersV2Dump(ctx context.Context, in *WireguardPeersV2Dump) (RPCService_WireguardPeersV2DumpClient, error) {
+	stream, err := c.conn.NewStream(ctx)
+	if err != nil {
+		return nil, err
+	}
+	x := &serviceClient_WireguardPeersV2DumpClient{stream}
+	if err := x.Stream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err = x.Stream.SendMsg(&memclnt.ControlPing{}); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+type RPCService_WireguardPeersV2DumpClient interface {
+	Recv() (*WireguardPeersV2Details, error)
+	api.Stream
+}
+
+type serviceClient_WireguardPeersV2DumpClient struct {
+	api.Stream
+}
+
+func (c *serviceClient_WireguardPeersV2DumpClient) Recv() (*WireguardPeersV2Details, error) {
+	msg, err := c.Stream.RecvMsg()
+	if err != nil {
+		return nil, err
+	}
+	switch m := msg.(type) {
+	case *WireguardPeersV2Details:
 		return m, nil
 	case *memclnt.ControlPingReply:
 		err = c.Stream.Close()

--- a/vpplink/generated/generate.log
+++ b/vpplink/generated/generate.log
@@ -1,20 +1,17 @@
-VPP Version                 : 26.06-rc0~260-g316da3ca2
+VPP Version                 : 26.06-rc0~544-gc79208ac1
 Binapi-generator version    : v0.11.0
-VPP Base commit             : cd5b8d6e7 gerrit:34726/3 interface: add buffer stats api
+VPP Base commit             : 3a64ed84a gerrit:42343/2 vcl: LDP default to regular option
 ------------------ Cherry picked commits --------------------
+interface: add buffer stats api
 npol: add matched rule id to acl trace
 ip-neighbor: preserve interface LL receive DPO for self link-local
 acl: acl-plugin custom policies
 cnat: [WIP] no k8s maglev from pods
-pbl: Port based balancer
-gerrit:44935/4 virtio: add support for secondary MAC filtering
-gerrit:44930/4 virtio: add support for MAC address change
 gerrit:45046/4 ip6-nd: add punt reason for neigh advs
 gerrit:45099/2 ip6-nd: add nd-proxy all dst
-gerrit:44966/5 ip-neighbor: fix missing solicited-node multicast MAC
 gerrit:44903/1 vxlan: reset next_dpo on delete
 gerrit:44350/3 vnet: fix unicast NA handling in ND proxy
-gerrit:43369/37 cnat: support encapsulation and session cleanup on backend deletion
+gerrit:45644/1 misc: update vpp_if_stats govpp version
+gerrit:43369/41 cnat: support encapsulation and session cleanup on backend deletion
 gerrit:42343/2 vcl: LDP default to regular option
-gerrit:34726/3 interface: add buffer stats api
 -------------------------------------------------------------

--- a/vpplink/generated/patches/0006-interface-add-buffer-stats-api.patch
+++ b/vpplink/generated/patches/0006-interface-add-buffer-stats-api.patch
@@ -1,0 +1,148 @@
+From e1fc3fd84ed342fbc9437f89191134ad42975239 Mon Sep 17 00:00:00 2001
+From: hedi bouattour <hedibouattour2010@gmail.com>
+Date: Fri, 10 Dec 2021 15:18:05 +0000
+Subject: [PATCH] interface: add buffer stats api
+
+Type: fix
+
+Change-Id: I9c2c0b0a35884f0375b4f589841732ad9979fe6c
+Signed-off-by: hedi bouattour <hedibouattour2010@gmail.com>
+---
+ src/vlib/buffer.c         | 14 ++++++++++++++
+ src/vlib/buffer.h         |  9 +++++++++
+ src/vnet/interface.api    | 21 +++++++++++++++++++++
+ src/vnet/interface_api.c  | 17 +++++++++++++++++
+ src/vnet/interface_test.c | 12 ++++++++++++
+ 5 files changed, 73 insertions(+)
+
+diff --git a/src/vlib/buffer.c b/src/vlib/buffer.c
+index ed751f422..990a9a537 100644
+--- a/src/vlib/buffer.c
++++ b/src/vlib/buffer.c
+@@ -782,6 +782,20 @@ buffer_get_by_index (vlib_buffer_main_t * bm, u32 index)
+   return bp;
+ }
+ 
++void
++get_buffers_stats (buffers_stats_t *bs, u32 index)
++{
++  vlib_main_t *vm = vlib_get_main ();
++  vlib_buffer_pool_t *bp =
++    buffer_get_by_index (vm->buffer_main, clib_net_to_host_u32 (index));
++  if (!bp)
++    return;
++  bs->available_buffers = htonl (bp->n_avail);
++  bs->cached_buffers = htonl (buffer_get_cached (bp));
++  bs->used_buffers =
++    htonl (bp->n_buffers - bp->n_avail - buffer_get_cached (bp));
++}
++
+ static void
+ buffer_gauges_collect_used_fn (vlib_stats_collector_data_t *d)
+ {
+diff --git a/src/vlib/buffer.h b/src/vlib/buffer.h
+index d6f62abd4..58b77981b 100644
+--- a/src/vlib/buffer.h
++++ b/src/vlib/buffer.h
+@@ -424,6 +424,15 @@ struct vlib_main_t;
+ 
+ #define VLIB_BUFFER_POOL_PER_THREAD_CACHE_SZ 512
+ 
++typedef struct
++{
++  u32 available_buffers;
++  u32 cached_buffers;
++  u32 used_buffers;
++} buffers_stats_t;
++
++void get_buffers_stats (buffers_stats_t *bs, u32 index);
++
+ typedef struct
+ {
+   CLIB_CACHE_LINE_ALIGN_MARK (cacheline0);
+diff --git a/src/vnet/interface.api b/src/vnet/interface.api
+index 470f72cac..e3cae68c3 100644
+--- a/src/vnet/interface.api
++++ b/src/vnet/interface.api
+@@ -822,6 +822,27 @@ define sw_interface_get_default_rx_mode_reply
+   vl_api_rx_mode_t mode;
+ };
+ 
++/** \brief Get available, cached and used buffers
++    @param client_index - opaque cookie to identify the sender
++    @param context - sender context, to match reply w/ request
++    @param buffer_index - buffer stat index
++*/
++define get_buffers_stats
++{
++  u32 client_index;
++  u32 context;
++  u32 buffer_index;
++};
++
++define get_buffers_stats_reply
++{
++  u32 context;
++  i32 retval;
++  u32 available_buffers;
++  u32 cached_buffers;
++  u32 used_buffers;
++};
++
+ /*
+  * Local Variables:
+  * eval: (c-set-style "gnu")
+diff --git a/src/vnet/interface_api.c b/src/vnet/interface_api.c
+index 7648b0410..9df3042f9 100644
+--- a/src/vnet/interface_api.c
++++ b/src/vnet/interface_api.c
+@@ -74,6 +74,23 @@ vpe_api_main_t vpe_api_main;
+   _ (SW_INTERFACE_ADDRESS_REPLACE_BEGIN, sw_interface_address_replace_begin)                       \
+   _ (SW_INTERFACE_ADDRESS_REPLACE_END, sw_interface_address_replace_end)
+ 
++static void
++vl_api_get_buffers_stats_t_handler (vl_api_get_buffers_stats_t *mp)
++{
++  vl_api_get_buffers_stats_reply_t *rmp;
++
++  int rv = 0;
++  buffers_stats_t obj = { 0, 0, 0 };
++  buffers_stats_t *bs = &obj;
++  get_buffers_stats (bs, mp->buffer_index);
++
++  REPLY_MACRO2 (VL_API_GET_BUFFERS_STATS_REPLY, ({
++		  rmp->available_buffers = bs->available_buffers;
++		  rmp->cached_buffers = bs->cached_buffers;
++		  rmp->used_buffers = bs->used_buffers;
++		}));
++}
++
+ static void
+ vl_api_sw_interface_set_flags_t_handler (vl_api_sw_interface_set_flags_t * mp)
+ {
+diff --git a/src/vnet/interface_test.c b/src/vnet/interface_test.c
+index d37d4deee..0ada3e137 100644
+--- a/src/vnet/interface_test.c
++++ b/src/vnet/interface_test.c
+@@ -33,6 +33,18 @@ typedef struct
+ 
+ static interface_test_main_t interface_test_main;
+ 
++static int
++api_get_buffers_stats (vat_main_t *vam)
++{
++  int ret = 0;
++  return ret;
++}
++
++static void
++vl_api_get_buffers_stats_reply_t_handler (vl_api_get_buffers_stats_reply_t *mp)
++{
++}
++
+ static int
+ api_sw_interface_set_flags (vat_main_t *vam)
+ {
+-- 
+2.43.0
+

--- a/vpplink/generated/vpp_clone_current.sh
+++ b/vpplink/generated/vpp_clone_current.sh
@@ -111,27 +111,26 @@ function git_clone_cd_and_reset ()
 # --------------- Things to cherry pick ---------------
 
 #
-BASE="${BASE:-"1f7348b6d5cd1b09f17de1183af2e1565d308f3f"}"
+BASE="${BASE:-"df29c4ff84d2d3c06f2908f62f49040d3164778f"}"
 if [ "$VPP_DIR" = "" ]; then
        VPP_DIR="$1"
 fi
 git_clone_cd_and_reset "$VPP_DIR" ${BASE}
 
-git_cherry_pick refs/changes/26/34726/3 # 34726: interface: add buffer stats api | https://gerrit.fd.io/r/c/vpp/+/34726
 git_cherry_pick refs/changes/43/42343/2 # 42343: vcl: LDP default to regular option | https://gerrit.fd.io/r/c/vpp/+/42343
 
 # cnat new implementation: a cnat session is now used for every packet for fastpath, we delete sessions when
 # corresponding translation disappears
-git_cherry_pick refs/changes/69/43369/41 # 43369: cnat: converge new cnat implementation to support encaps (calico) https://gerrit.fd.io/r/c/vpp/+/43369
+git_cherry_pick refs/changes/69/43369/41 # 43369: cnat: converge new cnat implementation to support encaps (calico) | https://gerrit.fd.io/r/c/vpp/+/43369
+
+# update vpp_if_stats govpp version
+git_cherry_pick refs/changes/44/45644/1 # 45644: misc: update vpp_if_stats govpp version | https://gerrit.fd.io/r/c/vpp/+/45644
 
 # IPv6 related fixes:
 git_cherry_pick refs/changes/50/44350/3 # 44350: vnet: fix unicast NA handling in ND proxy | https://gerrit.fd.io/r/c/vpp/+/44350
 git_cherry_pick refs/changes/03/44903/1 # 44903: vxlan: reset next_dpo on delete | https://gerrit.fd.io/r/c/vpp/+/44903
-git_cherry_pick refs/changes/66/44966/5 # 44966: ip-neighbor: fix missing solicited-node multicast MAC | https://gerrit.fd.io/r/c/vpp/+/44966
 git_cherry_pick refs/changes/99/45099/2 # 45099: ip6-nd: add nd-proxy all dst | https://gerrit.fd.io/r/c/vpp/+/45099
 git_cherry_pick refs/changes/46/45046/4 # 45046: ip6-nd: add punt reason for neigh advs | https://gerrit.fd.io/r/c/vpp/+/45046
-git_cherry_pick refs/changes/30/44930/4 # 44930: virtio: add support for MAC address change | https://gerrit.fd.io/r/c/vpp/+/44930
-git_cherry_pick refs/changes/35/44935/4 # 44935: virtio: add support for secondary MAC filtering | https://gerrit.fd.io/r/c/vpp/+/44935
 
 # --------------- private patches/plugins ---------------
 # Patch files generated with 'git format-patch --zero-commit -o ./patches/ HEAD^^^'
@@ -139,6 +138,7 @@ git_apply_private 0002-cnat-WIP-no-k8s-maglev-from-pods.patch
 git_apply_private 0003-acl-acl-plugin-custom-policies.patch
 git_apply_private 0004-ip-neighbor-preserve-interface-ll-receive-dpo.patch
 git_apply_private 0005-npol-add-matched-rule-id-to-acl-trace.patch
-# TTL fixup is kept as a private plugin source tree.
+git_apply_private 0006-interface-add-buffer-stats-api.patch
+# VPP Private plugins:
 copy_private_plugin ip_ttl_fixup
 copy_private_plugin pbl


### PR DESCRIPTION
Gerrit [#45262](https://gerrit.fd.io/r/c/vpp/+/45262) merged on VPP `master` was causing a **merge conflict** when we `cherry-pick` Gerrit [#34726](https://gerrit.fd.io/r/c/vpp/+/34726) causing VPP daily `kube-test` runs to fail.

- Bumped VPP commit to latest `master`.
- Converted Gerrit [#34726](https://gerrit.fd.io/r/c/vpp/+/34726) to a **private patch** `0006-interface-add-buffer-stats-api.patch` rebased on latest VPP `master`.
- Cherry-picked Gerrit patch [#45644](https://gerrit.fd.io/r/c/vpp/+/45644) to update `vpp_if_stats` **govpp** version.
- Ran `make goapi` to update `vpplink` bindings based on latest VPP `master`.
- Removed 3 `git_cherry_pick` already merged on latest VPP `master` from `vpp_clone_current.sh`.