### PR TITLE
kind: use fixed v0.30 version target k8s v1.34

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -67,3 +67,6 @@ DOCKER_BUILD_ARGS += --build-arg GIT_COMMIT="$(shell git describe --always --abb
 ifeq (${NO_CACHE},true)
 	DOCKER_BUILD_ARGS += --no-cache
 endif
+
+KIND_VERSION ?= v0.30.0
+KIND ?= go run sigs.k8s.io/kind@$(KIND_VERSION)

--- a/test/kind/Makefile
+++ b/test/kind/Makefile
@@ -9,9 +9,10 @@ TIGERA_OPERATOR_VERSION ?= v3.32.0
 new-cluster:
 	@CPU_PINNING=$(CPU_PINNING) \
 		CLUSTER_NAME=$(CLUSTER_NAME) \
+		KIND="$(KIND)" \
 		./new_cluster.sh
 	mkdir -p $(HOME)/.kube
-	kind get kubeconfig --name $(CLUSTER_NAME) > $(HOME)/.kube/config
+	$(KIND) get kubeconfig --name $(CLUSTER_NAME) > $(HOME)/.kube/config
 
 .PHONY: install-cni
 install-cni:
@@ -24,7 +25,7 @@ install-cni:
 
 .PHONY: rm-cluster
 rm-cluster:
-	kind delete cluster --name $(CLUSTER_NAME)
+	$(KIND) delete cluster --name $(CLUSTER_NAME)
 
 .PHONY: dev
 dev:

