### PR TITLE
Backport new tests 3.31

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,8 +196,15 @@ run-tests-nat-policy:
 	test/scripts/cases.sh nat_policy_ipv4
 	test/scripts/test.sh down nat-policy
 
+.PHONY: run-tests-hep
+run-tests-hep:
+	test/scripts/test.sh up hep
+	@bash -c 'kubectl -n hep wait pod --all --for=condition=Ready --timeout=60s'
+	test/scripts/cases.sh hep_ipv4
+	test/scripts/test.sh down hep
+
 .PHONY: run-main-tests
-run-main-tests: run-tests-nat run-tests-policy run-tests-nat-policy
+run-main-tests: run-tests-nat run-tests-policy run-tests-nat-policy run-tests-hep
 
 .PHONY: run-cnat-drain-test
 run-cnat-drain-test:

--- a/Makefile
+++ b/Makefile
@@ -189,6 +189,9 @@ run-tests-policy:
 	test/scripts/cases.sh policy_ipv4
 	test/scripts/test.sh down policy
 
+.PHONY: run-main-tests
+run-main-tests: run-tests-nat run-tests-policy
+
 .PHONY: run-cnat-drain-test
 run-cnat-drain-test:
 	test/yaml/trex/run-cnat-drain-test.sh

--- a/Makefile
+++ b/Makefile
@@ -189,6 +189,10 @@ run-tests-policy:
 	test/scripts/cases.sh policy_ipv4
 	test/scripts/test.sh down policy
 
+.PHONY: run-cnat-drain-test
+run-cnat-drain-test:
+	test/yaml/trex/run-cnat-drain-test.sh
+
 .PHONY: restart-calicovpp
 restart-calicovpp:
 	kubectl -n calico-vpp-dataplane rollout restart ds/calico-vpp-node

--- a/Makefile
+++ b/Makefile
@@ -189,8 +189,15 @@ run-tests-policy:
 	test/scripts/cases.sh policy_ipv4
 	test/scripts/test.sh down policy
 
+.PHONY: run-tests-nat-policy
+run-tests-nat-policy:
+	test/scripts/test.sh up nat-policy
+	@bash -c 'kubectl -n nat-policy wait pod --all --for=condition=Ready --timeout=60s'
+	test/scripts/cases.sh nat_policy_ipv4
+	test/scripts/test.sh down nat-policy
+
 .PHONY: run-main-tests
-run-main-tests: run-tests-nat run-tests-policy
+run-main-tests: run-tests-nat run-tests-policy run-tests-nat-policy
 
 .PHONY: run-cnat-drain-test
 run-cnat-drain-test:

--- a/test/kind/install_calico_vpp.sh
+++ b/test/kind/install_calico_vpp.sh
@@ -60,6 +60,14 @@ export CALICO_ENCAPSULATION_V6=None # VXLAN IPIP None
 export CALICO_NAT_OUTGOING=Enabled
 export CALICOVPP_DISABLE_HUGEPAGES=true
 
+CNAT_SESSION_CLEANUP_TIMEOUT=${CNAT_SESSION_CLEANUP_TIMEOUT:-}
+CNAT_CONFIG_BLOCK=""
+if [[ -n "$CNAT_SESSION_CLEANUP_TIMEOUT" ]]; then
+    CNAT_CONFIG_BLOCK="cnat {
+  session-cleanup-timeout ${CNAT_SESSION_CLEANUP_TIMEOUT}
+}"
+fi
+
 export CALICOVPP_CONFIG_TEMPLATE="unix {
   nodaemon
   full-coredump
@@ -81,6 +89,7 @@ plugins {
     plugin default { enable }
     plugin dpdk_plugin.so { disable }
 }
+${CNAT_CONFIG_BLOCK}
 "
 
 ${SCRIPTDIR}/../../yaml/overlays/dev/kustomize.sh up

--- a/test/scripts/cases.sh
+++ b/test/scripts/cases.sh
@@ -283,11 +283,50 @@ EOF
     POD=policy-client-samehost
     test_expect_fail "Calico egress deny same-node"  curl -s --max-time 3 http://${POLICY_SVC_IP}
 
+    POD=policy-client
+    test_expect_fail "Calico egress deny cross-node"  curl -s --max-time 3 http://${POLICY_SVC_IP}
+
     cat <<EOF | delete_and_wait_policy
 apiVersion: crd.projectcalico.org/v1
 kind: NetworkPolicy
 metadata:
   name: calico-egress-deny-all
+  namespace: policy
+EOF
+
+    # ---- Calico: Egress Allow TCP:80 to server pods (post-DNAT) ----
+    # Policy is enforced post-DNAT: destination is the backend pod IP, not the ClusterIP.
+    echo "--Calico egress allow TCP:80 (post-DNAT selector)--"
+    cat <<EOF | apply_and_wait_policy
+apiVersion: crd.projectcalico.org/v1
+kind: NetworkPolicy
+metadata:
+  name: calico-egress-allow-tcp80
+  namespace: policy
+spec:
+  selector: role == 'client'
+  egress:
+  - action: Allow
+    protocol: TCP
+    destination:
+      selector: role == 'server'
+      ports:
+        - 80
+EOF
+
+    POD=policy-client-samehost
+    test "Calico egress allow TCP:80 same-node"   curl -s --max-time 3 http://${POLICY_SVC_IP}
+    assert_test_output_contains "Welcome to nginx"
+
+    POD=policy-client
+    test "Calico egress allow TCP:80 cross-node"  curl -s --max-time 3 http://${POLICY_SVC_IP}
+    assert_test_output_contains "Welcome to nginx"
+
+    cat <<EOF | delete_and_wait_policy
+apiVersion: crd.projectcalico.org/v1
+kind: NetworkPolicy
+metadata:
+  name: calico-egress-allow-tcp80
   namespace: policy
 EOF
 

--- a/test/scripts/cases.sh
+++ b/test/scripts/cases.sh
@@ -361,6 +361,8 @@ metadata:
 EOF
 
     # ---- Kubernetes NetworkPolicy: Ingress Allow TCP:80 from clients ----
