### PR TITLE
keep policies naming consistent

### DIFF
--- a/calico-vpp-agent/felix/felix_server.go
+++ b/calico-vpp-agent/felix/felix_server.go
@@ -1668,8 +1668,8 @@ func (s *Server) createEndpointToHostPolicy( /*may be return*/ ) (err error) {
 
 	conf := types.NewInterfaceConfig()
 	conf.IngressPolicyIDs = append(conf.IngressPolicyIDs, s.workloadsToHostPolicy.VppID)
-	conf.PolicyDefaultTx = npol.NPOL_DEFAULT_ALLOW
-	conf.PolicyDefaultRx = npol.NPOL_DEFAULT_ALLOW
+	conf.PolicyDefaultIngress = npol.NPOL_DEFAULT_ALLOW
+	conf.PolicyDefaultEgress = npol.NPOL_DEFAULT_ALLOW
 	swifindexes, err := s.vpp.SearchInterfacesWithTagPrefix("host-") // tap0 interfaces
 	if err != nil {
 		s.log.Error(err)

--- a/calico-vpp-agent/felix/host_endpoint.go
+++ b/calico-vpp-agent/felix/host_endpoint.go
@@ -181,24 +181,24 @@ func (h *HostEndpoint) getTapPolicies(state *PolicyState) (conf *types.Interface
 		// note: this applies to ingress and egress separately, so if you don't have
 		// ingress only you drop ingress
 		conf.IngressPolicyIDs = []uint32{h.server.workloadsToHostPolicy.VppID, h.server.failSafePolicy.VppID}
-		conf.PolicyDefaultTx = npol.NPOL_DEFAULT_DENY
+		conf.PolicyDefaultIngress = npol.NPOL_DEFAULT_DENY
 	} else {
 		if len(conf.IngressPolicyIDs) > 0 {
-			conf.PolicyDefaultTx = npol.NPOL_DEFAULT_DENY
+			conf.PolicyDefaultIngress = npol.NPOL_DEFAULT_DENY
 		} else if len(conf.ProfileIDs) > 0 {
-			conf.PolicyDefaultTx = npol.NPOL_DEFAULT_PASS
+			conf.PolicyDefaultIngress = npol.NPOL_DEFAULT_PASS
 		}
 		conf.IngressPolicyIDs = append([]uint32{h.server.failSafePolicy.VppID}, conf.IngressPolicyIDs...)
 		conf.IngressPolicyIDs = append([]uint32{h.server.workloadsToHostPolicy.VppID}, conf.IngressPolicyIDs...)
 	}
 	if len(conf.EgressPolicyIDs) == 0 && len(conf.ProfileIDs) == 0 {
 		conf.EgressPolicyIDs = []uint32{h.server.AllowFromHostPolicy.VppID, h.server.failSafePolicy.VppID}
-		conf.PolicyDefaultRx = npol.NPOL_DEFAULT_DENY
+		conf.PolicyDefaultEgress = npol.NPOL_DEFAULT_DENY
 	} else {
 		if len(conf.EgressPolicyIDs) > 0 {
-			conf.PolicyDefaultRx = npol.NPOL_DEFAULT_DENY
+			conf.PolicyDefaultEgress = npol.NPOL_DEFAULT_DENY
 		} else if len(conf.ProfileIDs) > 0 {
-			conf.PolicyDefaultRx = npol.NPOL_DEFAULT_PASS
+			conf.PolicyDefaultEgress = npol.NPOL_DEFAULT_PASS
 		}
 		conf.EgressPolicyIDs = append([]uint32{h.server.failSafePolicy.VppID}, conf.EgressPolicyIDs...)
 		conf.EgressPolicyIDs = append([]uint32{h.server.AllowFromHostPolicy.VppID}, conf.EgressPolicyIDs...)
@@ -213,15 +213,15 @@ func (h *HostEndpoint) getForwardPolicies(state *PolicyState) (conf *types.Inter
 	}
 	if len(conf.EgressPolicyIDs) > 0 {
 		conf.EgressPolicyIDs = append([]uint32{h.server.allowToHostPolicy.VppID}, conf.EgressPolicyIDs...)
-		conf.PolicyDefaultRx = npol.NPOL_DEFAULT_DENY
+		conf.PolicyDefaultEgress = npol.NPOL_DEFAULT_DENY
 	} else if len(conf.ProfileIDs) > 0 {
-		conf.PolicyDefaultRx = npol.NPOL_DEFAULT_PASS
+		conf.PolicyDefaultEgress = npol.NPOL_DEFAULT_PASS
 	}
 	if len(conf.IngressPolicyIDs) > 0 {
 		conf.IngressPolicyIDs = append([]uint32{h.server.allowToHostPolicy.VppID}, conf.IngressPolicyIDs...)
-		conf.PolicyDefaultTx = npol.NPOL_DEFAULT_DENY
+		conf.PolicyDefaultIngress = npol.NPOL_DEFAULT_DENY
 	} else if len(conf.ProfileIDs) > 0 {
-		conf.PolicyDefaultTx = npol.NPOL_DEFAULT_PASS
+		conf.PolicyDefaultIngress = npol.NPOL_DEFAULT_PASS
 	}
 	return conf, nil
 }

--- a/calico-vpp-agent/felix/workload_endpoint.go
+++ b/calico-vpp-agent/felix/workload_endpoint.go
@@ -119,14 +119,14 @@ func (w *WorkloadEndpoint) getWorkloadPolicies(state *PolicyState, network strin
 	}
 	if len(conf.IngressPolicyIDs) > 0 {
 		conf.IngressPolicyIDs = append([]uint32{w.server.AllowFromHostPolicy.VppID}, conf.IngressPolicyIDs...)
-		conf.PolicyDefaultTx = npol.NPOL_DEFAULT_DENY
+		conf.PolicyDefaultIngress = npol.NPOL_DEFAULT_DENY
 	} else if len(conf.ProfileIDs) > 0 {
-		conf.PolicyDefaultTx = npol.NPOL_DEFAULT_PASS
+		conf.PolicyDefaultIngress = npol.NPOL_DEFAULT_PASS
 	}
 	if len(conf.EgressPolicyIDs) > 0 {
-		conf.PolicyDefaultRx = npol.NPOL_DEFAULT_DENY
+		conf.PolicyDefaultEgress = npol.NPOL_DEFAULT_DENY
 	} else if len(conf.ProfileIDs) > 0 {
-		conf.PolicyDefaultRx = npol.NPOL_DEFAULT_PASS
+		conf.PolicyDefaultEgress = npol.NPOL_DEFAULT_PASS
 	}
 	return conf, nil
 }

--- a/vpplink/npol.go
+++ b/vpplink/npol.go
@@ -191,8 +191,8 @@ func (v *VppLink) PolicyDelete(policyID uint32) error {
 func (v *VppLink) ConfigurePolicies(swIfIndex uint32, conf *types.InterfaceConfig, invertRxTx uint8) error {
 	client := npol.NewServiceClient(v.GetConnection())
 
-	// In the calico agent, policies are expressed from the point of view of PODs
-	// in VPP this is reversed
+	// In the calico agent, policies are expressed from the point of view of PODs or Host
+	// in VPP this is reversed except for uplink, where we use invertRxTx
 	rxPolicyIDs := conf.EgressPolicyIDs
 	txPolicyIDs := conf.IngressPolicyIDs
 	profileIDs := conf.ProfileIDs
@@ -206,10 +206,10 @@ func (v *VppLink) ConfigurePolicies(swIfIndex uint32, conf *types.InterfaceConfi
 		TotalIds:         uint32(len(rxPolicyIDs) + len(txPolicyIDs) + len(profileIDs)),
 		PolicyIds:        ids,
 		InvertRxTx:       invertRxTx,
-		PolicyDefaultRx:  conf.PolicyDefaultRx,
-		PolicyDefaultTx:  conf.PolicyDefaultTx,
-		ProfileDefaultRx: conf.ProfileDefaultRx,
-		ProfileDefaultTx: conf.ProfileDefaultTx,
+		PolicyDefaultRx:  conf.PolicyDefaultEgress,
+		PolicyDefaultTx:  conf.PolicyDefaultIngress,
+		ProfileDefaultRx: conf.ProfileDefaultEgress,
+		ProfileDefaultTx: conf.ProfileDefaultIngress,
 	})
 	if err != nil {
 		return fmt.Errorf("npolConfigurePolicies failed: %w", err)

--- a/vpplink/types/npol.go
+++ b/vpplink/types/npol.go
@@ -320,24 +320,24 @@ func (p *Policy) String() string {
 }
 
 type InterfaceConfig struct {
-	IngressPolicyIDs []uint32
-	EgressPolicyIDs  []uint32
-	ProfileIDs       []uint32
-	PolicyDefaultRx  npol.NpolPolicyDefault
-	PolicyDefaultTx  npol.NpolPolicyDefault
-	ProfileDefaultRx npol.NpolPolicyDefault
-	ProfileDefaultTx npol.NpolPolicyDefault
+	IngressPolicyIDs      []uint32
+	EgressPolicyIDs       []uint32
+	ProfileIDs            []uint32
+	PolicyDefaultEgress   npol.NpolPolicyDefault
+	PolicyDefaultIngress  npol.NpolPolicyDefault
+	ProfileDefaultEgress  npol.NpolPolicyDefault
+	ProfileDefaultIngress npol.NpolPolicyDefault
 }
 
 func NewInterfaceConfig() *InterfaceConfig {
 	return &InterfaceConfig{
-		IngressPolicyIDs: make([]uint32, 0),
-		EgressPolicyIDs:  make([]uint32, 0),
-		ProfileIDs:       make([]uint32, 0),
-		PolicyDefaultRx:  npol.NPOL_DEFAULT_ALLOW,
-		PolicyDefaultTx:  npol.NPOL_DEFAULT_ALLOW,
-		ProfileDefaultRx: npol.NPOL_DEFAULT_DENY,
-		ProfileDefaultTx: npol.NPOL_DEFAULT_DENY,
+		IngressPolicyIDs:      make([]uint32, 0),
+		EgressPolicyIDs:       make([]uint32, 0),
+		ProfileIDs:            make([]uint32, 0),
+		PolicyDefaultEgress:   npol.NPOL_DEFAULT_ALLOW,
+		PolicyDefaultIngress:  npol.NPOL_DEFAULT_ALLOW,
+		ProfileDefaultEgress:  npol.NPOL_DEFAULT_DENY,
+		ProfileDefaultIngress: npol.NPOL_DEFAULT_DENY,
 	}
 }
 


### PR DESCRIPTION
In calico, we have ingress vs egress policies, policies are expressed from the POV of the pods/host
In vpp, we use rx vs tx, from the POV of VPP interfaces. So we reverse intent (except for uplink where we use invertRxTx) This patch keeps naming consistent.

`InterfaceConfig` is expressed in Calico manner.
`func (v *VppLink) ConfigurePolicies` is where we pass from Calico to VPP
convention.