### PR TITLE
fix(peers-watcher): propagate BGPPeer.TTLSecurity to gobgp for GTSM

### DIFF
--- a/calico-vpp-agent/watchers/peers_watcher.go
+++ b/calico-vpp-agent/watchers/peers_watcher.go
@@ -448,6 +448,15 @@ func (w *PeerWatcher) createBGPPeer(ip string, asn uint32, peerSpec *calicov3.BG
 		AfiSafis: afiSafis,
 	}
 
+	// GTSM (RFC 5082): outbound TTL=255 and inbound >= 255-N.
+	// Needed for external eBGP peers across VPP's host-eth0 ↔ tap L3 hop.
+	if peerSpec.TTLSecurity != nil && *peerSpec.TTLSecurity > 0 {
+		peer.TtlSecurity = &bgpapi.TtlSecurity{
+			Enabled: true,
+			TtlMin:  uint32(255 - *peerSpec.TTLSecurity),
+		}
+	}
+
 	if w.getSecretKeyRef(peerSpec) != nil {
 		peer.Conf.AuthPassword, err = w.getPassword(peerSpec.Password.SecretKeyRef)
 		if err != nil {


### PR DESCRIPTION
## Summary

Bridge `BGPPeerSpec.TTLSecurity` into gobgp so GTSM (RFC 5082) actually takes effect on Calico-VPP. Setting `TTLSecurity` on a `BGPPeer` CR currently has no effect because `calico-vpp-agent` never forwards the field into gobgp -- the resulting eBGP session still uses the RFC 4271 default TTL=1 in both directions.

## Why this matters on Calico-VPP

VPP performs L3 routing between the host-eth0 uplink and the tap interface that carries the agent's BGP traffic. The extra hop consumes the eBGP default TTL=1, so any external eBGP peer one hop away from a Calico-VPP node stays in a hold-timer-expired loop until GTSM is enabled.

```text
$ kubectl ... gobgp neighbor 192.168.1.13      # before
192.168.1.13 64513 Active |0  0                # hold-timer expired loop
```

## Fix

`calico-vpp-agent/watchers/peers_watcher.go`:

```go
if peerSpec.TTLSecurity != nil && *peerSpec.TTLSecurity > 0 {
    peer.TtlSecurity = &bgpapi.TtlSecurity{
        Enabled: true,
        TtlMin:  uint32(255 - *peerSpec.TTLSecurity),
    }
}
```

gobgp now sends BGP packets with TTL=255 and accepts inbound packets with TTL ≥ 255 - N, so the session comes up across VPP's extra L3 hop.

```text
$ kubectl ... gobgp neighbor 192.168.1.13      # after
192.168.1.13 64513 Establ |1  1
```

## Compatibility

Peers without `BGPPeer.TTLSecurity` configured are unaffected -- gobgp's default `TtlSecurity` stays disabled.