+    # One K8s pair to verify the K8s→Calico translation in the agent; VPP path is
+    # identical to Calico policies so we don't repeat egress/deny variants.
     echo "--K8s ingress allow TCP:80--"
     cat <<EOF | apply_and_wait_policy
 apiVersion: networking.k8s.io/v1
@@ -615,36 +617,6 @@ apiVersion: crd.projectcalico.org/v1
 kind: NetworkPolicy
 metadata:
   name: calico-ingress-allow-tcp80
-  namespace: nat-policy
-EOF
-
-    # ---- Group 1c: DNAT + K8s ingress deny all on server ----
-    echo "--DNAT + K8s ingress deny all on server--"
-    cat <<EOF | apply_and_wait_policy
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: k8s-ingress-deny-all
-  namespace: nat-policy
-spec:
-  podSelector:
-    matchLabels:
-      role: server
-  policyTypes:
-    - Ingress
-EOF
-
-    POD=np-client-samehost
-    test_expect_fail "DNAT + K8s ingress deny same-node"   curl -s --max-time 3 http://${NP_SVC_IP}
-
-    POD=np-client
-    test_expect_fail "DNAT + K8s ingress deny cross-node"  curl -s --max-time 3 http://${NP_SVC_IP}
-
-    cat <<EOF | delete_and_wait_policy
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: k8s-ingress-deny-all
   namespace: nat-policy
 EOF
 

--- a/test/scripts/cases.sh
+++ b/test/scripts/cases.sh
@@ -520,6 +520,362 @@ function test_nat_ipv4 ()
        assert_test_output_contains "1 received"
 }
 
