### PR TITLE
routerwatcher: provide link index to netlink

### DIFF
--- a/calico-vpp-agent/watchers/uplink_route_watcher.go
+++ b/calico-vpp-agent/watchers/uplink_route_watcher.go
@@ -168,6 +168,10 @@ func (r *RouteWatcher) getNetworkRoute(network string, physicalNet string) (rout
 				Protocol: syscall.RTPROT_STATIC,
 				MTU:      GetUplinkMtu(),
 				Priority: priority,
+				// Provide LinkIndex to ensure that we do add the route to the tap
+				// created by VPP and not another interface, e.g. in the case where
+				// VPP has stopped
+				LinkIndex: uplinkStatus.LinkIndex,
 			})
 		}
 	}
@@ -202,6 +206,10 @@ func (r *RouteWatcher) WatchRoutes(t *tomb.Tomb) error {
 				Protocol: syscall.RTPROT_STATIC,
 				MTU:      GetUplinkMtu(),
 				Priority: priority,
+				// Provide LinkIndex to ensure that we do add the route to the tap
+				// created by VPP and not another interface, e.g. in the case where
+				// VPP has stopped
+				LinkIndex: uplinkStatus.LinkIndex,
 			})
 			if err != nil {
 				r.log.Error(err, "cannot add route through vpp tap for service CIDR: %s", serviceCIDR.String())


### PR DESCRIPTION
This patch passes the link index to the route we craft for ippools we need to route through the cluster.

This makes sure that the route is added for the tap created by VPP and not the uplink in the event where VPP has restared.

Guarantee is provided by the fact that the kernel does not immediately reuse link indexes, and that they are scoped by netns. We should thus see only the uplinks and the taps in the main netns, and have no risk of conflict between uplink and tap.