### PR TITLE
Fix external BGP SR Policy parsing and install path

### DIFF
--- a/calico-vpp-agent/routing/bgp_watcher.go
+++ b/calico-vpp-agent/routing/bgp_watcher.go
@@ -22,6 +22,7 @@ import (
 
 	bgpapi "github.com/osrg/gobgp/v3/api"
 	"github.com/pkg/errors"
+	"google.golang.org/protobuf/types/known/anypb"
 	"gopkg.in/tomb.v2"
 
 	calicov3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
@@ -124,11 +125,142 @@ func (s *Server) injectRoute(path *bgpapi.Path) error {
 	return nil
 }
 
+// vppMaxSRv6Sids is the fixed size of vl_api_srv6_sid_list_t.sids in VPP
+// (src/vnet/srv6/sr.api). Each VPP Segment List therefore holds at most 16
+// SIDs; multiple Segment Lists must be installed via SrPolicyMod.
+const vppMaxSRv6Sids = 16
+
+// errSRPolicyMixedBehavior is wrapped into the error returned by
+// getSRPolicy when an advertised SR Policy's Segment Lists disagree on
+// trailing endpoint behavior. injectSRv6Policy unwraps it to decide
+// whether to dispatch an SRv6PolicyDeleted event for the endpoint --
+// previously-installed state under the same NLRI key must be torn down,
+// not silently kept, when the controller's new advertisement is rejected.
+var errSRPolicyMixedBehavior = errors.New("sr policy: candidate paths disagree on endpoint behavior; this agent installs one Behavior per BSID and cannot represent the candidate-path set safely")
+
+// walkSRPolicyInnerTLVs invokes fn for every inner TLV inside the
+// TunnelEncapAttribute(s) of an SR Policy path, hiding the
+// Path -> Pattrs -> TunnelEncapAttribute.Tlvs -> Tlv.Tlvs unmarshal nest.
+func walkSRPolicyInnerTLVs(path *bgpapi.Path, fn func(*anypb.Any) error) error {
+	for _, pattr := range path.Pattrs {
+		tun := &bgpapi.TunnelEncapAttribute{}
+		if err := pattr.UnmarshalTo(tun); err != nil {
+			// path.Pattrs is heterogeneous (OriginAttribute,
+			// AsPathAttribute, NextHopAttribute, ...). Anything that is
+			// not a TunnelEncapAttribute fails UnmarshalTo here, which is
+			// expected, not a decoding bug -- skip and keep scanning.
+			continue
+		}
+		for _, tlv := range tun.Tlvs {
+			for _, innerTlv := range tlv.Tlvs {
+				if err := fn(innerTlv); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// parseSegmentList converts one TunnelEncapSubTLVSRSegmentList into a
+// single types.Srv6SidList, preserving the sub-TLV's weight. It also
+// returns the last SegmentTypeB so the caller can inspect the
+// EndpointBehaviorStructure that drives the SR Policy install behavior.
+//
+// Caller contract: getSRPolicy propagates any error returned here through
+// walkSRPolicyInnerTLVs, which means *one bad Segment List rejects the
+// entire SR Policy*, not just the offending list. That whole-policy
+// rejection is intentional -- partial installation would change the
+// candidate-path / weight semantics the controller advertised (see the
+// design note in the PR description). parseSegmentList itself does not
+// know about sibling Segment Lists; it just guarantees that a list it
+// accepts can be installed in VPP without further validation.
+//
+// Segment-type policy: an SR Policy advertised to an SRv6 dataplane is
+// expected to carry SegmentTypeB (IPv6 SID) entries end-to-end. A
+// SegmentTypeA (SR-MPLS label) entry is legitimate per
+// draft-ietf-idr-segment-routing-te-policy but cannot be installed by
+// this SRv6 agent; silently skipping it would install a SID chain that
+// differs from the advertised one -- the forwarding path would change
+// in a way the advertising peer never intended. The list is therefore
+// rejected with a distinct error so operators can tell "advertiser sent
+// SR-MPLS segments we cannot install" from "advertiser sent malformed
+// protobuf bytes".
+//
+// EndpointBehaviorStructure on the trailing SegmentTypeB is required
+// (it drives srv6tunnel.Behavior). Lists whose last segment has no
+// behavior structure are rejected here per-list, so getSRPolicy does
+// not have to re-validate it after the walk.
+func parseSegmentList(
+	sub *bgpapi.TunnelEncapSubTLVSRSegmentList,
+	srnrli *bgpapi.SRPolicyNLRI,
+) (types.Srv6SidList, *bgpapi.SegmentTypeB, error) {
+	segments := make([]*bgpapi.SegmentTypeB, 0, len(sub.GetSegments()))
+	for i, raw := range sub.GetSegments() {
+		segment := &bgpapi.SegmentTypeB{}
+		if err := raw.UnmarshalTo(segment); err == nil {
+			segments = append(segments, segment)
+			continue
+		}
+		// Distinguish "advertiser sent a known but unsupported segment
+		// type (SR-MPLS Type-A)" from "advertiser sent bytes that decode
+		// as no SR segment type at all". Both reject the list, but the
+		// SR-MPLS case is intentional on the advertiser's side and the
+		// genuinely-malformed case is a protocol violation; the
+		// different error wording makes the operator-side triage
+		// obvious.
+		typeA := &bgpapi.SegmentTypeA{}
+		if err := raw.UnmarshalTo(typeA); err == nil {
+			return types.Srv6SidList{}, nil, fmt.Errorf(
+				"sr policy endpoint=%s: SegmentTypeA (SR-MPLS label %d) at index %d cannot be installed by this SRv6 agent; rejecting list to avoid installing a SID chain different from the advertised one",
+				net.IP(srnrli.Endpoint), typeA.GetLabel(), i)
+		}
+		return types.Srv6SidList{}, nil, fmt.Errorf(
+			"sr policy endpoint=%s has an unsupported or malformed segment at index %d",
+			net.IP(srnrli.Endpoint), i)
+	}
+	// Defensive: protobuf message with zero `segments` repeated entries.
+	// parseSegmentList is called via walkSRPolicyInnerTLVs which only
+	// hits us for actual SegmentList sub-TLVs, but the peer could still
+	// advertise one with no inner Any entries.
+	if len(segments) == 0 {
+		return types.Srv6SidList{}, nil, fmt.Errorf(
+			"sr policy endpoint=%s has a segment list with no segments",
+			net.IP(srnrli.Endpoint))
+	}
+	if len(segments) > vppMaxSRv6Sids {
+		return types.Srv6SidList{}, nil, fmt.Errorf(
+			"sr policy endpoint=%s segment list has %d segments, vpp supports up to %d",
+			net.IP(srnrli.Endpoint), len(segments), vppMaxSRv6Sids)
+	}
+	// EndpointBehaviorStructure is optional in the protobuf but required
+	// by this agent: srv6tunnel.Behavior is derived from the trailing
+	// segment's behavior code, and the generated GetEndpointBehaviorStructure()
+	// is nil-safe but accessing .Behavior on the returned nil pointer panics.
+	// Reject the list here instead of crashing later in getSRPolicy.
+	last := segments[len(segments)-1]
+	if last.GetEndpointBehaviorStructure() == nil {
+		return types.Srv6SidList{}, nil, fmt.Errorf(
+			"sr policy endpoint=%s last segment has no endpoint behavior structure",
+			net.IP(srnrli.Endpoint))
+	}
+	sids := [vppMaxSRv6Sids]ip_types.IP6Address{}
+	for i, segment := range segments {
+		sids[i] = types.ToVppIP6Address(net.IP(segment.Sid))
+	}
+	weight := uint32(1)
+	if w := sub.GetWeight(); w != nil {
+		weight = w.GetWeight()
+	}
+	return types.Srv6SidList{
+		NumSids: uint8(len(segments)),
+		Weight:  weight,
+		Sids:    sids,
+	}, last, nil
+}
+
 func (s *Server) getSRPolicy(path *bgpapi.Path) (srv6Policy *types.SrPolicy, srv6tunnel *common.SRv6Tunnel, srnrli *bgpapi.SRPolicyNLRI, err error) {
 	srnrli = &bgpapi.SRPolicyNLRI{}
-	tun := &bgpapi.TunnelEncapAttribute{}
-	subTLVSegList := &bgpapi.TunnelEncapSubTLVSRSegmentList{}
-	segments := []*bgpapi.SegmentTypeB{}
 	srv6bsid := &bgpapi.SRBindingSID{}
 	srv6tunnel = &common.SRv6Tunnel{}
 
@@ -147,92 +279,84 @@ func (s *Server) getSRPolicy(path *bgpapi.Path) (srv6Policy *types.SrPolicy, srv
 		return nil, srv6tunnel, srnrli, nil
 	}
 
-	for _, pattr := range path.Pattrs {
-		if err := pattr.UnmarshalTo(tun); err == nil {
-			for _, tlv := range tun.Tlvs {
-				// unmarshal Tlvs
-				for _, innerTlv := range tlv.Tlvs {
-					// search for TunnelEncapSubTLVSRSegmentList
-					if err := innerTlv.UnmarshalTo(subTLVSegList); err == nil {
-						for _, seglist := range subTLVSegList.Segments {
-							segment := &bgpapi.SegmentTypeB{}
-							if err = seglist.UnmarshalTo(segment); err == nil {
-								segments = append(segments, segment)
-							}
-						}
-					}
-					// search for TunnelEncapSubTLVSRBindingSID
-					subTLVBsid := &bgpapi.TunnelEncapSubTLVSRBindingSID{}
-					if err := innerTlv.UnmarshalTo(subTLVBsid); err == nil {
-						s.log.Debugf("getSRPolicy TunnelEncapSubTLVSRBindingSID")
-						if subTLVBsid.Bsid != nil {
-							if err := subTLVBsid.Bsid.UnmarshalTo(srv6bsid); err != nil {
-								return nil, nil, nil, err
-							}
-						}
-					}
+	var (
+		sidLists      []types.Srv6SidList
+		listBehaviors []bgpapi.SRv6Behavior // parallel to sidLists; trailing-segment Behavior per list
+	)
 
-					// search for TunnelEncapSubTLVSRPriority
-					subTLVSRPriority := &bgpapi.TunnelEncapSubTLVSRPriority{}
-					if err := innerTlv.UnmarshalTo(subTLVSRPriority); err == nil {
-						s.log.Debugf("getSRPolicyPriority TunnelEncapSubTLVSRPriority")
-						srv6tunnel.Priority = subTLVSRPriority.Priority
-					}
-
-				}
+	err = walkSRPolicyInnerTLVs(path, func(innerTlv *anypb.Any) error {
+		// Segment List sub-TLV: one VPP Srv6SidList per occurrence so the
+		// SR Policy Architecture (RFC 9256) notion of independent Segment
+		// Lists -- weighted load balancing or back-up candidates -- is
+		// preserved end-to-end instead of being flattened into a single
+		// strict SID chain.
+		sub := &bgpapi.TunnelEncapSubTLVSRSegmentList{}
+		if e := innerTlv.UnmarshalTo(sub); e == nil {
+			list, last, lerr := parseSegmentList(sub, srnrli)
+			if lerr != nil {
+				return lerr
 			}
+			sidLists = append(sidLists, list)
+			listBehaviors = append(listBehaviors, last.GetEndpointBehaviorStructure().GetBehavior())
+			return nil
 		}
-
+		// Binding SID sub-TLV.
+		bsid := &bgpapi.TunnelEncapSubTLVSRBindingSID{}
+		if e := innerTlv.UnmarshalTo(bsid); e == nil {
+			s.log.Debugf("getSRPolicy TunnelEncapSubTLVSRBindingSID")
+			if bsid.Bsid != nil {
+				return bsid.Bsid.UnmarshalTo(srv6bsid)
+			}
+			return nil
+		}
+		// Priority sub-TLV.
+		prio := &bgpapi.TunnelEncapSubTLVSRPriority{}
+		if e := innerTlv.UnmarshalTo(prio); e == nil {
+			s.log.Debugf("getSRPolicyPriority TunnelEncapSubTLVSRPriority")
+			srv6tunnel.Priority = prio.Priority
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, nil, srnrli, err
 	}
-
-	// VPP's vl_api_srv6_sid_list_t carries a fixed-size sids[16] array
-	// (src/vnet/srv6/sr.api → types.Srv6SidList.Sids). Reject SR Policies
-	// whose segment list is either empty (we'd dereference segments[-1]
-	// below) or too long (we'd write past policySidListsids[vppMaxSRv6Sids-1])
-	// instead of panicking the agent process on malformed or oversized input.
-	const vppMaxSRv6Sids = 16
-	if len(segments) == 0 {
+	if len(sidLists) == 0 {
 		return nil, nil, srnrli, fmt.Errorf(
 			"sr policy endpoint=%s has no segments", net.IP(srnrli.Endpoint))
 	}
-	if len(segments) > vppMaxSRv6Sids {
-		return nil, nil, srnrli, fmt.Errorf(
-			"sr policy endpoint=%s has %d segments, vpp supports up to %d",
-			net.IP(srnrli.Endpoint), len(segments), vppMaxSRv6Sids)
-	}
 
-	policySidListsids := [vppMaxSRv6Sids]ip_types.IP6Address{}
-	for i, segment := range segments {
-		policySidListsids[i] = types.ToVppIP6Address(net.IP(segment.Sid))
-	}
 	srv6Policy = &types.SrPolicy{
 		Bsid:     types.ToVppIP6Address(net.IP(srv6bsid.Sid)),
 		IsSpray:  false,
 		IsEncap:  true,
 		FibTable: 0,
-		SidLists: []types.Srv6SidList{{
-			NumSids: uint8(len(segments)),
-			Weight:  1,
-			Sids:    policySidListsids,
-		}},
+		SidLists: sidLists,
 	}
 	srv6tunnel.Bsid = srv6Policy.Bsid.ToIP()
 	srv6tunnel.Policy = srv6Policy
 
-	// EndpointBehaviorStructure is an optional sub-TLV in SegmentTypeB
-	// (RFC 9830, RFC 9256). The protobuf-generated
-	// GetEndpointBehaviorStructure() is nil-safe, but accessing .Behavior on
-	// the returned nil pointer panics. Reject SR Policies whose last segment
-	// lacks endpoint behavior info instead of crashing the agent.
-	lastEBS := segments[len(segments)-1].GetEndpointBehaviorStructure()
-	if lastEBS == nil {
-		return nil, nil, srnrli, fmt.Errorf(
-			"sr policy endpoint=%s last segment has no endpoint behavior structure",
-			net.IP(srnrli.Endpoint))
+	// RFC 9256 permits candidate paths to terminate with different endpoint
+	// behaviors, but this agent's install layer keeps one Behavior per BSID
+	// (srv6tunnel.Behavior is matched against the destination pod prefix
+	// family in connectivity/srv6.go: getPolicyNode), and VPP installs all
+	// Segment Lists under a single sr_policy entry that ECMP/weight-load-
+	// balances across them. Accepting a mixed-behavior policy would mean
+	// installing two SID chains with one decap behavior, and traffic that
+	// hashes onto a list whose trailing segment expects the other behavior
+	// would be dropped/misdecapped at the egress node. Reject the policy
+	// here so the failure is visible at receive time instead of becoming a
+	// silent forwarding bug. parseSegmentList already guarantees every
+	// trailing segment has a non-nil EndpointBehaviorStructure.
+	for i := 1; i < len(listBehaviors); i++ {
+		if listBehaviors[i] != listBehaviors[0] {
+			return nil, nil, srnrli, fmt.Errorf(
+				"sr policy endpoint=%s: segment list 0 ends with endpoint behavior %d, segment list %d ends with %d: %w",
+				net.IP(srnrli.Endpoint), listBehaviors[0], i, listBehaviors[i], errSRPolicyMixedBehavior)
+		}
 	}
-	srv6tunnel.Behavior = uint8(lastEBS.Behavior)
+	srv6tunnel.Behavior = uint8(listBehaviors[0])
 
-	return srv6Policy, srv6tunnel, srnrli, err
+	return srv6Policy, srv6tunnel, srnrli, nil
 }
 
 func (s *Server) injectSRv6Policy(path *bgpapi.Path) error {
@@ -240,6 +364,35 @@ func (s *Server) injectSRv6Policy(path *bgpapi.Path) error {
 	_, srv6tunnel, srnrli, err := s.getSRPolicy(path)
 
 	if err != nil {
+		// The rejected advertisement may be an UPDATE for an SR Policy that
+		// was previously accepted and installed in VPP. Keeping the old
+		// installed state would diverge from the controller's view (the
+		// controller considers the policy replaced; we silently keep the old
+		// version). For rejection paths that hit on a parseable NLRI, treat
+		// the receive-time failure as an implicit withdraw of any earlier
+		// install under the same endpoint by dispatching SRv6PolicyDeleted.
+		// SRv6Provider.DelConnectivity is currently a no-op (separate
+		// pre-existing FIXME) so the actual VPP teardown will land when
+		// that work merges; the event signal here makes the cleanup intent
+		// correct in the meantime instead of leaving a silent gap.
+		//
+		// Scoped to errSRPolicyMixedBehavior for now: only this reject
+		// path is reachable AFTER an initial accept (the receive-time
+		// validation paths in parseSegmentList / NLRI unmarshal would
+		// have rejected the first advertisement too, so there is no
+		// stale install to tear down).
+		if srnrli != nil && srnrli.Endpoint != nil && errors.Is(err, errSRPolicyMixedBehavior) {
+			s.log.Warnf("injectSRv6Policy: rejecting mixed-behavior SR Policy for endpoint=%s and signalling teardown of any prior install under the same endpoint", net.IP(srnrli.Endpoint))
+			common.SendEvent(common.CalicoVppEvent{
+				Type: common.SRv6PolicyDeleted,
+				Old: &common.NodeConnectivity{
+					Dst:              net.IPNet{},
+					NextHop:          srnrli.Endpoint,
+					ResolvedProvider: "",
+					Custom:           &common.SRv6Tunnel{Dst: net.IP(srnrli.Endpoint)},
+				},
+			})
+		}
 		return errors.Wrap(err, "error injectSRv6Policy")
 	}
 	s.log.Debugf("injectSRv6Policy: endpoint=%s, dst=%s, behavior=%d, bsid=%s, sids=%v",

--- a/calico-vpp-agent/watchers/peers_watcher.go
+++ b/calico-vpp-agent/watchers/peers_watcher.go
@@ -448,6 +448,19 @@ func (w *PeerWatcher) createBGPPeer(ip string, asn uint32, peerSpec *calicov3.BG
 		AfiSafis: afiSafis,
 	}
 
+	// BGPPeerSpec.TTLSecurity (GTSM, RFC 5082): N hops allowed -> outbound
+	// TTL=255, inbound TTL must be >= 255-N. Required for external eBGP peers
+	// on VPP nodes because VPP performs L3 routing between host-eth0 and tap,
+	// adding a hop that drops the eBGP-default TTL=1 packets (= peer never
+	// reaches Established). Without this, BGPPeer.TTLSecurity is silently
+	// ignored and external peers fail with "hold timer expired" loops.
+	if peerSpec.TTLSecurity != nil && *peerSpec.TTLSecurity > 0 {
+		peer.TtlSecurity = &bgpapi.TtlSecurity{
+			Enabled: true,
+			TtlMin:  uint32(255 - *peerSpec.TTLSecurity),
+		}
+	}
+
 	if w.getSecretKeyRef(peerSpec) != nil {
 		peer.Conf.AuthPassword, err = w.getPassword(peerSpec.Password.SecretKeyRef)
 		if err != nil {

--- a/vpplink/srv6.go
+++ b/vpplink/srv6.go
@@ -8,7 +8,9 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/projectcalico/vpp-dataplane/v3/vpplink/generated/bindings/interface_types"
+	"github.com/projectcalico/vpp-dataplane/v3/vpplink/generated/bindings/ip_types"
 	"github.com/projectcalico/vpp-dataplane/v3/vpplink/generated/bindings/sr"
+	"github.com/projectcalico/vpp-dataplane/v3/vpplink/generated/bindings/sr_types"
 	"github.com/projectcalico/vpp-dataplane/v3/vpplink/types"
 )
 
@@ -74,26 +76,72 @@ func (v *VppLink) AddModSRv6Policy(policy *types.SrPolicy) (err error) {
 func (v *VppLink) AddSRv6Policy(policy *types.SrPolicy) error {
 	client := sr.NewServiceClient(v.GetConnection())
 
-	// supporting only one SID list here -> multiple weighted paths for workload balance not supported
-	// This means that lso IsSpray setting is useless as it switches between default weighted path mode
-	// and spray mode(=replicate-traffic-and-multicast-to-all-paths)
-	sidlist := policy.SidLists[0]
+	if len(policy.SidLists) == 0 {
+		return fmt.Errorf("failed to add SRv6Policy: policy has no SID lists")
+	}
+	// sr_policy_mod accepts an SR Policy keyed by either bsid_addr or a
+	// non-zero sr_policy_index; this code path only sets bsid_addr, so
+	// reject a zero / unset BSID up-front. Otherwise an SR Policy that
+	// reached AddSRv6Policy without a Binding SID sub-TLV decoded into it
+	// would silently target the all-zero-BSID entry on later SrPolicyMod
+	// calls.
+	if (policy.Bsid == ip_types.IP6Address{}) {
+		return fmt.Errorf("failed to add SRv6Policy: BSID is unset (zero address)")
+	}
 
-	_, err := client.SrPolicyAdd(v.GetContext(), &sr.SrPolicyAdd{
+	// VPP's sr_policy_add accepts a single Segment List, so the first one is
+	// installed via SrPolicyAdd and any additional lists are appended one at
+	// a time with SrPolicyMod{Operation: SR_POLICY_OP_API_ADD}. This keeps
+	// the RFC 9256 notion of multiple weighted Segment Lists per SR Policy
+	// (ECMP / fallback candidates) intact rather than collapsing them into a
+	// single strict chain.
+	//
+	// The "weight" field appears twice on the wire: once at the top level
+	// (sr_policy_add.weight, documented as "weight of the sid list") and
+	// once nested inside Sids (vl_api_srv6_sid_list_t.weight). VPP's
+	// sr_policy_add_fn implementation reads the top-level field as the
+	// authoritative per-SID-list weight; the nested copy is set to the same
+	// value so the on-wire srv6_sid_list_t round-trips correctly (the
+	// generated marshaller emits both). SrPolicyMod below behaves the same.
+	first := policy.SidLists[0]
+	total := len(policy.SidLists)
+	if _, err := client.SrPolicyAdd(v.GetContext(), &sr.SrPolicyAdd{
 		BsidAddr: policy.Bsid,
+		Weight:   first.Weight,
 		IsEncap:  policy.IsEncap,
 		IsSpray:  policy.IsSpray,
 		FibTable: policy.FibTable,
 		Sids: sr.Srv6SidList{
-			NumSids: sidlist.NumSids,
-			Weight:  sidlist.Weight,
-			Sids:    sidlist.Sids,
+			NumSids: first.NumSids,
+			Weight:  first.Weight,
+			Sids:    first.Sids,
 		},
-	})
-	if err != nil {
+	}); err != nil {
 		return fmt.Errorf("failed to add SRv6Policy: %w", err)
 	}
-	return err
+
+	for i, sl := range policy.SidLists[1:] {
+		listIdx := i + 2 // 1-based, accounting for the SrPolicyAdd above
+		if _, err := client.SrPolicyMod(v.GetContext(), &sr.SrPolicyMod{
+			BsidAddr:  policy.Bsid,
+			FibTable:  policy.FibTable,
+			Operation: sr_types.SR_POLICY_OP_API_ADD,
+			Weight:    sl.Weight,
+			Sids: sr.Srv6SidList{
+				NumSids: sl.NumSids,
+				Weight:  sl.Weight,
+				Sids:    sl.Sids,
+			},
+		}); err != nil {
+			if _, delErr := client.SrPolicyDel(v.GetContext(), &sr.SrPolicyDel{
+				BsidAddr: policy.Bsid,
+			}); delErr != nil {
+				return fmt.Errorf("failed to append SID list %d/%d to SRv6Policy: %w; additionally failed to roll back SRv6Policy: %w", listIdx, total, err, delErr)
+			}
+			return fmt.Errorf("failed to append SID list %d/%d to SRv6Policy: %w; rolled back by deleting the SRv6Policy", listIdx, total, err)
+		}
+	}
+	return nil
 }
 
 func (v *VppLink) DelSRv6Policy(policy *types.SrPolicy) error {


### PR DESCRIPTION
## Summary

Fix the SR Policy parser and the VPP install path so multi-Segment-List `TunnelEncapSubTLVSRSegmentList` advertisements are preserved end-to-end instead of being flat-concatenated into one strict SID chain, and close several panic exits from `getSRPolicy()`. Also bridge `BGPPeer.TTLSecurity` into gobgp so external eBGP peers can establish across VPP's host-eth0 ↔ tap L3 hop -- without that, the SR Policy fix cannot be validated end-to-end.

Prior fixes (`projectcalico/vpp-dataplane#1012`, `#1018`) plugged some panics piecemeal but left the root cause -- no per-Segment-List parse function -- in place.

## Scope of this PR

Two fixes that together make external-BGP-controller SR Policy distribution validatable end-to-end:

1. **SR Policy parser and VPP install** (`calico-vpp-agent/routing/bgp_watcher.go`, `vpplink/srv6.go`). A mix of three categories, not "RFC-violation fixes" wholesale:
   - **RFC 9256 alignment.** Stop flat-concatenating multiple `TunnelEncapSubTLVSRSegmentList` entries into one chain. Independent Segment Lists are the RFC's ECMP / weighted-candidate-path mechanism; flatten silently changes the advertised forwarding semantics.
   - **Defensive validation.** Close per-list panic paths (`EndpointBehaviorStructure` nil deref, over-limit segment count, empty list, garbage `Any`) so malformed advertisements no longer crash the agent. Plain bug fixes.
   - **Implementation-constraint rejects.** `SegmentTypeA` (SR-MPLS) presence and cross-list trailing-behavior disagreement are *not* RFC-forbidden. They are rejected because Calico-VPP's install layer is built around one Behavior per BSID and a single VPP `sr_policy` entry per BSID; the advertised semantics cannot be represented in that model, and silently coercing them (skip Type-A / pick a "winner" behavior) would diverge installed from advertised. The error wording frames it as an agent-side constraint so the controller-side fix (split into per-Behavior BSIDs) is clear.

2. **`BGPPeer.TTLSecurity` propagation** (`calico-vpp-agent/watchers/peers_watcher.go`). Not an RFC violation -- the Calico CR field exists for GTSM (RFC 5082), but the agent never bridges it into `gobgp.TtlSecurity`. VPP's host-eth0 ↔ tap L3 hop consumes the eBGP default TTL=1 (RFC 4271), so external eBGP peers loop on hold-timer-expired until this is bridged. 5-line fix; could be carved into its own PR but kept here because (1) is not testable without it.

## Changes

### `calico-vpp-agent/routing/bgp_watcher.go`

Two helpers added:

- `walkSRPolicyInnerTLVs(path, fn)`: walks `Path.Pattrs → TunnelEncapAttribute.Tlvs → Tlv.Tlvs`. `path.Pattrs` is heterogeneous, so `UnmarshalTo(TunnelEncapAttribute)` failures are expected (not decode bugs) and are silent-skipped.
- `parseSegmentList(stlv, srnrli) → (types.Srv6SidList, *SegmentTypeB, error)`: per-list parse + validation, returns the trailing `SegmentTypeB` so the caller can read the `EndpointBehaviorStructure`.

`parseSegmentList` rejects (instead of panicking on): empty list, list whose `SegmentTypeB` count > VPP's 16-SID limit, trailing `SegmentTypeB` with nil `EndpointBehaviorStructure`. A list containing `SegmentTypeA` is rejected as a whole list with a distinct error message so operators can distinguish "advertiser sent SR-MPLS we cannot install" from "malformed protobuf at index N".

`getSRPolicy()` is rewritten into a two-level walk and returns `types.SrPolicy.SidLists` with the advertised list count intact.

**Choosing `srv6tunnel.Behavior`.** VPP keeps one Behavior per BSID; the agent uses `srv6tunnel.Behavior` in `connectivity/srv6.go: getPolicyNode` to match a policy against the destination pod prefix family; VPP installs all Segment Lists under one `sr_policy` and ECMP/weight load-balances. Accepting a multi-list policy whose trailing behaviors disagree (e.g. `END_DT4` and `END_DT6`) would install both lists under one BSID, and any packet hashed onto the wrong-behavior list is dropped or mis-decapped at the egress. The PR rejects at receive time and dispatches `SRv6PolicyDeleted` on the existing event bus so any previously-installed policy under the same endpoint follows the same teardown path as a normal withdraw (downstream `SRv6Provider.DelConnectivity` is a pre-existing no-op tracked separately; the event-bus signal here is correct for when that lands).

### `calico-vpp-agent/watchers/peers_watcher.go`

```go
if peerSpec.TTLSecurity != nil && *peerSpec.TTLSecurity > 0 {
    peer.TtlSecurity = &bgpapi.TtlSecurity{
        Enabled: true,
        TtlMin:  uint32(255 - *peerSpec.TTLSecurity),
    }
}
```

Propagates `BGPPeerSpec.TTLSecurity` (GTSM, RFC 5082) into gobgp so external eBGP peers can come up across VPP's extra L3 hop.

### `vpplink/srv6.go`

`AddSRv6Policy` extended for multiple Segment Lists: empty `SidLists` / zero `Bsid` rejected up front, first list via `SrPolicyAdd`, the rest via `SrPolicyMod{Operation: SR_POLICY_OP_API_ADD}`, with a `SrPolicyDel` rollback on intermediate failure so partial state is not left behind. Rollback error message reports 1-based `listIdx/total`.

`sr_policy_add`'s top-level `weight` and `vl_api_srv6_sid_list_t.weight` are wire-format duplicates of the same per-list weight (top-level is authoritative server-side); both are set so the on-wire encoding stays consistent.

## Design decisions

- **Malformed or unsupported-for-this-dataplane input** (no SegmentType decode succeeds / required EBS missing / over the 16-SID VPP compile-time limit / empty list) → reject whole SR Policy.
- **Known-but-uninstallable segment type** (`SegmentTypeA`) → reject list with a distinct error. Priority is "never install a SID chain different from advertised"; skipping Type-A and keeping Type-B would change forwarding behavior.
- **Cross-list trailing-behavior disagreement** → reject whole Policy (implementation-constraint, not RFC-forbidden). Plus dispatch `SRv6PolicyDeleted` for the endpoint so any previous install is signalled for teardown.

## Verification

### Build / static check

- `make build` (`vpplink`, `calico-vpp-agent`) succeeds
- `go vet ./calico-vpp-agent/... ./vpplink/...` clean
- `gofmt -l` clean
- Unit tests added in `calico-vpp-agent/routing/bgp_watcher_test.go`, cross-compiles with `CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go test -c`:
  - `parseSegmentList`: empty list, >16 SIDs, garbage `Any`, Type-A mixed, Type-A only, trailing EBS nil, weight preserve / weight defaults
  - `walkSRPolicyInnerTLVs`: non-TunnelEncap `pattr` silent-skipped, fn-error propagation

### Live cluster

IPv6 single-stack Kubernetes v1.36.1, AlmaLinux 10, kernel 6.12, cri-o 1.32.1, 1 master + 2 workers. External gobgpd VM (`bgp-ctrl`) connected as eBGP peer, injecting SR Policy NLRI (AFI 2 SAFI 73) on the wire.

**Before** (panic + TTL issue both present):

```text
panic: runtime error: index out of range [-1]
github.com/.../routing.(*Server).getSRPolicy
    .../bgp_watcher.go:203
github.com/.../routing.(*Server).injectSRv6Policy
    .../bgp_watcher.go:210

$ kubectl -n calico-vpp-dataplane get pods
calico-vpp-node-v2zb4   1/2   CrashLoopBackOff   872
calico-vpp-node-smtlt   1/2   CrashLoopBackOff   868

$ kubectl ... exec -- gobgp neighbor 192.168.1.13
192.168.1.13 64513 Active |0  0       # hold-timer expired loop
```

**After** (this PR):

```text
$ for n in master worker-1 worker-2; do
    kubectl ... logs $POD -c agent | grep -cE "panic|index out of range"
  done
0 0 0

$ kubectl ... gobgp neighbor
192.168.1.11 64512 Establ |3  3
192.168.1.12 64512 Establ |3  3
192.168.1.13 64513 Establ |1  1
```

**Parser side, multi-list received without panic.** An SR Policy NLRI carrying two `TunnelEncapSubTLVSRSegmentList` entries was injected from bgp-ctrl. All three nodes parsed it and stored `len(SidLists) == 2` in their per-endpoint policy registry without panicking. Agent log:

```text
SRv6Provider new policy cafe::beef with behavior 18 on node fd00:1::11 and priority 0
```

**VPP install + dataplane**, verified on a separate single-Segment-List policy (`cafe::18b`) because the multi-list `cafe::beef` did not match an outbound pod prefix in this run. Triggered by a pod prefix outside `localSidIPPool` (`default-ipv6-ippool` / `fd20::/64`):

```text
$ vppctl show sr policies
[0].- BSID: cafe::18b   Behavior: Encapsulation   EncapSrcIP: fd00:1::12
      Segment Lists:
        [0].- < fcff::11aa:f136:797:4082:31aa > weight: 12

$ vppctl show sr steering-policies
L3 fd20::f136:797:4082:3180/128  cafe::18b
L3 fd20::f136:797:4082:3180/122  cafe::18b

$ kubectl exec te-src -- ping6 -c 5 fd20::f136:797:4082:3182
5 packets transmitted, 5 packets received, 0% packet loss
```

A multi-list `vppctl show sr policies` capture (where `[1].-` is also printed) is on the follow-up list under the interop tests below.

## Compatibility

- Existing BGP UPDATEs with a single `TunnelEncapSubTLVSRSegmentList`: `getSRPolicy` returns `SidLists` of length 1, downstream behavior unchanged (`SrPolicyAdd` only, `SrPolicyMod` never reached).
- VPP already supports `SrPolicyMod { Operation: SR_POLICY_OP_API_ADD }`; no VPP-side patch needed.
- Behavior changes from the previous lenient parser:
  - Trailing EBS missing: old → downstream nil deref panic; new → per-list reject.
  - `SegmentTypeA` in a list: old → silently skipped, only Type-B installed (installed chain ≠ advertised); new → list reject with distinct wording.
  - Cross-list trailing-behavior disagreement: old → walk-order last value silently used (ECMP can land packets on a wrong-behavior list); new → receive-time reject + `SRv6PolicyDeleted` dispatched.
  - Peers without `BGPPeer.TTLSecurity` configured are unaffected (gobgp default `TtlSecurity` disabled).

## Follow-up work

1. Implement `SRv6Provider.DelConnectivity` so normal withdraws and the reject-as-withdraw path can actually remove VPP state.
2. Add more SR Policy interop tests with external GoBGP / FRR controllers (including a multi-list install capture with `[1].-` present in `vppctl show sr policies`).