+function test_nat_policy_ipv4 ()
+{
+    NS=nat-policy
+    SVC=np-service
+    NP_SVC_IP=$(getClusterIP)
+    SVC=np-udp-service
+    NP_UDP_SVC_IP=$(getClusterIP)
+    SVC=np-hairpin-service
+    NP_HAIRPIN_SVC_IP=$(getClusterIP)
+
+    # ---- Baseline: no policies, all DNAT traffic should pass ----
+    echo "--Baseline: no policies--"
+    POD=np-client-samehost
+    test "NP baseline DNAT same-node TCP"   curl -s --max-time 3 http://${NP_SVC_IP}
+    assert_test_output_contains "Welcome to nginx"
+
+    POD=np-client
+    test "NP baseline DNAT cross-node TCP"  curl -s --max-time 3 http://${NP_SVC_IP}
+    assert_test_output_contains "Welcome to nginx"
+
+    # ---- Group 1: DNAT + Calico ingress deny on server ----
+    echo "--DNAT + Calico ingress deny all on server--"
+    cat <<EOF | apply_and_wait_policy
+apiVersion: crd.projectcalico.org/v1
+kind: NetworkPolicy
+metadata:
+  name: calico-ingress-deny-all
+  namespace: nat-policy
+spec:
+  selector: role == 'server'
+  ingress: []
+EOF
+
+    POD=np-client-samehost
+    test_expect_fail "DNAT + Calico ingress deny same-node"   curl -s --max-time 3 http://${NP_SVC_IP}
+
+    POD=np-client
+    test_expect_fail "DNAT + Calico ingress deny cross-node"  curl -s --max-time 3 http://${NP_SVC_IP}
+
+    cat <<EOF | delete_and_wait_policy
+apiVersion: crd.projectcalico.org/v1
+kind: NetworkPolicy
+metadata:
+  name: calico-ingress-deny-all
+  namespace: nat-policy
+EOF
+
+    # ---- Group 1b: DNAT + Calico ingress allow TCP:80 from clients ----
+    echo "--DNAT + Calico ingress allow TCP:80 from clients--"
+    cat <<EOF | apply_and_wait_policy
+apiVersion: crd.projectcalico.org/v1
+kind: NetworkPolicy
+metadata:
+  name: calico-ingress-allow-tcp80
+  namespace: nat-policy
+spec:
+  selector: role == 'server'
+  ingress:
+  - action: Allow
+    protocol: TCP
+    source:
+      selector: role == 'client'
+    destination:
+      ports:
+        - 80
+EOF
+
+    POD=np-client-samehost
+    test "DNAT + Calico ingress allow TCP:80 same-node"   curl -s --max-time 3 http://${NP_SVC_IP}
+    assert_test_output_contains "Welcome to nginx"
+
+    POD=np-client
+    test "DNAT + Calico ingress allow TCP:80 cross-node"  curl -s --max-time 3 http://${NP_SVC_IP}
+    assert_test_output_contains "Welcome to nginx"
+
+    cat <<EOF | delete_and_wait_policy
+apiVersion: crd.projectcalico.org/v1
+kind: NetworkPolicy
+metadata:
+  name: calico-ingress-allow-tcp80
+  namespace: nat-policy
+EOF
+
+    # ---- Group 1c: DNAT + K8s ingress deny all on server ----
+    echo "--DNAT + K8s ingress deny all on server--"
+    cat <<EOF | apply_and_wait_policy
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: k8s-ingress-deny-all
+  namespace: nat-policy
+spec:
+  podSelector:
+    matchLabels:
+      role: server
+  policyTypes:
+    - Ingress
+EOF
+
+    POD=np-client-samehost
+    test_expect_fail "DNAT + K8s ingress deny same-node"   curl -s --max-time 3 http://${NP_SVC_IP}
+
+    POD=np-client
+    test_expect_fail "DNAT + K8s ingress deny cross-node"  curl -s --max-time 3 http://${NP_SVC_IP}
+
+    cat <<EOF | delete_and_wait_policy
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: k8s-ingress-deny-all
+  namespace: nat-policy
+EOF
+
+    # ---- Group 2: DNAT + Calico egress deny on client ----
+    echo "--DNAT + Calico egress deny all on client--"
+    cat <<EOF | apply_and_wait_policy
+apiVersion: crd.projectcalico.org/v1
+kind: NetworkPolicy
+metadata:
+  name: calico-egress-deny-all
+  namespace: nat-policy
+spec:
+  selector: role == 'client'
+  egress: []
+EOF
+
+    POD=np-client-samehost
+    test_expect_fail "DNAT + Calico egress deny same-node"   curl -s --max-time 3 http://${NP_SVC_IP}
+
+    POD=np-client
+    test_expect_fail "DNAT + Calico egress deny cross-node"  curl -s --max-time 3 http://${NP_SVC_IP}
+
+    cat <<EOF | delete_and_wait_policy
+apiVersion: crd.projectcalico.org/v1
+kind: NetworkPolicy
+metadata:
+  name: calico-egress-deny-all
+  namespace: nat-policy
+EOF
+
+    # ---- Group 2b: DNAT + Calico egress allow TCP:80 to server pods (post-DNAT) ----
+    # Policy is enforced post-DNAT: destination is the backend pod IP, not the ClusterIP.
+    echo "--DNAT + Calico egress allow TCP:80 (post-DNAT selector)--"
+    cat <<EOF | apply_and_wait_policy
+apiVersion: crd.projectcalico.org/v1
+kind: NetworkPolicy
+metadata:
+  name: calico-egress-allow-tcp80
+  namespace: nat-policy
+spec:
+  selector: role == 'client'
+  egress:
+  - action: Allow
+    protocol: TCP
+    destination:
+      selector: role == 'server'
+      ports:
+        - 80
+EOF
+
+    POD=np-client-samehost
+    test "DNAT + Calico egress allow TCP:80 same-node"   curl -s --max-time 3 http://${NP_SVC_IP}
+    assert_test_output_contains "Welcome to nginx"
+
+    POD=np-client
+    test "DNAT + Calico egress allow TCP:80 cross-node"  curl -s --max-time 3 http://${NP_SVC_IP}
+    assert_test_output_contains "Welcome to nginx"
+
+    cat <<EOF | delete_and_wait_policy
+apiVersion: crd.projectcalico.org/v1
+kind: NetworkPolicy
+metadata:
+  name: calico-egress-allow-tcp80
+  namespace: nat-policy
+EOF
+
+    # ---- Group 3: SNAT + Calico egress deny on client ----
+    echo "--SNAT + Calico egress deny all on client--"
+    cat <<EOF | apply_and_wait_policy
+apiVersion: crd.projectcalico.org/v1
+kind: NetworkPolicy
+metadata:
+  name: calico-egress-deny-all
+  namespace: nat-policy
+spec:
+  selector: role == 'client'
+  egress: []
+EOF
+
+    POD=np-client
+    test_expect_fail "SNAT + Calico egress deny external"   curl -s --max-time 3 http://1.1.1.1
+
+    cat <<EOF | delete_and_wait_policy
+apiVersion: crd.projectcalico.org/v1
+kind: NetworkPolicy
+metadata:
+  name: calico-egress-deny-all
+  namespace: nat-policy
+EOF
+
+    # ---- Group 3b: SNAT + Calico egress allow external ----
+    echo "--SNAT + Calico egress allow external--"
+    cat <<EOF | apply_and_wait_policy
+apiVersion: crd.projectcalico.org/v1
+kind: NetworkPolicy
+metadata:
+  name: calico-egress-allow-external
+  namespace: nat-policy
+spec:
+  selector: role == 'client'
+  egress:
+  - action: Allow
+    protocol: TCP
+    destination:
+      nets:
+        - 1.1.1.1/32
+      ports:
+        - 80
+EOF
+
+    POD=np-client
+    test "SNAT + Calico egress allow external"   curl -s --max-time 3 http://1.1.1.1
+    assert_test_output_contains_not "curl: ("
+
+    cat <<EOF | delete_and_wait_policy
+apiVersion: crd.projectcalico.org/v1
+kind: NetworkPolicy
+metadata:
+  name: calico-egress-allow-external
+  namespace: nat-policy
+EOF
+
+    # ---- Group 4: Hairpin NAT + Calico ingress deny on hairpin pod ----
+    echo "--Hairpin NAT + Calico ingress deny on pod--"
+    cat <<EOF | apply_and_wait_policy
+apiVersion: crd.projectcalico.org/v1
+kind: NetworkPolicy
+metadata:
+  name: calico-hairpin-ingress-deny
+  namespace: nat-policy
+spec:
+  selector: role == 'hairpin'
+  ingress: []
+EOF
+
+    POD=np-hairpin
+    test_expect_fail "Hairpin NAT + Calico ingress deny"   curl -s -o /dev/null -w "%{http_code}" --max-time 3 http://${NP_HAIRPIN_SVC_IP}:8080
+
+    cat <<EOF | delete_and_wait_policy
+apiVersion: crd.projectcalico.org/v1
+kind: NetworkPolicy
+metadata:
+  name: calico-hairpin-ingress-deny
+  namespace: nat-policy
+EOF
+
+    # ---- Group 4b: Hairpin NAT + Calico egress deny on hairpin pod ----
+    echo "--Hairpin NAT + Calico egress deny on pod--"
+    cat <<EOF | apply_and_wait_policy
+apiVersion: crd.projectcalico.org/v1
+kind: NetworkPolicy
+metadata:
+  name: calico-hairpin-egress-deny
+  namespace: nat-policy
+spec:
+  selector: role == 'hairpin'
+  egress: []
+EOF
+
+    POD=np-hairpin
+    test_expect_fail "Hairpin NAT + Calico egress deny"   curl -s -o /dev/null -w "%{http_code}" --max-time 3 http://${NP_HAIRPIN_SVC_IP}:8080
+
+    cat <<EOF | delete_and_wait_policy
+apiVersion: crd.projectcalico.org/v1
+kind: NetworkPolicy
+metadata:
+  name: calico-hairpin-egress-deny
+  namespace: nat-policy
+EOF
+
+    # ---- Group 5: ICMP + Calico ingress deny on server ----
+    echo "--ICMP + Calico ingress deny on server--"
+    POD=np-server
+    NP_SERVER_POD_IP=$(getPodIP)
+
+    cat <<EOF | apply_and_wait_policy
+apiVersion: crd.projectcalico.org/v1
+kind: NetworkPolicy
+metadata:
+  name: calico-icmp-ingress-deny
+  namespace: nat-policy
+spec:
+  selector: role == 'server'
+  ingress: []
+EOF
+
+    POD=np-client-samehost
+    test_expect_fail "ICMP + Calico ingress deny same-node"   ping -c 1 -W 3 ${NP_SERVER_POD_IP}
+
+    POD=np-client
+    test_expect_fail "ICMP + Calico ingress deny cross-node"  ping -c 1 -W 3 ${NP_SERVER_POD_IP}
+
+    cat <<EOF | delete_and_wait_policy
+apiVersion: crd.projectcalico.org/v1
+kind: NetworkPolicy
+metadata:
+  name: calico-icmp-ingress-deny
+  namespace: nat-policy
+EOF
+
+    # ---- Group 5b: ICMP + Calico ingress allow ICMP from clients ----
+    echo "--ICMP + Calico ingress allow ICMP from clients--"
+    cat <<EOF | apply_and_wait_policy
+apiVersion: crd.projectcalico.org/v1
+kind: NetworkPolicy
+metadata:
+  name: calico-icmp-ingress-allow
+  namespace: nat-policy
+spec:
+  selector: role == 'server'
+  ingress:
+  - action: Allow
+    protocol: ICMP
+    source:
+      selector: role == 'client'
+EOF
+
+    POD=np-client-samehost
+    test "ICMP + Calico ingress allow same-node"   ping -c 1 -W 3 ${NP_SERVER_POD_IP}
+    assert_test_output_contains "1 received"
+
+    POD=np-client
+    test "ICMP + Calico ingress allow cross-node"  ping -c 1 -W 3 ${NP_SERVER_POD_IP}
+    assert_test_output_contains "1 received"
+
+    cat <<EOF | delete_and_wait_policy
+apiVersion: crd.projectcalico.org/v1
+kind: NetworkPolicy
+metadata:
+  name: calico-icmp-ingress-allow
+  namespace: nat-policy
+EOF
+
+    # ---- Cleanup & verify connectivity restored ----
+    echo "--Cleanup: verify all policies removed--"
+    kubectl -n nat-policy delete networkpolicy --all --ignore-not-found
+    kubectl -n nat-policy delete networkpolicies.crd.projectcalico.org --all --ignore-not-found 2>/dev/null || true
+    sleep ${POLICY_PROPAGATION_DELAY:-3}
+
+    POD=np-client
+    SVC=np-service
+    NP_SVC_IP=$(getClusterIP)
+    test "NP post-cleanup DNAT cross-node" curl -s --max-time 3 http://${NP_SVC_IP}
+    assert_test_output_contains "Welcome to nginx"
+}
+
 if [ $# = 0 ]; then
 	echo "Usage"
 	for f in $(declare -F); do

--- a/test/scripts/cases.sh
+++ b/test/scripts/cases.sh
@@ -510,6 +510,21 @@ function test_nat_ipv4 ()
        test "Hairpin NAT (pod via service to itself)"  curl -s -o /dev/null -w "%{http_code}" --max-time 3 http://${NAT_HAIRPIN_SVC_IP}:8080
        assert_test_output_contains "200"
 
+       echo "--NodePort DNAT: pod -> nodeIP:nodePort -> nginx--"
+       SVC=nat-nodeport-service
+       PROTO=TCP
+       NAT_NODEPORT=$(getServiceNodePort)
+       NAT_SERVER_NODE=$(kubectl get pods -n nat -l app=nat-server -o jsonpath='{.items[0].spec.nodeName}')
+       NAT_SERVER_NODE_IP=$(getNodeIP ${NAT_SERVER_NODE})
+
+       POD=nat-client
+       test "NodePort DNAT cross-node"               curl -s --max-time 3 http://${NAT_SERVER_NODE_IP}:${NAT_NODEPORT}
+       assert_test_output_contains "Welcome to nginx"
+
+       POD=nat-client-samehost
+       test "NodePort DNAT same-node"                curl -s --max-time 3 http://${NAT_SERVER_NODE_IP}:${NAT_NODEPORT}
+       assert_test_output_contains "Welcome to nginx"
+
        echo "--SNAT: pod -> outside cluster--"
        POD=nat-client
        test "SNAT external connectivity"             curl -s --max-time 3 http://checkip.amazonaws.com

--- a/test/scripts/cases.sh
+++ b/test/scripts/cases.sh
@@ -452,7 +452,15 @@ function test_nat_ipv4 ()
        test "DNAT cross-node via ClusterIP (UDP)"   sh -c "echo hello | nc -u -w2 ${NAT_UDP_SVC_IP} 9999"
        assert_test_output_contains "hello"
 
+       echo "--Hairpin NAT: pod -> service -> itself--"
+       POD=nat-hairpin
+       SVC=nat-hairpin-service
+       NAT_HAIRPIN_SVC_IP=$(getClusterIP)
+       test "Hairpin NAT (pod via service to itself)"  curl -s -o /dev/null -w "%{http_code}" --max-time 3 http://${NAT_HAIRPIN_SVC_IP}:8080
+       assert_test_output_contains "200"
+
        echo "--SNAT: pod -> outside cluster--"
+       POD=nat-client
        test "SNAT external connectivity"             curl -s --max-time 3 http://checkip.amazonaws.com
        assert_test_output_contains_not "curl: ("
 }

