### PR TITLE
watchers: fix route matching to include LinkIndex and Priority

### DIFF
--- a/calico-vpp-agent/watchers/uplink_route_watcher.go
+++ b/calico-vpp-agent/watchers/uplink_route_watcher.go
@@ -81,7 +81,9 @@ func (r *RouteWatcher) DelRoute(route *netlink.Route) (err error) {
 		return err
 	}
 	for i, watched := range r.routes {
-		if watched.Dst.String() == route.Dst.String() {
+		if watched.Dst.String() == route.Dst.String() &&
+			watched.LinkIndex == route.LinkIndex &&
+			watched.Priority == route.Priority {
 			r.routes[i] = r.routes[len(r.routes)-1]
 			r.routes = r.routes[:len(r.routes)-1]
 			break
@@ -334,7 +336,9 @@ func (r *RouteWatcher) WatchRoutes(t *tomb.Tomb) error {
 				if update.Type == syscall.RTM_DELROUTE {
 					for _, route := range r.routes {
 						// See if it is one of our routes
-						if update.Dst != nil && update.Dst.String() == route.Dst.String() {
+						if update.Dst != nil && update.Dst.String() == route.Dst.String() &&
+							update.LinkIndex == route.LinkIndex &&
+							update.Priority == route.Priority {
 							r.log.Infof("Re-adding route %+v", route)
 							err = netlink.RouteReplace(&route)
 							if err != nil {


### PR DESCRIPTION
With multi-uplink configurations on the same physical network, the route watcher creates multiple routes with **identical destination prefix** but **different** `LinkIndex` and `Priority`.
`DelRoute()` and `RTM_DELROUTE` handler matched routes only by `Dst`, ignoring `LinkIndex` and `Priority`.
- `DelRoute`: Matched only by `Dst.String()`, removing the first matching entry from `r.routes` regardless of which uplink's route was actually deleted from netlink.
- `RTM_DELROUTE` handler: Matched only by `Dst.String()`, re-adding the first matching route from `r.routes` even if a different uplink's route was deleted.
 
Updated both locations to match by **`Dst`, `LinkIndex`, and `Priority`**.