### PR TITLE
build: use relative path in copy_private_plugin

### DIFF
--- a/vpplink/generated/vpp_clone_current.sh
+++ b/vpplink/generated/vpp_clone_current.sh
@@ -69,8 +69,8 @@ function copy_private_plugin ()
 {
 	name=$1
 	blue "Copying private plugin $name..."
-	rm -rf "$VPP_DIR/src/plugins/$name"
-	cp -r "$SCRIPTDIR/private_plugins/$name" "$VPP_DIR/src/plugins/$name"
+	rm -rf "src/plugins/$name"
+	cp -r "$SCRIPTDIR/private_plugins/$name" "src/plugins/$name"
 }
 
 


### PR DESCRIPTION
build doesn't work anywhere if we pass relative paths from outside the function.