### PR TITLE
fix(bgp): bound-check segment count in getSRPolicy

### DIFF
--- a/calico-vpp-agent/routing/bgp_watcher.go
+++ b/calico-vpp-agent/routing/bgp_watcher.go
@@ -175,7 +175,23 @@ func (s *Server) getSRPolicy(path *bgpapi.Path) (srv6Policy *types.SrPolicy, srv
 
 	}
 
-	policySidListsids := [16]ip_types.IP6Address{}
+	// VPP's vl_api_srv6_sid_list_t carries a fixed-size sids[16] array
+	// (src/vnet/srv6/sr.api → types.Srv6SidList.Sids). Reject SR Policies
+	// whose segment list is either empty (we'd dereference segments[-1]
+	// below) or too long (we'd write past policySidListsids[vppMaxSRv6Sids-1])
+	// instead of panicking the agent process on malformed or oversized input.
+	const vppMaxSRv6Sids = 16
+	if len(segments) == 0 {
+		return nil, nil, srnrli, fmt.Errorf(
+			"sr policy endpoint=%s has no segments", net.IP(srnrli.Endpoint))
+	}
+	if len(segments) > vppMaxSRv6Sids {
+		return nil, nil, srnrli, fmt.Errorf(
+			"sr policy endpoint=%s has %d segments, vpp supports up to %d",
+			net.IP(srnrli.Endpoint), len(segments), vppMaxSRv6Sids)
+	}
+
+	policySidListsids := [vppMaxSRv6Sids]ip_types.IP6Address{}
 	for i, segment := range segments {
 		policySidListsids[i] = types.ToVppIP6Address(net.IP(segment.Sid))
 	}


### PR DESCRIPTION
## Summary

`calico-vpp-agent/routing/bgp_watcher.go::getSRPolicy` has **no bound check on the segment count**, so a malformed SR Policy NLRI from a BGP peer (segment list of 0 or 17+ entries) crashes the agent process with a runtime panic. This PR adds a small guard that returns an `error` instead of panicking on malformed input.

---

## Root cause

### 1. VPP API uses a fixed 16-SID array

VPP's `src/vnet/srv6/sr.api`:

```c
typedef srv6_sid_list {
  u8 num_sids;
  u32 weight;
  vl_api_ip6_address_t sids[16];   // <- fixed length 16
};
```

This is auto-generated as `vpplink/generated/bindings/sr/sr.ba.go::Srv6SidList.Sids [16]ip_types.IP6Address`. The `16` is not a Calico-VPP convention — it is the **VPP plugin's API contract**.

### 2. Two out-of-range accesses in `getSRPolicy`

```go
// bgp_watcher.go (before fix)
segments := []*bgpapi.SegmentTypeB{}     // unbounded slice, peer-supplied
// ... unmarshal TunnelEncap sub-TLVs and append ...

// (A) 17+ entries -> fixed-array OOR
policySidListsids := [16]ip_types.IP6Address{}
for i, segment := range segments {
    policySidListsids[i] = ...           // panics at i = 16
}

// (B) 0 entries -> empty-slice tail dereference (index -1)
srv6tunnel.Behavior = uint8(
    segments[len(segments)-1].           // len(segments) = 0 -> index -1
        GetEndpointBehaviorStructure().Behavior,
)
```

`startBGPMonitoring` has no `defer recover()`, so the panic propagates from the `WatchBGPPath` goroutine and **kills the entire agent process** — i.e. a remote DoS of the node's routing daemon.

---

## Panic logs captured on a real cluster master node

Stack traces from invoking `getSRPolicy` with crafted 17-segment / 0-segment input on `master.ryskn.k8s` (`Linux 6.12.0-124.52.3.el10_1.x86_64`, AlmaLinux 10.1):

### Case A: 17 segments — fixed-array OOR

```
panic: runtime error: index out of range [16] with length 16 [recovered, repanicked]

goroutine 14 [running]:
panic({0x21c53e0?, 0x611b48ce240?})
	/opt/homebrew/Cellar/go/1.26.2/libexec/src/runtime/panic.go:860 +0x13a
github.com/projectcalico/vpp-dataplane/v3/calico-vpp-agent/routing.(*Server).getSRPolicy(0x611b48a5e98, 0x611b48a5d98)
	/Users/ryosuke/project/vpp-dataplane/calico-vpp-agent/routing/bgp_watcher.go:187 +0x98a
```

Offending line (`bgp_watcher.go:187`):

```go
policySidListsids[i] = types.ToVppIP6Address(net.IP(segment.Sid))
```

### Case B: 0 segments — empty-slice index -1

```
panic: runtime error: index out of range [-1] [recovered, repanicked]

goroutine 36 [running]:
panic({0x21c53e0?, 0x11bf36732108?})
	/opt/homebrew/Cellar/go/1.26.2/libexec/src/runtime/panic.go:860 +0x13a
github.com/projectcalico/vpp-dataplane/v3/calico-vpp-agent/routing.(*Server).getSRPolicy(0x11bf36755e98, 0x11bf36755d98)
	/Users/ryosuke/project/vpp-dataplane/calico-vpp-agent/routing/bgp_watcher.go:203 +0x985
```

Offending line (`bgp_watcher.go:203`):

```go
srv6tunnel.Behavior = uint8(segments[len(segments)-1].GetEndpointBehaviorStructure().Behavior)
```

> Note: the `/opt/homebrew/Cellar/go/...` and `/Users/ryosuke/project/...` paths in the stack traces come from build-path embedding (the binary was cross-compiled on a macOS host). The execution host is `master.ryskn.k8s`, confirmed via `uname -a`.

---

## Behavior after the fix (same master node)

```
getSRPolicy returned error: sr policy endpoint=2001:db8::1 has 17 segments, vpp supports up to 16
getSRPolicy returned error: sr policy endpoint=2001:db8::1 has no segments
```

The caller `injectSRv6Policy` already wraps the error with `errors.Wrap(err, "error injectSRv6Policy")` and returns it up the stack, so a malformed SR Policy now produces a single `level=error` log line and the process keeps running.
