### PR TITLE
fix(srv6): steer pod-to-node service traffic through End.DT6 SID

### DIFF
--- a/calico-vpp-agent/connectivity/srv6.go
+++ b/calico-vpp-agent/connectivity/srv6.go
@@ -94,12 +94,12 @@ func (p *SRv6Provider) RescanState() {
 
 }
 
-func (p *SRv6Provider) CreateSRv6Tunnnel(dst net.IP, prefixDst ip_types.Prefix, policyTunnel *types.SrPolicy) (err error) {
-	p.log.Infof("SRv6Provider CreateSRv6Tunnnel")
+func (p *SRv6Provider) CreateSRv6Tunnel(dst net.IP, prefixDst ip_types.Prefix, policyTunnel *types.SrPolicy) (err error) {
+	p.log.Infof("SRv6Provider CreateSRv6Tunnel")
 
 	err = p.vpp.AddModSRv6Policy(policyTunnel)
 	if err != nil {
-		p.log.Errorf("SRv6Provider CreateSRv6Tunnnel AddSRv6Policy %s", err)
+		p.log.Errorf("SRv6Provider CreateSRv6Tunnel AddSRv6Policy %s", err)
 
 	}
 	srSteer := &types.SrSteer{
@@ -115,11 +115,40 @@ func (p *SRv6Provider) CreateSRv6Tunnnel(dst net.IP, prefixDst ip_types.Prefix, 
 	err = p.vpp.AddSRv6Steering(srSteer)
 
 	if err != nil {
-		p.log.Errorf("SRv6Provider CreateSRv6Tunnnel AddSRv6Steering %s", err)
+		p.log.Errorf("SRv6Provider CreateSRv6Tunnel AddSRv6Steering %s", err)
 
 	}
 
 	return err
+}
+
+// steerNodeIPViaSID steers pod traffic to a remote node's own IP onto that node's
+// End.DT6 SID (in PodVRFIndex) so host-network backed ClusterIPs work under SRv6.
+func (p *SRv6Provider) steerNodeIPViaSID(nodeip string) {
+	nodeIP := net.ParseIP(nodeip)
+	if nodeIP == nil || !vpplink.IsIP6(nodeIP) {
+		return // IPv6 only; IPv4 node IPs would need End.DT4
+	}
+	policy, err := p.getPolicyNode(nodeip, types.SrBehaviorDT6)
+	if err != nil || policy == nil {
+		p.log.Debugf("SRv6Provider steerNodeIPViaSID: no DT6 policy for %s yet, will retry later", nodeip)
+		return
+	}
+	prefix, err := ip_types.ParsePrefix(nodeIP.String() + "/128")
+	if err != nil {
+		p.log.Errorf("SRv6Provider steerNodeIPViaSID parse prefix %s: %v", nodeip, err)
+		return
+	}
+	// policy is already installed by CreateSRv6Tunnel; only add the steering.
+	srSteer := &types.SrSteer{
+		TrafficType: types.SrSteerIPv6,
+		FibTable:    common.PodVRFIndex,
+		Prefix:      prefix,
+		Bsid:        policy.Bsid,
+	}
+	if err := p.vpp.AddSRv6Steering(srSteer); err != nil {
+		p.log.Errorf("SRv6Provider steerNodeIPViaSID AddSRv6Steering node=%s prefix=%s: %v", nodeip, prefix.String(), err)
+	}
 }
 
 // AddConnectivity creates dynamic parts of SRv6 tunnel leading to node that we are adding connectivity to.
@@ -218,12 +247,16 @@ func (p *SRv6Provider) AddConnectivity(cn *common.NodeConnectivity) (err error) 
 
 			policy, err := p.getPolicyNode(nodeip, prefixBehavior)
 			if err == nil && policy != nil {
-				if err := p.CreateSRv6Tunnnel(p.nodePrefixes[nodeip].Node, prefix, policy); err != nil {
+				if err := p.CreateSRv6Tunnel(p.nodePrefixes[nodeip].Node, prefix, policy); err != nil {
 					p.log.Error(err)
 				}
 			}
 
 		}
+
+		// Bring the host plane onto SRv6 too: steer pod traffic to this node's
+		// IP via its End.DT6 SID so host-network backed ClusterIPs work.
+		p.steerNodeIPViaSID(nodeip)
 	}
 
 	return err


### PR DESCRIPTION
## Summary

In an IPv6 single-stack + SRv6 setup, once SRv6 is actually active (the `localsid`/policy pools are marked `allowedUses: [Tunnel]` so Pods are allocated from the default pool), host-network-backed ClusterIP Services break.

A concrete example is a Pod on one node accessing the `kubernetes` Service:

```text
fd30::1 -> apiserver node IP fd00:1::10
```

The packet is dropped on the backend node. Pod-backed ClusterIP Services are unaffected.

## Root cause

For a host-network-backed Service, cnat DNATs the Service VIP to a node IP. That node IP is directly connected in the uplink subnet, so the packet bypasses SRv6 and is forwarded over the uplink as plain IPv6.

At the same time, cnat excludes node-IP destinations from SNAT, so the Pod source address is preserved.

On the receiving node, that Pod prefix is only reachable through the SRv6 overlay. As a result, a Pod-sourced packet arriving unencapsulated from the uplink fails the source/reverse-path lookup and is dropped (`ip6 source lookup miss`).

Pod-backed Services do not hit this path because the backend is a Pod address; its FIB resolution is an SRv6 tunnel, so traffic stays symmetric.

## Fix

Steer Pod-originated traffic destined to a remote node's own IPv6 address (`/128`) through that node's already-advertised End.DT6 SID. This adds `steerNodeIPViaSID` in `AddConnectivity`.

- The steering entry is installed in `PodVRFIndex`, so node-to-node control traffic in the main table is unaffected.
- It reuses the remote node's existing End.DT6 local SID (created by `setEndDT` with FibTable 0); no new dataplane primitive is required.
- The Pod source identity is preserved; no SNAT is needed.

The resulting path is:

```text
pod source preserved
  -> SRv6 encap toward the remote node's End.DT6 SID
  -> remote node decapsulates
  -> lookup in table 0
  -> delivered to the host-network backend
```

The DT6 policy is already installed in VPP by the `CreateSRv6Tunnel` pass over the node's Pod prefixes, so this change only adds the steering entry and does not re-add the policy. This avoids churn of a live policy shared with the Pod-prefix steering, since `AddModSRv6Policy` is delete-then-add.

## Notes

- IPv4 node IPs / DT4 are out of scope for this PR. Dual-stack support would need the corresponding End.DT4 and `SrSteerIPv4` handling.
- Explicit teardown of this node-IP steering is not implemented here because `DelConnectivity` is currently a no-op, matching the existing limitation for Pod-prefix steering. Once #1025 lands, this steering should be removed from the same teardown path.
