### PR TITLE
fix(bgp): handle SR Policy withdraw and validate endpoint behavior in getSRPolicy

### DIFF
--- a/calico-vpp-agent/routing/bgp_watcher.go
+++ b/calico-vpp-agent/routing/bgp_watcher.go
@@ -137,6 +137,16 @@ func (s *Server) getSRPolicy(path *bgpapi.Path) (srv6Policy *types.SrPolicy, srv
 	}
 	srv6tunnel.Dst = net.IP(srnrli.Endpoint)
 
+	// SR Policy withdraws carry only the (distinguisher, color, endpoint)
+	// NLRI key; per RFC 9012 / draft-ietf-idr-segment-routing-te-policy the
+	// TunnelEncap path attribute is not required. Short-circuit so the
+	// caller (injectSRv6Policy) can dispatch SRv6PolicyDeleted instead of
+	// reaching the empty-segments check below and dropping the withdraw
+	// without emitting SRv6PolicyDeleted.
+	if path.IsWithdraw {
+		return nil, srv6tunnel, srnrli, nil
+	}
+
 	for _, pattr := range path.Pattrs {
 		if err := pattr.UnmarshalTo(tun); err == nil {
 			for _, tlv := range tun.Tlvs {
@@ -209,7 +219,18 @@ func (s *Server) getSRPolicy(path *bgpapi.Path) (srv6Policy *types.SrPolicy, srv
 	srv6tunnel.Bsid = srv6Policy.Bsid.ToIP()
 	srv6tunnel.Policy = srv6Policy
 
-	srv6tunnel.Behavior = uint8(segments[len(segments)-1].GetEndpointBehaviorStructure().Behavior)
+	// EndpointBehaviorStructure is an optional sub-TLV in SegmentTypeB
+	// (RFC 9830, RFC 9256). The protobuf-generated
+	// GetEndpointBehaviorStructure() is nil-safe, but accessing .Behavior on
+	// the returned nil pointer panics. Reject SR Policies whose last segment
+	// lacks endpoint behavior info instead of crashing the agent.
+	lastEBS := segments[len(segments)-1].GetEndpointBehaviorStructure()
+	if lastEBS == nil {
+		return nil, nil, srnrli, fmt.Errorf(
+			"sr policy endpoint=%s last segment has no endpoint behavior structure",
+			net.IP(srnrli.Endpoint))
+	}
+	srv6tunnel.Behavior = uint8(lastEBS.Behavior)
 
 	return srv6Policy, srv6tunnel, srnrli, err
 }


### PR DESCRIPTION
## Summary

Follow-up to PR #1012 (c0b8d78e). Closes the remaining two `getSRPolicy()` paths in `calico-vpp-agent/routing/bgp_watcher.go`.

| Case | Trigger | Pre-fix behaviour | This PR |
|---|---|---|---|
| Oversized segments | Peer sends SR Policy with 17+ SegmentTypeB | out-of-range panic while writing the 17th SID | Already fixed by #1012 (bound check) |
| **Withdraw** | `MP_UNREACH_NLRI` for SR Policy (RFC 9012) — empty Pattrs | Pre-#1012: `segments[-1]` panic. Post-#1012: drop without emitting `SRv6PolicyDeleted`, VPP keeps stale policy. | `path.IsWithdraw` short-circuit so `injectSRv6Policy` can dispatch the deletion event |
| **Nil EBS** | Peer sends SegmentTypeB without `EndpointBehaviorStructure` | `nil.Behavior` SIGSEGV → agent process abort | Reject the SR Policy with an error when the last segment lacks endpoint behavior info |

## Why these matter

SRv6 Endpoint Behavior and SID Structure is **optional** for Segment Type B per RFC 9830 (and described in RFC 9256 as MAY be provided for validation at the headend). Conforming peers may legally advertise SR Policy NLRIs without it. The receive path must tolerate that encoding, not dereference an optional field that may be nil.

Withdraw handling is also required for normal SR Policy lifecycle operations such as policy deletion or BGP session teardown. Without this path, a previously installed VPP SR policy / steering entry can remain stale because `SRv6PolicyDeleted` is never published.

In local interop testing, `gobgpd`-generated SR Policy updates can omit `EndpointBehaviorStructure`, which is what surfaced the nil dereference here.

## Prior reproduction in the same function

A reproducer triggered the oversized-segments case (already fixed by #1012) and the agent aborted at `getSRPolicy()` (`bgp_watcher.go:187`, `runtime error: index out of range [16] with length 16`, exitCode 2). The withdraw and nil-EBS cases live in the same peer-input parsing path. The withdraw case can leave stale VPP state by dropping withdraws before `SRv6PolicyDeleted` is emitted, while the nil-EBS case can still abort the agent process through a nil optional field dereference. The fixes here make both paths return explicit errors or deletion events before any unsafe slice / pointer access.

## Diff summary

`calico-vpp-agent/routing/bgp_watcher.go`, +23 / -1:

1. Early `path.IsWithdraw` return immediately after NLRI unmarshal, with `srv6tunnel.Dst` populated so `injectSRv6Policy` can still send `SRv6PolicyDeleted`.
2. Nil check on `GetEndpointBehaviorStructure()` before `.Behavior` access, returning a descriptive error on nil.

No new dependencies, no API changes, no test fixture changes.

## Notes

Same function as PR #1012; comments match the surrounding style.
