### PR TITLE
agent: set cnat snat addresses before allowing other servers to run.

### DIFF
--- a/calico-vpp-agent/felix/felix_server.go
+++ b/calico-vpp-agent/felix/felix_server.go
@@ -1195,10 +1195,6 @@ func (s *Server) handleHostMetadataV4V6Update(msg *proto.HostMetadataV4V6Update,
 
 	if localNodeSpec.Name == *config.NodeName &&
 		(localNodeSpec.IPv4Address != nil || localNodeSpec.IPv6Address != nil) {
-		/* We found a BGP Spec that seems valid enough */
-		s.GotOurNodeBGPchanOnce.Do(func() {
-			s.GotOurNodeBGPchan <- localNodeSpec
-		})
 		ip4 := net.IP{}
 		ip6 := net.IP{}
 		if localNodeSpec.IPv4Address != nil {
@@ -1213,6 +1209,10 @@ func (s *Server) handleHostMetadataV4V6Update(msg *proto.HostMetadataV4V6Update,
 		if err != nil {
 			s.log.Errorf("Failed to configure SNAT addresses %v", err)
 		}
+		/* We found a BGP Spec that seems valid enough */
+		s.GotOurNodeBGPchanOnce.Do(func() {
+			s.GotOurNodeBGPchan <- localNodeSpec
+		})
 
 		err = s.createAllowFromHostPolicy()
 		if err != nil {


### PR DESCRIPTION
We saw a bug where we are trying to exclude a prefix before setting cnatsnat entries, which results in NULL entry dereference.

We should have called cnatSetSnat before, which is something we do in handleHostMetadataV4V6Update: where wee send s.GotOurNodeBGPchan <- localNodeSpec before calling s.vpp.CnatSetSnatAddresses(ip4, ip6), so we allowGo(serviceServer.ServeService) & co to run, before setting the cnat snat entry.

The fix is to call cnatSetSnatAddresses before seding the s.GotOurNodeBGPchan signal.