### PR TITLE
build: remove copied plugins from tree

### DIFF
--- a/vpplink/generated/vpp_clone_current.sh
+++ b/vpplink/generated/vpp_clone_current.sh
@@ -106,6 +106,8 @@ function git_clone_cd_and_reset ()
 		git fetch --tags "https://gerrit.fd.io/r/vpp"
 	fi
 	git reset --hard ${VPP_COMMIT}
+	# Remove plugins copied with copy_private_plugin
+	git clean -fd src/plugins/
 }
 
 # --------------- Things to cherry pick ---------------


### PR DESCRIPTION
This patch removes the unversioned plugins that were previously copied by copy_private_plugin() in this build or another build.

This allows keeping stale files around and conflicting between copied plugin and plugins applied with a patch using the same name