--- a/test/kind/README.md
+++ b/test/kind/README.md
@@ -1,0 +1,27 @@
+# Testing with kind
+
+## Calico Kubernetes versions matrix
+
+The following table represent the compatibility matrix between:
+
+- Calico version `3.X`
+- k8s versions `1.X`
+- kind versions `0.X`
+
+| k8s  | 3.32 | 3.31 | 3.30 | 3.29 | 3.28 | 3.27 | 3.26 | Kind      |
+| :--: | :--: | :--: | :--: | :--: | :--: | :--: | :--: | :-------: |
+| 1.36 |  X   |  X   |  X   |      |      |      |      | 0.32?     |
+| 1.35 |  X   |  X   |  X   |      |      |      |      | 0.31      |
+| 1.34 |  X   |  X   |  X   |      |      |      |      | 0.30      |
+| 1.33 |      |  X   |  X   |      |      |      |      | 0.29      |
+| 1.32 |      |  X   |  X   |  X   |      |      |      | 0.26-0.28 |
+| 1.31 |      |      |  X   |  X   |      |      |      | 0.24-0.25 |
+| 1.30 |      |      |  X   |  X   |   X  |      |      | 0.23      |
+| 1.29 |      |      |  X   |  X   |   X  |  X   |      | 0.21-0.22 |
+| 1.28 |      |      |      |      |   X  |  X   |  X   | 0.20      |
+| 1.27 |      |      |      |      |   X  |  X   |  X   | 0.19      |
+| 1.26 |      |      |      |      |      |      |  X   | 0.18      |
+| 1.25 |      |      |      |      |      |      |  X   | 0.16-0.17 |
+| 1.24 |      |      |      |      |      |      |  X   | 0.15      |
+
+[Source](https://docs.tigera.io/calico/latest/getting-started/kubernetes/requirements#kubernetes-requirements)

--- a/test/kind/install_calico_vpp.sh
+++ b/test/kind/install_calico_vpp.sh
@@ -1,8 +1,15 @@
 #!/bin/bash
 
+VERBOSE=${VERBOSE:-false}
+WAIT=${WAIT:-false}
+
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-kubectl create -f https://raw.githubusercontent.com/projectcalico/calico/${TIGERA_OPERATOR_VERSION}/manifests/tigera-operator.yaml
+if [ "${VERBOSE}" == "true" ]; then
+set -x
+fi
+
+kubectl create -f "https://raw.githubusercontent.com/projectcalico/calico/${TIGERA_OPERATOR_VERSION}/manifests/tigera-operator.yaml"
 
 while [[ "$(kubectl api-resources --api-group=operator.tigera.io | grep Installation)" == "" ]]; do echo "waiting for Installation kubectl resource"; sleep 2; done
 
@@ -88,4 +95,8 @@ plugins {
 ${CNAT_CONFIG_BLOCK}
 "
 
-${SCRIPTDIR}/../../yaml/overlays/dev/kustomize.sh up
+"${SCRIPTDIR}/../../yaml/overlays/dev/kustomize.sh" up
+
+if [ "${WAIT}" == "true" ]; then
+kubectl wait --for=condition=Ready nodes --all --timeout=600s
+fi

--- a/test/kind/new_cluster.sh
+++ b/test/kind/new_cluster.sh
@@ -1,21 +1,36 @@
 #!/bin/bash
 set -o errexit
 
-if [[ $(kind get clusters | grep -E '^'${CLUSTER_NAME}'$') == "${CLUSTER_NAME}" ]]; then
-	echo "Cluster kind already exists"
-	exit 0
-fi
-
 N_KIND_CONTROL_PLANES=${N_KIND_CONTROL_PLANES:-1}
 N_KIND_WORKERS=${N_KIND_WORKERS:-2}
 IPFAMILY=${IPFAMILY:-dual}
 
+KIND_REGISTRY_NAME=${KIND_REGISTRY_NAME:-kind-registry}
+KIND_REGISTRY_PORT=${KIND_REGISTRY_PORT:-5000}
+
+CPU_PINNING=${CPU_PINNING:-false}
+FIRST_CPU=${FIRST_CPU:-3}
+
+VERBOSE=${VERBOSE:-false}
+NO_TAINT=${NO_TAINT:-false}
+
+if [ "${VERBOSE}" == "true" ]; then
+set -x
+cat /proc/sys/fs/inotify/max_user_instances
+cat /proc/sys/fs/inotify/max_user_watches
+cat /proc/sys/vm/nr_hugepages
+go version
+fi
+
+if [[ $(${KIND} get clusters | grep -E '^'"${CLUSTER_NAME}"'$') == "${CLUSTER_NAME}" ]]; then
+	echo "Cluster kind already exists"
+	exit 0
+fi
+
 # create registry container unless it already exists
-reg_name='kind-registry'
-reg_port='5000'
-if [ "$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)" != 'true' ]; then
+if [ "$(docker inspect -f '{{.State.Running}}' "${KIND_REGISTRY_NAME}" 2>/dev/null || true)" != 'true' ]; then
   docker run \
-    -d --restart=always -p "127.0.0.1:${reg_port}:5000" --name "${reg_name}" \
+    -d --restart=always -p "127.0.0.1:${KIND_REGISTRY_PORT}:5000" --name "${KIND_REGISTRY_NAME}" \
     registry:2
 fi
 
@@ -26,14 +41,14 @@ apiVersion: kind.x-k8s.io/v1alpha4
 name: ${CLUSTER_NAME}
 containerdConfigPatches:
 - |-
-  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${reg_port}"]
-    endpoint = ["http://${reg_name}:5000"]
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${KIND_REGISTRY_PORT}"]
+    endpoint = ["http://${KIND_REGISTRY_NAME}:5000"]
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
-    endpoint = ["http://${reg_name}:5000"]
+    endpoint = ["http://${KIND_REGISTRY_NAME}:5000"]
 EOF
 )
 
-if [ "$IPFAMILY" == "v4" ]; then
+if [ "${IPFAMILY}" == "v4" ]; then
 config=$(cat <<EOF
 $config
 networking:
@@ -44,7 +59,7 @@ networking:
 nodes:
 EOF
 )
-elif [ "$IPFAMILY" == "v6" ]; then
+elif [ "${IPFAMILY}" == "v6" ]; then
 config=$(cat <<EOF
 $config
 networking:
@@ -68,19 +83,7 @@ EOF
 )
 fi
 
-
-if [ "$N_KIND_CONTROL_PLANES" == "" ]; then
-	echo "Please Set N_KIND_CONTROL_PLANES"
-	exit 1
-fi
-
-if [ "$N_KIND_WORKERS" == "" ]; then
-	echo "Please Set N_KIND_WORKERS"
-	exit 1
-fi
-
-FIRST_CPU=3
-for ((i=1; i<=$N_KIND_CONTROL_PLANES; i++)); do \
+for ((i=1; i<=N_KIND_CONTROL_PLANES; i++)); do \
 config=$(cat <<EOF
 $config
 - role: control-plane
@@ -89,17 +92,17 @@ $config
       containerPath: $HOME
 EOF
 );
-if [ "$CPU_PINNING" == "true" ]; then
+if [ "${CPU_PINNING}" == "true" ]; then
 config=$(cat <<EOF
 $config
-  cpuSet: "$(($N_KIND_WORKERS+$FIRST_CPU+1+i)),$(($N_KIND_WORKERS+$FIRST_CPU+2-2*(i%2)+i))"
+  cpuSet: "$((N_KIND_WORKERS+FIRST_CPU+1+i)),$((N_KIND_WORKERS+FIRST_CPU+2-2*(i%2)+i))"
 EOF
 );\
 fi
 done
 # use cpuSet in the case of a patched kind version like in scale tests (test/scale/README.md)
 
-for ((i=1; i<=$N_KIND_WORKERS; i++)); do \
+for ((i=1; i<=N_KIND_WORKERS; i++)); do \
 config=$(cat <<EOF
 $config
 - role: worker
@@ -108,21 +111,21 @@ $config
       containerPath: $HOME
 EOF
 );
-if [ "$CPU_PINNING" == "true" ]; then
+if [ "${CPU_PINNING}" == "true" ]; then
 config=$(cat <<EOF
 $config
-  cpuSet: "$(($N_KIND_WORKERS+$FIRST_CPU+1+i)),$(($N_KIND_WORKERS+$FIRST_CPU+2-2*(i%2)+i))"
+  cpuSet: "$((N_KIND_WORKERS+FIRST_CPU+1+i)),$((N_KIND_WORKERS+FIRST_CPU+2-2*(i%2)+i))"
 EOF
 );\
 fi
 done
 # use cpuSet in the case of a patched kind version like in scale tests (test/scale/README.md)
 
-echo -e "$config" | kind create cluster --config=-
+echo -e "$config" | ${KIND} create cluster --config=-
 
 # connect the registry to the cluster network if not already connected
-if [ "$(docker inspect -f='{{json .NetworkSettings.Networks.kind}}' "${reg_name}")" = 'null' ]; then
-  docker network connect "kind" "${reg_name}"
+if [ "$(docker inspect -f='{{json .NetworkSettings.Networks.kind}}' "${KIND_REGISTRY_NAME}")" = 'null' ]; then
+  docker network connect "kind" "${KIND_REGISTRY_NAME}"
 fi
 
 # Document the local registry
@@ -135,6 +138,11 @@ metadata:
   namespace: kube-public
 data:
   localRegistryHosting.v1: |
-    host: "localhost:${reg_port}"
+    host: "localhost:${KIND_REGISTRY_PORT}"
     help: "https://kind.sigs.k8s.io/docs/user/local-registry/"
 EOF
+
+
+if [ "${NO_TAINT}" == "true" ]; then
+kubectl taint nodes --all node-role.kubernetes.io/control-plane- || true
+fi


### PR DESCRIPTION
This patch fixes the kind version used in the `make kind` directive. This removes the requriement of installing kind globally on the system and makes the testing more consistent between environments.

version can be set using `make kind KIND_VERSION=v0.30.0`

The default value is set to v0.30.0
This corresponds to k8s 1.34

Keeping in mind that Calico v3.32.0 officially supports k8s v1.34 ; v1.35 and v1.36