### PR TITLE
prometheus: fix parallel CI job collisions with PID-based container name

### DIFF
--- a/calico-vpp-agent/prometheus/prometheus_test.go
+++ b/calico-vpp-agent/prometheus/prometheus_test.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -57,8 +58,11 @@ func TestPrometheusIntegration(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	// Set unique container name for Prometheus tests
-	testutils.VPPContainerName = "prometheus-tests-vpp"
+	// Make the container name unique per test run so that parallel CI jobs
+	// sharing the same host Docker daemon do not collide. Use the PID of
+	// the test process, which is unique on the host.
+	uniqueID := strconv.Itoa(os.Getpid())
+	testutils.VPPContainerName = "prometheus-tests-vpp-" + uniqueID
 
 	// extract common input for prometheus integration tests
 	var found bool
@@ -107,12 +111,13 @@ var _ = Describe("Prometheus exporter functionality", func() {
 		vpp, uplinkSwIfIndex = testutils.ConfigureVPP(log)
 
 		// Wait for VPP stats socket to become available
-		waitForStatsSocket("/tmp/"+testutils.VPPContainerName+"/stats.sock", 2*time.Second)
+		pidSubdir := "/tmp/prometheus-tests-vpp/" + strconv.Itoa(os.Getpid())
+		waitForStatsSocket(pidSubdir+"/stats.sock", 2*time.Second)
 
 		// Create a symlink from the expected location to the actual stats socket location
 		// This is a workaround for the issue where the statsclient expects /run/vpp/stats.sock
-		// but our test VPP container has this at /tmp/prom-tests-vpp/stats.sock
-		actualSocketPath := "/tmp/" + testutils.VPPContainerName + "/stats.sock"
+		// but our test VPP container has this at /tmp/prometheus-tests-vpp/<PID>/stats.sock
+		actualSocketPath := pidSubdir + "/stats.sock"
 		expectedSocketPath := "/run/vpp/stats.sock"
 
 		// Create the directory if it doesn't exist

--- a/calico-vpp-agent/testutils/testutils.go
+++ b/calico-vpp-agent/testutils/testutils.go
@@ -305,6 +305,12 @@ func IPFamilyIndex(ipFamily vpplink.IPFamily) int {
 
 // StartVPP creates docker container and runs inside the VPP
 func StartVPP() {
+	// Create PID-based subdirectory within the /tmp/prometheus-tests-vpp/
+	// mounted volume to ensure uniqueness across parallel test runs
+	pidSubdir := "/tmp/prometheus-tests-vpp/" + strconv.Itoa(os.Getpid())
+	err := os.MkdirAll(pidSubdir, 0755)
+	Expect(err).Should(BeNil(), "Failed to create PID subdirectory")
+
 	// prepare VPP configuration
 	vppBinaryConfigArg := `unix {
 			nodaemon
@@ -329,7 +335,7 @@ func StartVPP() {
 		  }`
 
 	// docker container cleanup (failed test that didn't properly clean up docker containers?)
-	err := exec.Command("docker", "rm", "-f", VPPContainerName).Run()
+	err = exec.Command("docker", "rm", "-f", VPPContainerName).Run()
 	Expect(err).Should(BeNil(), "Failed to clean up old VPP docker container")
 
 	wd, err := os.Getwd()
@@ -337,7 +343,7 @@ func StartVPP() {
 	repoDir := strings.TrimSpace(filepath.Join(wd, "../.."))
 	// start VPP inside docker container
 	cmdParams := []string{"run", "-d", "--privileged", "--name", VPPContainerName,
-		"-v", "/tmp/" + VPPContainerName + ":/var/run/vpp/",
+		"-v", pidSubdir + ":/var/run/vpp/",
 		"-v", "/proc:/proc", // needed for manipulation of another docker container's network namespace
 		"--sysctl", "net.ipv6.conf.all.disable_ipv6=0", // enable IPv6 in container (to set IPv6 on host's end of uplink)
 		"-v", repoDir + ":/repo/",
@@ -355,8 +361,9 @@ func StartVPP() {
 
 // ConfigureVPP connects to VPP and configures it with common configuration needed for tests
 func ConfigureVPP(log *logrus.Logger) (vpp *vpplink.VppLink, uplinkSwIfIndex uint32) {
-	// connect to VPP
-	vpp, err := common.CreateVppLinkInRetryLoop("/tmp/"+VPPContainerName+"/vpp-api-test.sock",
+	// connect to VPP using PID-based subdirectory path
+	pidSubdir := "/tmp/prometheus-tests-vpp/" + strconv.Itoa(os.Getpid())
+	vpp, err := common.CreateVppLinkInRetryLoop(pidSubdir+"/vpp-api-test.sock",
 		log.WithFields(logrus.Fields{"component": "vpp-api"}), 20*time.Second, 100*time.Millisecond)
 	Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Cannot create VPP client: %v", err))
 	Expect(vpp).NotTo(BeNil())


### PR DESCRIPTION
### RCA:
The Prometheus integration tests fail intermittently when multiple CI jobs run in parallel on the same host. The test infrastructure uses a **sibling container** pattern, mounting the host Docker daemon (`/var/run/docker.sock`) into the test runner container. This allows the tests to manage VPP containers on the host, but it means:
- All concurrent CI jobs share the same Docker daemon
- All use the same hardcoded host path: `/tmp/prometheus-tests-vpp`

This creates two failure modes:
- **Container Name Collision**:
`StartVPP()` begins with `docker rm -f prometheus-tests-vpp`. With a hardcoded container name:
  - Job B's startup kills Job A's running VPP container mid-test
  - Job A's `statsclient` loses its connection
  - All subsequent `DumpStats()` calls fail
  - Test assertions that check metric counts fail
- **Shared Socket Directory**:
When Job B starts a new VPP container mounting the same host path, VPP recreates its socket files in `/tmp/prometheus-tests-vpp/`. Job A has a symlink `/run/vpp/stats.sock → /tmp/prometheus-tests-vpp/stats.sock` that now points to Job B's VPP instance.

### Fix:
Make the container name and host `/tmp` directory unique **per test process** using its PID:
```go
// prometheus_test.go BeforeSuite
uniqueID := strconv.Itoa(os.Getpid())
testutils.VPPContainerName = "prometheus-tests-vpp-" + uniqueID

// testutils.go StartVPP()
pidSubdir := "/tmp/prometheus-tests-vpp/" + strconv.Itoa(os.Getpid())
os.MkdirAll(pidSubdir, 0755)
```