### PR TITLE
Fix CI missing vpp go.mod before gomod check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -299,11 +299,11 @@ delete-multinet:
 
 .PHONY: lint
 lint:
+	test -d ${VPP_DATAPLANE_DIR}/vpp-manager/vpp_build && touch ${VPP_DATAPLANE_DIR}/vpp-manager/vpp_build/go.mod || true
 	go mod tidy --diff || (echo -e "Please run\ngo mod tidy" && exit 1)
 	gofmt -s -l . | grep -vE '(binapi|vpp_build|vendor)' \
 		| diff -u /dev/null - \
 		|| (echo -e "Please run\ngofmt -w ." && exit 1)
-	test -d vpp-manager/vpp_build && touch vpp-manager/vpp_build/go.mod || true
 	golangci-lint run --color=never
 	markdownlint --dot \
 		--ignore vpp-manager/vpp_build \


### PR DESCRIPTION
We need to run the touch VPP/go.mod before
running go mod tidy otherwise we will recurse
into VPP's golang code that does not contain
the proper go.mod files.