--- a/test/scripts/cases.sh
+++ b/test/scripts/cases.sh
@@ -863,6 +863,131 @@ EOF
     assert_test_output_contains "Welcome to nginx"
 }
 
+function test_hep_ipv4 ()
+{
+    NS=hep
+
+    HEP_NODE=$(kubectl get pods -n hep hep-host-listener -o jsonpath='{.spec.nodeName}')
+    HEP_NODE_IP=$(getNodeIP ${HEP_NODE})
+
+    SVC=hep-nodeport-service
+    PROTO=TCP
+    HEP_NODEPORT=$(getServiceNodePort)
+
+    POD=hep-client
+
+    # ---- Test 1: Terminated traffic ----
+    # Empty HEP activates the tap policy plane with default-deny on all non-failsafe terminated traffic.
+
+    echo "--Terminated baseline: pod can reach host port 7777--"
+    test "Terminated baseline (host reachable)"    curl -s --max-time 3 http://${HEP_NODE_IP}:7777
+    assert_test_output_contains "hep-listener"
+
+    echo "--Empty HEP: terminated traffic blocked--"
+    cat <<EOF | kubectl apply -f -
+apiVersion: projectcalico.org/v3
+kind: HostEndpoint
+metadata:
+  name: hep-wildcard
+  labels:
+    host-endpoint: enabled
+spec:
+  node: ${HEP_NODE}
+  interfaceName: "*"
+  expectedIPs:
+    - "${HEP_NODE_IP}"
+EOF
+    sleep ${POLICY_PROPAGATION_DELAY:-3}
+
+    test_expect_fail "Terminated blocked by empty HEP"    curl -s --max-time 3 http://${HEP_NODE_IP}:7777
+
+    # ---- Test 1b: HEP + explicit allow policy restores terminated traffic ----
+    # Add an allow rule to the still-active HEP. Proves user-defined tap policies
+    # are evaluated — if policies were silently dropped, the default-deny would still block.
+    echo "--HEP + explicit allow TCP:7777: terminated traffic allowed--"
+    cat <<EOF | kubectl apply -f -
+apiVersion: projectcalico.org/v3
+kind: GlobalNetworkPolicy
+metadata:
+  name: hep-allow-terminated-tcp7777
+spec:
+  selector: host-endpoint == 'enabled'
+  applyOnForward: false
+  types:
+    - Ingress
+  ingress:
+    - action: Allow
+      protocol: TCP
+      destination:
+        ports:
+          - 7777
+EOF
+    sleep ${POLICY_PROPAGATION_DELAY:-3}
+
+    test "Terminated allowed by explicit policy"    curl -s --max-time 3 http://${HEP_NODE_IP}:7777
+    assert_test_output_contains "hep-listener"
+
+    kubectl delete globalnetworkpolicy hep-allow-terminated-tcp7777 --ignore-not-found
+    kubectl delete hostendpoint hep-wildcard --ignore-not-found
+    sleep ${POLICY_PROPAGATION_DELAY:-3}
+
+    test "Terminated restored after HEP delete"    curl -s --max-time 3 http://${HEP_NODE_IP}:7777
+    assert_test_output_contains "hep-listener"
+
+    # ---- Test 2: Forwarded traffic (applyOnForward) ----
+    # HEP + GlobalNetworkPolicy with applyOnForward=true enforces on the uplink
+    # (ForwardTiers, invertRxTx=1) — a distinct VPP path from the tap policy plane.
+    # The policy denies the nodePort itself (traffic arrives on the uplink before DNAT,
+    # so the destination port seen is the nodePort, not the backend port 80).
+
+    echo "--Forward baseline: NodePort reachable--"
+    test "Forward baseline (NodePort works)"    curl -s --max-time 3 http://${HEP_NODE_IP}:${HEP_NODEPORT}
+    assert_test_output_contains "Welcome to nginx"
+
+    echo "--HEP + applyOnForward policy: forwarded traffic blocked--"
+    # Policy is evaluated post-DNAT: the destination port seen by the forward policy
+    # is the backend port (80), not the nodePort. See docs/policies/host_endpoints.md.
+    cat <<EOF | kubectl apply -f -
+apiVersion: projectcalico.org/v3
+kind: HostEndpoint
+metadata:
+  name: hep-wildcard
+  labels:
+    host-endpoint: enabled
+spec:
+  node: ${HEP_NODE}
+  interfaceName: "*"
+  expectedIPs:
+    - "${HEP_NODE_IP}"
+---
+apiVersion: projectcalico.org/v3
+kind: GlobalNetworkPolicy
+metadata:
+  name: hep-deny-forward-tcp80
+spec:
+  selector: host-endpoint == 'enabled'
+  applyOnForward: true
+  types:
+    - Ingress
+  ingress:
+    - action: Deny
+      protocol: TCP
+      destination:
+        ports:
+          - 80
+EOF
+    sleep ${POLICY_PROPAGATION_DELAY:-3}
+
+    test_expect_fail "Forward blocked by applyOnForward policy"    curl -s --max-time 3 http://${HEP_NODE_IP}:${HEP_NODEPORT}
+
+    kubectl delete globalnetworkpolicy hep-deny-forward-tcp80 --ignore-not-found
+    kubectl delete hostendpoint hep-wildcard --ignore-not-found
+    sleep ${POLICY_PROPAGATION_DELAY:-3}
+
+    test "Forward restored after policy+HEP delete"    curl -s --max-time 3 http://${HEP_NODE_IP}:${HEP_NODEPORT}
+    assert_test_output_contains "Welcome to nginx"
+}
+
 if [ $# = 0 ]; then
 	echo "Usage"
 	for f in $(declare -F); do

--- a/test/scripts/cases.sh
+++ b/test/scripts/cases.sh
@@ -452,6 +452,18 @@ function test_nat_ipv4 ()
        test "DNAT cross-node via ClusterIP (UDP)"   sh -c "echo hello | nc -u -w2 ${NAT_UDP_SVC_IP} 9999"
        assert_test_output_contains "hello"
 
+       echo "--ICMP same-node: client -> pod IP--"
+       POD=nat-server
+       NAT_SERVER_POD_IP=$(getPodIP)
+       POD=nat-client-samehost
+       test "ICMP same-node (ping pod)"             ping -c 1 -W 3 ${NAT_SERVER_POD_IP}
+       assert_test_output_contains "1 received"
+
+       echo "--ICMP cross-node: client -> pod IP--"
+       POD=nat-client
+       test "ICMP cross-node (ping pod)"            ping -c 1 -W 3 ${NAT_SERVER_POD_IP}
+       assert_test_output_contains "1 received"
+
        echo "--Hairpin NAT: pod -> service -> itself--"
        POD=nat-hairpin
        SVC=nat-hairpin-service
@@ -463,6 +475,10 @@ function test_nat_ipv4 ()
        POD=nat-client
        test "SNAT external connectivity"             curl -s --max-time 3 http://checkip.amazonaws.com
        assert_test_output_contains_not "curl: ("
+
+       echo "--ICMP SNAT: pod -> outside cluster--"
+       test "ICMP SNAT external connectivity"        ping -c 1 -W 3 8.8.8.8
+       assert_test_output_contains "1 received"
 }
 
 if [ $# = 0 ]; then

--- a/test/yaml/nat-policy/test.yaml
+++ b/test/yaml/nat-policy/test.yaml
@@ -1,0 +1,164 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: nat-policy
+  name: np-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: np-server
+  template:
+    metadata:
+      labels:
+        app: np-server
+        role: server
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:alpine
+        ports:
+        - containerPort: 80
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 80
+          initialDelaySeconds: 3
+          periodSeconds: 3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: nat-policy
+  name: np-service
+spec:
+  selector:
+    app: np-server
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+---
+# UDP echo server for UDP DNAT+policy tests
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: nat-policy
+  name: np-udp-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: np-udp-server
+  template:
+    metadata:
+      labels:
+        app: np-udp-server
+        role: server
+    spec:
+      containers:
+      - name: udp-echo
+        image: nicolaka/netshoot
+        command: ["/bin/sh", "-c"]
+        args:
+        - |
+          python3 -c "
+          import socket
+          s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+          s.bind(('', 9999))
+          while True:
+              data, addr = s.recvfrom(1024)
+              s.sendto(data, addr)
+          "
+        ports:
+        - containerPort: 9999
+          protocol: UDP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: nat-policy
+  name: np-udp-service
+spec:
+  selector:
+    app: np-udp-server
+  ports:
+    - protocol: UDP
+      port: 9999
+      targetPort: 9999
+---
+# Client on the same node as the server
+apiVersion: v1
+kind: Pod
+metadata:
+  name: np-client-samehost
+  namespace: nat-policy
+  labels:
+    role: client
+spec:
+  affinity:
+    podAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              app: np-server
+          topologyKey: kubernetes.io/hostname
+  containers:
+  - name: client
+    image: nicolaka/netshoot
+    command: ["sleep", "3600"]
+---
+# Client on a different node from the server
+apiVersion: v1
+kind: Pod
+metadata:
+  name: np-client
+  namespace: nat-policy
+  labels:
+    role: client
+spec:
+
+  containers:
+  - name: client
+    image: nicolaka/netshoot
+    command: ["sleep", "3600"]
+---
+# Pod that acts as both client and server for hairpin NAT + policy tests
+apiVersion: v1
+kind: Pod
+metadata:
+  name: np-hairpin
+  namespace: nat-policy
+  labels:
+    app: np-hairpin
+    role: hairpin
+spec:
+  containers:
+  - name: server
+    image: nicolaka/netshoot
+    command: ["/bin/sh", "-c"]
+    args:
+    - python3 -m http.server 8080
+    ports:
+    - containerPort: 8080
+    readinessProbe:
+      tcpSocket:
+        port: 8080
+      initialDelaySeconds: 3
+      periodSeconds: 3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: nat-policy
+  name: np-hairpin-service
+spec:
+  selector:
+    app: np-hairpin
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080

--- a/test/yaml/nat/test.yaml
+++ b/test/yaml/nat/test.yaml
@@ -127,3 +127,39 @@ spec:
   - name: client
     image: nicolaka/netshoot
     command: ["sleep", "3600"]
+---
+# Pod that acts as both client and server for hairpin NAT testing
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nat-hairpin
+  namespace: nat
+  labels:
+    app: nat-hairpin
+spec:
+  containers:
+  - name: server
+    image: nicolaka/netshoot
+    command: ["/bin/sh", "-c"]
+    args:
+    - python3 -m http.server 8080
+    ports:
+    - containerPort: 8080
+    readinessProbe:
+      tcpSocket:
+        port: 8080
+      initialDelaySeconds: 3
+      periodSeconds: 3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: nat
+  name: nat-hairpin-service
+spec:
+  selector:
+    app: nat-hairpin
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080

--- a/test/yaml/nat/test.yaml
+++ b/test/yaml/nat/test.yaml
@@ -163,3 +163,18 @@ spec:
     - protocol: TCP
       port: 8080
       targetPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: nat
+  name: nat-nodeport-service
+spec:
+  type: NodePort
+  selector:
+    app: nat-server
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+      name: http

--- a/test/yaml/trex/run-cnat-drain-test.sh
+++ b/test/yaml/trex/run-cnat-drain-test.sh
@@ -1,0 +1,264 @@
+#!/bin/bash
+# run-cnat-drain-test.sh
+#
+# Automates the trex cnat session drain benchmark on an existing cluster:
+#   1. Deploy trex pod
+#   2. Configure MAC from VPP memif
+#   3. Start trex daemon
+#   4. Generate traffic profile (trex.py) from trex_template.py
+#   5. Run traffic at full speed
+#   6. Poll cnat sessions, record peak
+#   7. Stop traffic, measure drain time via cnat scanner
+#
+# Configurable env vars:
+#   DST_ADDRESS            Destination IP for traffic (default: 1.2.3.4)
+#   SRC_ADDRESS            Source IP range start (default: 12.0.0.0)
+#   SRC_ADDRESS2           Source IP range end   (default: 12.0.16.0)
+#   DST_PORT               Destination UDP port (default: 4444)
+#   SRC_PORT               Source port range start (default: 4444)
+#   SRC_PORT2              Source port range end   (default: 4444)
+#   TRAFFIC_DURATION       Seconds to run traffic before stopping (default: 60)
+#   POLL_INTERVAL          Seconds between session count polls (default: 2)
+#   LIMIT_FLOWS            Max concurrent flows generated (default: 10000000)
+#   SESSION_DRAIN_TIMEOUT  Max seconds to wait for drain to complete (default: 300)
+#   TREX_NAMESPACE         Kubernetes namespace for trex pod (default: trex)
+#   VPP_NAMESPACE          Kubernetes namespace for calico-vpp (default: calico-vpp-dataplane)
+
+set -euo pipefail
+
+SCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
+DST_ADDRESS=${DST_ADDRESS:-1.2.3.4}
+SRC_ADDRESS=${SRC_ADDRESS:-12.0.0.0}
+SRC_ADDRESS2=${SRC_ADDRESS2:-12.16.0.0}
+DST_PORT=${DST_PORT:-4444}
+SRC_PORT=${SRC_PORT:-4444}
+SRC_PORT2=${SRC_PORT2:-4444}
+TRAFFIC_DURATION=${TRAFFIC_DURATION:-30}
+POLL_INTERVAL=${POLL_INTERVAL:-2}
+LIMIT_FLOWS=${LIMIT_FLOWS:-10000000}
+SESSION_DRAIN_TIMEOUT=${SESSION_DRAIN_TIMEOUT:-300}
+TREX_NAMESPACE=${TREX_NAMESPACE:-trex}
+VPP_NAMESPACE=${VPP_NAMESPACE:-calico-vpp-dataplane}
+
+TREX_POD=trex
+TREX_PYTHONPATH=/usr/local/share/trex-interactive
+TREX_EXT_LIBS=/usr/local/share/trex-external_libs
+
+function green () { printf "\e[0;32m%s\e[0m\n" "$1"; }
+function blue  () { printf "\e[0;34m%s\e[0m\n" "$1"; }
+function red   () { printf "\e[0;31m%s\e[0m\n" "$1"; }
+
+# Pipe trex console commands (via stdin) into the interactive console inside the pod.
+trex_console () {
+    kubectl exec -i -n "$TREX_NAMESPACE" "$TREX_POD" -- \
+        env PYTHONPATH="${TREX_PYTHONPATH}" TREX_EXT_LIBS="${TREX_EXT_LIBS}" \
+        python3 -m trex.console.trex_console
+}
+
+# Wait until the trex daemon responds on port 4501.
+wait_for_trex_daemon () {
+    local output
+    for i in $(seq 1 15); do
+        output=$(echo "stats" | trex_console 2>&1)
+        if ! echo "$output" | grep -q 'Failed to get server response'; then
+            return 0
+        fi
+        sleep 2
+    done
+    red "trex daemon did not respond after 30s — check /tmp/trex-daemon.log"
+    return 1
+}
+
+# ---------------------------------------------------------------------------
+# Step 1: Deploy trex pod
+# ---------------------------------------------------------------------------
+blue "[1/9] Deploying trex pod in namespace '$TREX_NAMESPACE'..."
+kubectl create namespace "$TREX_NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+kubectl apply -f "$SCRIPTDIR/test.yaml"
+kubectl -n "$TREX_NAMESPACE" wait --for=condition=Ready pod/"$TREX_POD" --timeout=120s
+green "  trex pod is Ready"
+
+# ---------------------------------------------------------------------------
+# Step 2: Find VPP pod on the same node
+# ---------------------------------------------------------------------------
+blue "[2/9] Locating VPP pod on same node as trex..."
+NODE=$(kubectl -n "$TREX_NAMESPACE" get pod "$TREX_POD" -o jsonpath='{.spec.nodeName}')
+VPP_POD=$(kubectl -n "$VPP_NAMESPACE" get pods \
+    --field-selector="spec.nodeName=${NODE}" \
+    -o jsonpath='{.items[0].metadata.name}')
+
+if [[ -z "$VPP_POD" ]]; then
+    red "No calico-vpp-node pod found on node '$NODE'"
+    exit 1
+fi
+green "  Node: $NODE"
+green "  VPP pod: $VPP_POD"
+
+# ---------------------------------------------------------------------------
+# Step 3: Get memif MAC from VPP and configure trex-start
+# ---------------------------------------------------------------------------
+blue "[3/9] Getting memif MAC from VPP..."
+MAC_ADDR=$(kubectl -n "$VPP_NAMESPACE" exec "$VPP_POD" -c vpp -- \
+    vppctl sh hard 2>/dev/null \
+    | grep -A3 memi \
+    | grep Ether \
+    | awk '{print $3}')
+
+if [[ -z "$MAC_ADDR" ]]; then
+    red "Could not read memif MAC from VPP — is the trex pod's memif attached yet?"
+    exit 1
+fi
+green "  Memif MAC: $MAC_ADDR"
+
+kubectl exec -n "$TREX_NAMESPACE" "$TREX_POD" -- \
+    bash -c "sed -i 's/dest_mac: .*/dest_mac: ${MAC_ADDR}/g' /usr/local/bin/trex-start"
+green "  Patched dest_mac in trex-start"
+
+# ---------------------------------------------------------------------------
+# Step 4: Start trex daemon in background
+# ---------------------------------------------------------------------------
+blue "[4/9] Starting trex daemon (trex -i)..."
+# Keep the kubectl exec session open (trex-start is the foreground process of the exec).
+# Backgrounding the exec itself avoids the daemon being killed when the shell exits.
+kubectl exec -n "$TREX_NAMESPACE" "$TREX_POD" -- \
+    bash /usr/local/bin/trex-start > /tmp/trex-daemon.log 2>&1 &
+TREX_DAEMON_PID=$!
+wait_for_trex_daemon
+green "  trex daemon ready (pid $TREX_DAEMON_PID)"
+
+# ---------------------------------------------------------------------------
+# Step 5: Generate traffic profile /trex-scripts/trex.py from trex_template.py
+# ---------------------------------------------------------------------------
+blue "[5/9] Generating traffic profile /trex-scripts/trex.py..."
+kubectl exec -n "$TREX_NAMESPACE" "$TREX_POD" -- \
+    bash -c "export DST_ADDRESS=${DST_ADDRESS} SRC_ADDRESS=${SRC_ADDRESS} SRC_ADDRESS2=${SRC_ADDRESS2} \
+                    DST_PORT=${DST_PORT} SRC_PORT=${SRC_PORT} SRC_PORT2=${SRC_PORT2} && \
+             envsubst < /trex-scripts/trex_template.py > /trex-scripts/trex.py"
+green "  Profile generated"
+
+get_session_count () {
+    kubectl exec -n "$VPP_NAMESPACE" "$VPP_POD" -c vpp -- \
+        vppctl show cnat session 2>/dev/null \
+        | grep -i "active elements" \
+        | awk '{print $1}' \
+        || echo 0
+}
+# Capture baseline before traffic so drain completion is relative, not absolute.
+baseline_sessions=$(get_session_count)
+baseline_sessions=${baseline_sessions:-0}
+# Drain is considered complete when sessions return within 10% of baseline + 50
+# (tolerates natural runtime fluctuation and unrelated sessions).
+DRAIN_THRESHOLD=$(( baseline_sessions + baseline_sessions / 10 + 50 ))
+green "  Baseline sessions: ${baseline_sessions}  (drain threshold: ≤${DRAIN_THRESHOLD})"
+
+# ---------------------------------------------------------------------------
+# Step 6: Start traffic
+# ---------------------------------------------------------------------------
+blue "[6/9] Starting traffic"
+echo "start -f /trex-scripts/trex.py -p 0 -m 10mbps" | trex_console
+green "  Traffic started"
+
+# ---------------------------------------------------------------------------
+# Step 7: Poll cnat sessions for TRAFFIC_DURATION seconds, track peak
+# ---------------------------------------------------------------------------
+blue "[7/9] Polling cnat sessions for ${TRAFFIC_DURATION}s (poll every ${POLL_INTERVAL}s)..."
+
+max_sessions=0
+elapsed=0
+#PEAK_VERBOSE=""
+
+while (( elapsed < TRAFFIC_DURATION )); do
+    count=$(get_session_count)
+    count=${count:-0}
+    printf "  t=+%ds  cnat sessions: %d\n" "$elapsed" "$count"
+    if (( count > max_sessions )); then
+        max_sessions=$count
+        #PEAK_VERBOSE=$(kubectl exec -n "$VPP_NAMESPACE" "$VPP_POD" -c vpp -- \
+        #    vppctl show cnat session verbose 2>/dev/null || true)
+    fi
+    sleep "$POLL_INTERVAL"
+    (( elapsed += POLL_INTERVAL ))
+done
+
+green "  Traffic phase done. Peak sessions observed: $max_sessions"
+
+# ---------------------------------------------------------------------------
+# Step 8: Stop traffic
+# ---------------------------------------------------------------------------
+blue "[8/9] Stopping traffic (stop -a)..."
+echo "stop -a" | trex_console
+green "  Traffic stopped"
+
+DRAIN_START=$(date +%s)
+DRAIN_START_HUMAN=$(date -Iseconds)
+
+# ---------------------------------------------------------------------------
+# Step 9: Poll drain until sessions return to near-baseline or timeout
+# ---------------------------------------------------------------------------
+blue "[9/9] Waiting for cnat scanner to drain sessions (timeout: ${SESSION_DRAIN_TIMEOUT}s)..."
+blue "  Waiting 30s for UDP session lifetime before polling..."
+sleep 30
+
+drain_elapsed=30
+prev_count=-1
+
+while (( drain_elapsed < SESSION_DRAIN_TIMEOUT )); do
+    count=$(get_session_count)
+    count=${count:-0}
+    if (( count != prev_count )); then
+        printf "  drain t=+%ds  cnat sessions: %d  (threshold: %d)\n" \
+            "$drain_elapsed" "$count" "$DRAIN_THRESHOLD"
+        prev_count=$count
+    fi
+    if (( count <= DRAIN_THRESHOLD )); then
+        break
+    fi
+    sleep "$POLL_INTERVAL"
+    (( drain_elapsed += POLL_INTERVAL ))
+done
+
+DRAIN_END=$(date +%s)
+DRAIN_DURATION=$(( DRAIN_END - DRAIN_START ))
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+echo ""
+green "============================================================"
+green "  CNAT DRAIN TEST RESULTS"
+green "============================================================"
+printf "  Destination              : %s:%s\n" "$DST_ADDRESS" "$DST_PORT"
+printf "  Source range             : %s..%s  ports %s..%s\n" "$SRC_ADDRESS" "$SRC_ADDRESS2" "$SRC_PORT" "$SRC_PORT2"
+printf "  Limit flows              : %d\n"    "$LIMIT_FLOWS"
+printf "  Traffic duration         : %ds\n"   "$TRAFFIC_DURATION"
+printf "  Poll interval            : %ds\n"   "$POLL_INTERVAL"
+printf "  Baseline cnat sessions   : %d\n"    "$baseline_sessions"
+printf "  Peak cnat sessions       : %d\n"    "$max_sessions"
+printf "  Drain threshold          : ≤%d\n"   "$DRAIN_THRESHOLD"
+printf "  Sessions at drain end    : %d\n"    "$count"
+printf "  Drain started at         : %s\n"    "$DRAIN_START_HUMAN"
+if (( drain_elapsed >= SESSION_DRAIN_TIMEOUT && count > DRAIN_THRESHOLD )); then
+    red   "  Drain result             : TIMEOUT (${SESSION_DRAIN_TIMEOUT}s), ${count} sessions remain"
+else
+    printf "  Sessions drained in      : %ds\n"   "$DRAIN_DURATION"
+    if (( DRAIN_DURATION > 30 && max_sessions > 0 )); then
+        printf "  Drain rate               : ~%d sessions/s\n" "$(( max_sessions / (DRAIN_DURATION - 30) ))"
+    fi
+    green "  Drain result             : COMPLETE"
+fi
+green "============================================================"
+
+#if [[ -n "$PEAK_VERBOSE" ]]; then
+#    echo ""
+#    blue "--- 'show cnat session verbose' snapshot at peak ---"
+#    echo "$PEAK_VERBOSE"
+#fi
+
+# ---------------------------------------------------------------------------
+# Cleanup (commented out — uncomment to tear down after test)
+# ---------------------------------------------------------------------------
+blue "Cleaning up..."
+kubectl delete -f "$SCRIPTDIR/test.yaml" --ignore-not-found
+kubectl delete namespace "$TREX_NAMESPACE" --ignore-not-found
+


### PR DESCRIPTION
Since we have backported all IPv6/DHCPv6 and NPOL changes in `release/v3.31.0`, perhaps we should backport the tests as well like we did in `release/v3.29.0`.