### PR TITLE
vpp-manager: fix uplink admin-up timing for VPP ARP initialization

### DIFF
--- a/vpp-manager/vpp_runner.go
+++ b/vpp-manager/vpp_runner.go
@@ -659,6 +659,22 @@ func (v *VppRunner) configureVppUplinkInterface(
 		}
 	}
 
+	// Bring the uplink interface admin-up now that all pre-configurations
+	// (IPv6 RA suppression, CNAT features, VRF assignment) are complete,
+	// but BEFORE adding any addresses or routes.
+	//
+	// If an IPv4 address is added to a DOWN interface, VPP skips creating the
+	// /32 local route for the interface address, the connected/glean route for
+	// the subnet and the broadcast routes. Without these routes, VPP's ARP
+	// subsystem cannot function since ARP neighbor learning requires the glean
+	// route to validate that the sender IP is in a connected subnet. Without
+	// validation, VPP refuses to learn neighbors resulting in an empty neighbor
+	// table and 100% packet loss for IPv4 traffic.
+	err = v.vpp.InterfaceAdminUp(ifSpec.SwIfIndex)
+	if err != nil {
+		return errors.Wrapf(err, "Error setting uplink interface %d admin-up", ifSpec.SwIfIndex)
+	}
+
 	for _, addr := range ifState.GetAddresses() {
 		log.Infof("Adding address %s to uplink interface", addr.IPNet.String())
 		err = v.vpp.AddInterfaceAddress(ifSpec.SwIfIndex, addr.IPNet)
@@ -1103,18 +1119,6 @@ func (v *VppRunner) runVpp() (err error) {
 	}
 
 	networkHook.ExecuteWithUserScript(hooks.HookVppRunning, config.HookScriptVppRunning, v.params)
-
-	// Bring all VPP uplinks admin-up now that RA suppression, CNAT, VRF binding,
-	// addresses and routes are all programmed, the host-side taps exist and are
-	// configured and v6 link-local addresses have been discovered and configured.
-	for idx := 0; idx < len(v.params.UplinksSpecs); idx++ {
-		err = v.vpp.InterfaceAdminUp(v.params.UplinksSpecs[idx].SwIfIndex)
-		if err != nil {
-			terminateVpp("Error setting uplink %d up: %v", v.params.UplinksSpecs[idx].SwIfIndex, err)
-			<-vppDeadChan
-			return errors.Wrapf(err, "Error setting uplink %d up", v.params.UplinksSpecs[idx].SwIfIndex)
-		}
-	}
 
 	// Set the TAP interfaces admin-up in VPP last, after all Linux-side
 	// configuration is complete.


### PR DESCRIPTION
### Summary:
This patch fixes `calico-vpp-node` `agent` container getting into `CrashLoopBackOff` caused by **VPP ARP resolution failure** for the Kubernetes API server by moving `InterfaceAdminUp()` into `configureVppUplinkInterface()`, placing it **_after_** IPv6 RA suppression, CNAT, and VRF configuration, but **_before_** addresses are added.

### RCA:
After commit 61ea20b4, the following symptoms were noticed:
- `calico-vpp-node` agent containers in **CrashLoopBackOff**
- `vpp-manager` logs: `dial tcp 11.96.0.1:443: i/o timeout` (Kubernetes API unreachable)
- VPP neighbor table: **empty** (no IPv4 neighbors learned)
- VPP FIB: `172.18.0.0/16 glean via host-eth0` showing **drops**
- `show ip arp` output: **empty** (no entries)

VPP's IPv4 address addition has a **fundamental dependency** on interface admin state.
```
ip4_add_del_interface_address_internal()
...
    if (vnet_sw_interface_is_admin_up(vnm, sw_if_index))
      ip4_add_interface_routes(sw_if_index, ...);
    else
      /* Skip route creation - interface is DOWN */
```
When an IPv4 address is added to a DOWN interface, VPP skips creating the `/32` local route for the interface address, the
connected/glean route for the subnet and the broadcast routes. Without the glean route, VPP's ARP neighbor learning cannot function since ARP learning requires the glean route to validate that the sender IP is within a connected subnet. Without this validation, VPP refuses to learn neighbor MAC addresses resulting in an empty neighbor table and 100% packet loss for IPv4 traffic.
```
void ip_neighbor_learn()
...
  // Lookup: Is sender_ip in a connected subnet on this interface?
  fib_node_index_t fei = fib_table_lookup_exact_match(fib_index, sender_ip);
  
  if (fei == FIB_NODE_INDEX_INVALID)
    // No covering route → sender not in connected subnet → REJECT
  
  if (!fib_entry_is_sourced(fei, FIB_SOURCE_INTERFACE))
    // Not a connected/interface route → REJECT
```

VPP does have a callback `ip4_sw_interface_admin_up_down()` that runs when an interface transitions UP:
```
ip4_sw_interface_admin_up_down ()
...
  u32 is_admin_up = (flags & VNET_SW_INTERFACE_FLAG_ADMIN_UP) != 0;  
  if (is_admin_up)
  {
    // Iterate all addresses on this interface and create routes
    foreach_ip_interface_address (&im->lookup_main, ia, sw_if_index, 0, ({
      ip4_add_interface_routes (sw_if_index, im, fib_index, ia);
    }));
  }
```

This should have fixed the problem by creating routes when the interface finally comes UP, but it ends up in a **race**:
- **Timing is too late**: By the time this callback runs, the Linux tap has been brought UP, `NetworkManager` has restarted, and ARP requests have already been sent and processed.
- **State is not recoverable**: VPP has already tried to process ARP packets in a broken state (no glean route). The neighbor table is empty and remains empty.
- **No retry mechanism**: VPP does not automatically retry neighbor learning for packets it already dropped.

### Fix:
Move `InterfaceAdminUp()` into `configureVppUplinkInterface()`, placing it **after policy configuration but before addresses**. Here is the ordering of operations: `CreateMainVppInterface` → `EnableInterfaceIP6` → `DisableIP6RouterAdvertisements` → `CnatEnableFeatures` → `SetInterfaceVRF` → `InterfaceAdminUp(uplink)` → `AddInterfaceAddress` → `RouteAdd(connected)` → `RouteAdd(defaultGWs)` → `configureLinuxTap` → `configureIPv6LinkLocal` → `InterfaceAdminUp(tap)`