### PR TITLE
upgrade vpp addressing buffer-stats-api conflict

### DIFF
--- a/vpplink/generated/bindings/classify/classify.ba.go
+++ b/vpplink/generated/bindings/classify/classify.ba.go
@@ -35,6 +35,7 @@ const (
 	CLASSIFY_API_ACTION_SET_IP4_FIB_INDEX ClassifyAction = 1
 	CLASSIFY_API_ACTION_SET_IP6_FIB_INDEX ClassifyAction = 2
 	CLASSIFY_API_ACTION_SET_METADATA      ClassifyAction = 3
+	CLASSIFY_API_ACTION_MARK_FLOW         ClassifyAction = 4
 )
 
 var (
@@ -43,12 +44,14 @@ var (
 		1: "CLASSIFY_API_ACTION_SET_IP4_FIB_INDEX",
 		2: "CLASSIFY_API_ACTION_SET_IP6_FIB_INDEX",
 		3: "CLASSIFY_API_ACTION_SET_METADATA",
+		4: "CLASSIFY_API_ACTION_MARK_FLOW",
 	}
 	ClassifyAction_value = map[string]uint8{
 		"CLASSIFY_API_ACTION_NONE":              0,
 		"CLASSIFY_API_ACTION_SET_IP4_FIB_INDEX": 1,
 		"CLASSIFY_API_ACTION_SET_IP6_FIB_INDEX": 2,
 		"CLASSIFY_API_ACTION_SET_METADATA":      3,
+		"CLASSIFY_API_ACTION_MARK_FLOW":         4,
 	}
 )
 
@@ -139,6 +142,7 @@ func (x PolicerClassifyTable) String() string {
 //   - metadata - valid only if action != 0
 //     VRF id if action is 1 or 2.
 //     sr policy index if action is 3.
+//     global tm flow id if action is 4.
 //   - match_len - length of match, should be equal to skip_n_vectors plus match_n_vectors
 //     of target table times sizeof (u32x4)
 //   - match - for add, match value for session, required,

--- a/vpplink/generated/bindings/cnat/cnat.ba.go
+++ b/vpplink/generated/bindings/cnat/cnat.ba.go
@@ -29,7 +29,7 @@ const _ = api.GoVppAPIPackageIsVersion2
 
 const (
 	APIFile    = "cnat"
-	APIVersion = "0.3.0"
+	APIVersion = "1.0.0"
 	VersionCrc = 0xc121e90a
 )
 

--- a/vpplink/generated/bindings/interface/interface.ba.go
+++ b/vpplink/generated/bindings/interface/interface.ba.go
@@ -3,7 +3,7 @@
 // Package interfaces contains generated bindings for API file interface.api.
 //
 // Contents:
-// - 78 messages
+// - 82 messages
 package interfaces
 
 import (
@@ -22,8 +22,8 @@ const _ = api.GoVppAPIPackageIsVersion2
 
 const (
 	APIFile    = "interface"
-	APIVersion = "3.2.4"
-	VersionCrc = 0x6bc9fe33
+	APIVersion = "3.2.5"
+	VersionCrc = 0x89001687
 )
 
 // Enable or disable detailed interface stats
@@ -1862,6 +1862,99 @@ func (m *SwInterfaceGetMacAddressReply) Unmarshal(b []byte) error {
 	return nil
 }
 
+// Get interface speed capabilities
+//   - sw_if_index - index of the interface
+//
+// SwInterfaceGetSpeedCapa defines message 'sw_interface_get_speed_capa'.
+type SwInterfaceGetSpeedCapa struct {
+	SwIfIndex interface_types.InterfaceIndex `binapi:"interface_index,name=sw_if_index" json:"sw_if_index,omitempty"`
+}
+
+func (m *SwInterfaceGetSpeedCapa) Reset()               { *m = SwInterfaceGetSpeedCapa{} }
+func (*SwInterfaceGetSpeedCapa) GetMessageName() string { return "sw_interface_get_speed_capa" }
+func (*SwInterfaceGetSpeedCapa) GetCrcString() string   { return "f9e6675e" }
+func (*SwInterfaceGetSpeedCapa) GetMessageType() api.MessageType {
+	return api.RequestMessage
+}
+
+func (m *SwInterfaceGetSpeedCapa) Size() (size int) {
+	if m == nil {
+		return 0
+	}
+	size += 4 // m.SwIfIndex
+	return size
+}
+func (m *SwInterfaceGetSpeedCapa) Marshal(b []byte) ([]byte, error) {
+	if b == nil {
+		b = make([]byte, m.Size())
+	}
+	buf := codec.NewBuffer(b)
+	buf.EncodeUint32(uint32(m.SwIfIndex))
+	return buf.Bytes(), nil
+}
+func (m *SwInterfaceGetSpeedCapa) Unmarshal(b []byte) error {
+	buf := codec.NewBuffer(b)
+	m.SwIfIndex = interface_types.InterfaceIndex(buf.DecodeUint32())
+	return nil
+}
+
+// Reply for sw_interface_get_speed_capa
+//   - retval - return value
+//   - count - number of supported speeds
+//   - speeds - supported speeds in Kbps
+//
+// SwInterfaceGetSpeedCapaReply defines message 'sw_interface_get_speed_capa_reply'.
+type SwInterfaceGetSpeedCapaReply struct {
+	Retval int32    `binapi:"i32,name=retval" json:"retval,omitempty"`
+	Count  uint32   `binapi:"u32,name=count" json:"-"`
+	Speeds []uint32 `binapi:"u32[count],name=speeds" json:"speeds,omitempty"`
+}
+
+func (m *SwInterfaceGetSpeedCapaReply) Reset() { *m = SwInterfaceGetSpeedCapaReply{} }
+func (*SwInterfaceGetSpeedCapaReply) GetMessageName() string {
+	return "sw_interface_get_speed_capa_reply"
+}
+func (*SwInterfaceGetSpeedCapaReply) GetCrcString() string { return "20b21417" }
+func (*SwInterfaceGetSpeedCapaReply) GetMessageType() api.MessageType {
+	return api.ReplyMessage
+}
+
+func (m *SwInterfaceGetSpeedCapaReply) Size() (size int) {
+	if m == nil {
+		return 0
+	}
+	size += 4                 // m.Retval
+	size += 4                 // m.Count
+	size += 4 * len(m.Speeds) // m.Speeds
+	return size
+}
+func (m *SwInterfaceGetSpeedCapaReply) Marshal(b []byte) ([]byte, error) {
+	if b == nil {
+		b = make([]byte, m.Size())
+	}
+	buf := codec.NewBuffer(b)
+	buf.EncodeInt32(m.Retval)
+	buf.EncodeUint32(uint32(len(m.Speeds)))
+	for i := 0; i < len(m.Speeds); i++ {
+		var x uint32
+		if i < len(m.Speeds) {
+			x = uint32(m.Speeds[i])
+		}
+		buf.EncodeUint32(x)
+	}
+	return buf.Bytes(), nil
+}
+func (m *SwInterfaceGetSpeedCapaReply) Unmarshal(b []byte) error {
+	buf := codec.NewBuffer(b)
+	m.Retval = buf.DecodeInt32()
+	m.Count = buf.DecodeUint32()
+	m.Speeds = make([]uint32, m.Count)
+	for i := 0; i < len(m.Speeds); i++ {
+		m.Speeds[i] = buf.DecodeUint32()
+	}
+	return nil
+}
+
 // Get VRF id assigned to interface
 //   - sw_if_index - index of the interface
 //
@@ -2347,6 +2440,82 @@ func (m *SwInterfaceSetIPDirectedBroadcastReply) Marshal(b []byte) ([]byte, erro
 	return buf.Bytes(), nil
 }
 func (m *SwInterfaceSetIPDirectedBroadcastReply) Unmarshal(b []byte) error {
+	buf := codec.NewBuffer(b)
+	m.Retval = buf.DecodeInt32()
+	return nil
+}
+
+// Set interface link speed (override)
+//   - sw_if_index - index of the interface
+//   - link_speed - link speed in Kbps (0 means unknown / auto)
+//
+// SwInterfaceSetLinkSpeed defines message 'sw_interface_set_link_speed'.
+type SwInterfaceSetLinkSpeed struct {
+	SwIfIndex interface_types.InterfaceIndex `binapi:"interface_index,name=sw_if_index" json:"sw_if_index,omitempty"`
+	LinkSpeed uint32                         `binapi:"u32,name=link_speed" json:"link_speed,omitempty"`
+}
+
+func (m *SwInterfaceSetLinkSpeed) Reset()               { *m = SwInterfaceSetLinkSpeed{} }
+func (*SwInterfaceSetLinkSpeed) GetMessageName() string { return "sw_interface_set_link_speed" }
+func (*SwInterfaceSetLinkSpeed) GetCrcString() string   { return "2f0867fa" }
+func (*SwInterfaceSetLinkSpeed) GetMessageType() api.MessageType {
+	return api.RequestMessage
+}
+
+func (m *SwInterfaceSetLinkSpeed) Size() (size int) {
+	if m == nil {
+		return 0
+	}
+	size += 4 // m.SwIfIndex
+	size += 4 // m.LinkSpeed
+	return size
+}
+func (m *SwInterfaceSetLinkSpeed) Marshal(b []byte) ([]byte, error) {
+	if b == nil {
+		b = make([]byte, m.Size())
+	}
+	buf := codec.NewBuffer(b)
+	buf.EncodeUint32(uint32(m.SwIfIndex))
+	buf.EncodeUint32(m.LinkSpeed)
+	return buf.Bytes(), nil
+}
+func (m *SwInterfaceSetLinkSpeed) Unmarshal(b []byte) error {
+	buf := codec.NewBuffer(b)
+	m.SwIfIndex = interface_types.InterfaceIndex(buf.DecodeUint32())
+	m.LinkSpeed = buf.DecodeUint32()
+	return nil
+}
+
+// SwInterfaceSetLinkSpeedReply defines message 'sw_interface_set_link_speed_reply'.
+type SwInterfaceSetLinkSpeedReply struct {
+	Retval int32 `binapi:"i32,name=retval" json:"retval,omitempty"`
+}
+
+func (m *SwInterfaceSetLinkSpeedReply) Reset() { *m = SwInterfaceSetLinkSpeedReply{} }
+func (*SwInterfaceSetLinkSpeedReply) GetMessageName() string {
+	return "sw_interface_set_link_speed_reply"
+}
+func (*SwInterfaceSetLinkSpeedReply) GetCrcString() string { return "e8d4e804" }
+func (*SwInterfaceSetLinkSpeedReply) GetMessageType() api.MessageType {
+	return api.ReplyMessage
+}
+
+func (m *SwInterfaceSetLinkSpeedReply) Size() (size int) {
+	if m == nil {
+		return 0
+	}
+	size += 4 // m.Retval
+	return size
+}
+func (m *SwInterfaceSetLinkSpeedReply) Marshal(b []byte) ([]byte, error) {
+	if b == nil {
+		b = make([]byte, m.Size())
+	}
+	buf := codec.NewBuffer(b)
+	buf.EncodeInt32(m.Retval)
+	return buf.Bytes(), nil
+}
+func (m *SwInterfaceSetLinkSpeedReply) Unmarshal(b []byte) error {
 	buf := codec.NewBuffer(b)
 	m.Retval = buf.DecodeInt32()
 	return nil
@@ -3373,6 +3542,8 @@ func file_interfaces_binapi_init() {
 	api.RegisterMessage((*SwInterfaceGetDefaultRxModeReply)(nil), "sw_interface_get_default_rx_mode_reply_2339da5a")
 	api.RegisterMessage((*SwInterfaceGetMacAddress)(nil), "sw_interface_get_mac_address_f9e6675e")
 	api.RegisterMessage((*SwInterfaceGetMacAddressReply)(nil), "sw_interface_get_mac_address_reply_40ef2c08")
+	api.RegisterMessage((*SwInterfaceGetSpeedCapa)(nil), "sw_interface_get_speed_capa_f9e6675e")
+	api.RegisterMessage((*SwInterfaceGetSpeedCapaReply)(nil), "sw_interface_get_speed_capa_reply_20b21417")
 	api.RegisterMessage((*SwInterfaceGetTable)(nil), "sw_interface_get_table_2d033de4")
 	api.RegisterMessage((*SwInterfaceGetTableReply)(nil), "sw_interface_get_table_reply_a6eb0109")
 	api.RegisterMessage((*SwInterfaceRxPlacementDetails)(nil), "sw_interface_rx_placement_details_9e44a7ce")
@@ -3385,6 +3556,8 @@ func file_interfaces_binapi_init() {
 	api.RegisterMessage((*SwInterfaceSetInterfaceNameReply)(nil), "sw_interface_set_interface_name_reply_e8d4e804")
 	api.RegisterMessage((*SwInterfaceSetIPDirectedBroadcast)(nil), "sw_interface_set_ip_directed_broadcast_ae6cfcfb")
 	api.RegisterMessage((*SwInterfaceSetIPDirectedBroadcastReply)(nil), "sw_interface_set_ip_directed_broadcast_reply_e8d4e804")
+	api.RegisterMessage((*SwInterfaceSetLinkSpeed)(nil), "sw_interface_set_link_speed_2f0867fa")
+	api.RegisterMessage((*SwInterfaceSetLinkSpeedReply)(nil), "sw_interface_set_link_speed_reply_e8d4e804")
 	api.RegisterMessage((*SwInterfaceSetMacAddress)(nil), "sw_interface_set_mac_address_c536e7eb")
 	api.RegisterMessage((*SwInterfaceSetMacAddressReply)(nil), "sw_interface_set_mac_address_reply_e8d4e804")
 	api.RegisterMessage((*SwInterfaceSetMtu)(nil), "sw_interface_set_mtu_5cbe85e5")
@@ -3456,6 +3629,8 @@ func AllMessages() []api.Message {
 		(*SwInterfaceGetDefaultRxModeReply)(nil),
 		(*SwInterfaceGetMacAddress)(nil),
 		(*SwInterfaceGetMacAddressReply)(nil),
+		(*SwInterfaceGetSpeedCapa)(nil),
+		(*SwInterfaceGetSpeedCapaReply)(nil),
 		(*SwInterfaceGetTable)(nil),
 		(*SwInterfaceGetTableReply)(nil),
 		(*SwInterfaceRxPlacementDetails)(nil),
@@ -3468,6 +3643,8 @@ func AllMessages() []api.Message {
 		(*SwInterfaceSetInterfaceNameReply)(nil),
 		(*SwInterfaceSetIPDirectedBroadcast)(nil),
 		(*SwInterfaceSetIPDirectedBroadcastReply)(nil),
+		(*SwInterfaceSetLinkSpeed)(nil),
+		(*SwInterfaceSetLinkSpeedReply)(nil),
 		(*SwInterfaceSetMacAddress)(nil),
 		(*SwInterfaceSetMacAddressReply)(nil),
 		(*SwInterfaceSetMtu)(nil),

--- a/vpplink/generated/bindings/interface/interface_rpc.ba.go
+++ b/vpplink/generated/bindings/interface/interface_rpc.ba.go
@@ -34,12 +34,14 @@ type RPCService interface {
 	SwInterfaceDump(ctx context.Context, in *SwInterfaceDump) (RPCService_SwInterfaceDumpClient, error)
 	SwInterfaceGetDefaultRxMode(ctx context.Context, in *SwInterfaceGetDefaultRxMode) (*SwInterfaceGetDefaultRxModeReply, error)
 	SwInterfaceGetMacAddress(ctx context.Context, in *SwInterfaceGetMacAddress) (*SwInterfaceGetMacAddressReply, error)
+	SwInterfaceGetSpeedCapa(ctx context.Context, in *SwInterfaceGetSpeedCapa) (*SwInterfaceGetSpeedCapaReply, error)
 	SwInterfaceGetTable(ctx context.Context, in *SwInterfaceGetTable) (*SwInterfaceGetTableReply, error)
 	SwInterfaceRxPlacementDump(ctx context.Context, in *SwInterfaceRxPlacementDump) (RPCService_SwInterfaceRxPlacementDumpClient, error)
 	SwInterfaceSetDefaultRxMode(ctx context.Context, in *SwInterfaceSetDefaultRxMode) (*SwInterfaceSetDefaultRxModeReply, error)
 	SwInterfaceSetFlags(ctx context.Context, in *SwInterfaceSetFlags) (*SwInterfaceSetFlagsReply, error)
 	SwInterfaceSetInterfaceName(ctx context.Context, in *SwInterfaceSetInterfaceName) (*SwInterfaceSetInterfaceNameReply, error)
 	SwInterfaceSetIPDirectedBroadcast(ctx context.Context, in *SwInterfaceSetIPDirectedBroadcast) (*SwInterfaceSetIPDirectedBroadcastReply, error)
+	SwInterfaceSetLinkSpeed(ctx context.Context, in *SwInterfaceSetLinkSpeed) (*SwInterfaceSetLinkSpeedReply, error)
 	SwInterfaceSetMacAddress(ctx context.Context, in *SwInterfaceSetMacAddress) (*SwInterfaceSetMacAddressReply, error)
 	SwInterfaceSetMtu(ctx context.Context, in *SwInterfaceSetMtu) (*SwInterfaceSetMtuReply, error)
 	SwInterfaceSetPromisc(ctx context.Context, in *SwInterfaceSetPromisc) (*SwInterfaceSetPromiscReply, error)
@@ -284,6 +286,15 @@ func (c *serviceClient) SwInterfaceGetMacAddress(ctx context.Context, in *SwInte
 	return out, api.RetvalToVPPApiError(out.Retval)
 }
 
+func (c *serviceClient) SwInterfaceGetSpeedCapa(ctx context.Context, in *SwInterfaceGetSpeedCapa) (*SwInterfaceGetSpeedCapaReply, error) {
+	out := new(SwInterfaceGetSpeedCapaReply)
+	err := c.conn.Invoke(ctx, in, out)
+	if err != nil {
+		return nil, err
+	}
+	return out, api.RetvalToVPPApiError(out.Retval)
+}
+
 func (c *serviceClient) SwInterfaceGetTable(ctx context.Context, in *SwInterfaceGetTable) (*SwInterfaceGetTableReply, error) {
 	out := new(SwInterfaceGetTableReply)
 	err := c.conn.Invoke(ctx, in, out)
@@ -365,6 +376,15 @@ func (c *serviceClient) SwInterfaceSetInterfaceName(ctx context.Context, in *SwI
 
 func (c *serviceClient) SwInterfaceSetIPDirectedBroadcast(ctx context.Context, in *SwInterfaceSetIPDirectedBroadcast) (*SwInterfaceSetIPDirectedBroadcastReply, error) {
 	out := new(SwInterfaceSetIPDirectedBroadcastReply)
+	err := c.conn.Invoke(ctx, in, out)
+	if err != nil {
+		return nil, err
+	}
+	return out, api.RetvalToVPPApiError(out.Retval)
+}
+
+func (c *serviceClient) SwInterfaceSetLinkSpeed(ctx context.Context, in *SwInterfaceSetLinkSpeed) (*SwInterfaceSetLinkSpeedReply, error) {
+	out := new(SwInterfaceSetLinkSpeedReply)
 	err := c.conn.Invoke(ctx, in, out)
 	if err != nil {
 		return nil, err

--- a/vpplink/generated/bindings/npol/npol.ba.go
+++ b/vpplink/generated/bindings/npol/npol.ba.go
@@ -27,7 +27,7 @@ const _ = api.GoVppAPIPackageIsVersion2
 const (
 	APIFile    = "npol"
 	APIVersion = "0.1.0"
-	VersionCrc = 0x79451d1
+	VersionCrc = 0x4d281077
 )
 
 // NpolEntryType defines enum 'npol_entry_type'.

--- a/vpplink/generated/generate.log
+++ b/vpplink/generated/generate.log
@@ -1,7 +1,9 @@
-VPP Version                 : 26.06-rc0~589-gf6ca8f28f
+VPP Version                 : 26.10-rc0~41-gceefe07fd
 Binapi-generator version    : v0.11.0
-VPP Base commit             : 08c0922e9 gerrit:42343/2 vcl: LDP default to regular option
+VPP Base commit             : b8be30b39 af_xdp: cleanup fds and netns on error
 ------------------ Cherry picked commits --------------------
+calicovpp plugin:pbl
+calicovpp plugin:ip_ttl_fixup
 interface: add buffer stats api
 npol: add matched rule id to acl trace
 ip-neighbor: preserve interface LL receive DPO for self link-local
@@ -12,4 +14,88 @@ gerrit:45099/2 ip6-nd: add nd-proxy all dst
 gerrit:44903/1 vxlan: reset next_dpo on delete
 gerrit:44350/3 vnet: fix unicast NA handling in ND proxy
 gerrit:42343/2 vcl: LDP default to regular option
+hsa: http proxy client do tx event after connected
+soft-rss: add handoff queue full node error counter
+http: h3 tunnel half-close fix
+hsa: http cli event timeout improvement
+tests: skip discover tests in hs-test folder
+sfdp_services_sample: move sfdp samples to plugin
+vlib: fetch multiple fuse messages in vlib_fuse_read
+perftool: fix c2cpel
+tap: infer single queue from queue counts
+vnet: add set interface link speed API
+session: increase number of dgrams per dispatch
+http: improve error path hst coverage
+svm: Fix svm_msg_q_timedwait fractional timeout precision loss
+tcp: fix order of events on app shutdown sequence
+hs-test: add app-namespace VCL echo tests
+octeon: ensure 64KB alignment for BAR mappings
+sfdp: guard packet bit shifts in lookup
+lb: Allow setting weight on AS
+iavf: add L4 checksum offload on RX
+lb: API bugfix
+docs: update install from packagecloud for stable/2606
+dpdk: add Intel QAT 420xx series support
+snort: fix daq instance enumeration
+octeon: implement hardware traffic management
+tm: add 'mark_flow' action for traffic management
+hs-test: add connect-tcp fin drain tests
+hsa: preserve proxy tunnel half-close
+build: support compiler-known platforms
+dev: add rx queue assignment policy
+misc: Initial 26.10-rc0 commit
+tm: add tm framework for hw traffic management
+octeon: update octeon roc version
+sfdp: fix FIN with payload in l4-lifecycle
+build: populate VPPConfig.cmake with dirs and platform selection
+http: per-thread rx and tx buffers resizing fix
+http: h1 parse request line fix path len underflow
+hsa: builtin echo fix tls bidirectional test stuck
+hsa: builtin echo server stream rx do deq ntf
+http: h2 connect-tcp handling of tcp fin fix
+http: h2 always unschedule connection when closing
+ip: fix reassembly bugs, add extended SV reass CLI and tests
+ip: fix reassembly bugs and add tests
+tests: stream and harden log expansion to avoid OOM hang
+stats: stat_segment_ls_r() only return NULL on error
+stats: don't leak regcomp() allocated memory
+build: fix make install-*-deps breakage on ubuntu 26.04
+cnat: mark no_return sessions as done in writeback
+ping: set LOCALLY_ORIGINATED flag on cli-initiated ping packets.
+wireguard: use alg variant DPDK cryptodev handles
+hs-test: Http3ClientFailedConnectMWTest fix
+kube-test: update latest CalicoVPP release to v3.32.0
+vppinfra: support high NUMA node IDs in discovery
+build: Fix error message
+sfdp_services: add l4-lifecycle tests
+quic: quic quicly crypto decrypt pkt improvement
+quic: configurable respect_app_limited parameter
+http: http_decode_varint loop unrolling
+tcp: fix goal size computation
+session: fix ct fifo cleanup for failed connects
+tls: fix picotls crash paths
+sfdp: add tests helper class
+cnat: update api version
+policer: avoid redundant l2_overhead array access on TX path
+memif: fix free_slots underflow in TX
+ipsec: add bound check on pad length received in esp footer
+memif: add jumbo frames test and fix test_memif_ping
+crypto: fix ctx engine key data leak on re-key
+http: h3 do not use http_timer, quic has timer
+quic: allow app to set some settings via ext cfg
+http: h3 program tx evt after state machine loop
+hsa: fix vts ctrl session access after pool free
+pci: fix MSI IRQ disabling
+build: add platform cmake file for icelake-server
+iavf: fix REQUEST_QUEUES timeout and irq guards
+vcl: vcl sapi ignoring tls-engine config
+vppinfra: initialize vm map header before publishing it
+snort: add support for IPv6
+vppapigen: union endian generation
+quic: fix vnet_crypto key management, add tests
+http: h2 program tx evt directly in update_time_cb
+http: http3_conn_init pool grow fix
+cnat: make snat policy del paths re-entrant
+dpdk: enable MBUF_FAST_FREE TX offload when multi-seg is disabled
+af_xdp: cleanup fds and netns on error
 -------------------------------------------------------------

--- a/vpplink/generated/patches/0005-interface-add-buffer-stats-api.patch
+++ b/vpplink/generated/patches/0005-interface-add-buffer-stats-api.patch
@@ -1,12 +1,9 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: hedi bouattour <hedibouattour2010@gmail.com>
-Date: Fri, 10 Dec 2021 15:18:05 +0000
+From: Nathan Skrzypczak <nathan.skrzypczak@gmail.com>
+Date: Fri, 29 May 2026 16:33:09 +0200
 Subject: [PATCH 5/5] interface: add buffer stats api
 
-Type: fix
-
-Change-Id: I9c2c0b0a35884f0375b4f589841732ad9979fe6c
-Signed-off-by: hedi bouattour <hedibouattour2010@gmail.com>
+Signed-off-by: Nathan Skrzypczak <nathan.skrzypczak@gmail.com>
 ---
  src/vlib/buffer.c         | 14 ++++++++++++++
  src/vlib/buffer.h         |  9 +++++++++
@@ -61,11 +58,11 @@ index d6f62abd4..58b77981b 100644
  {
    CLIB_CACHE_LINE_ALIGN_MARK (cacheline0);
 diff --git a/src/vnet/interface.api b/src/vnet/interface.api
-index 470f72cac..e3cae68c3 100644
+index 5d780c476..d757ddc5b 100644
 --- a/src/vnet/interface.api
 +++ b/src/vnet/interface.api
-@@ -822,6 +822,27 @@ define sw_interface_get_default_rx_mode_reply
-   vl_api_rx_mode_t mode;
+@@ -862,6 +862,27 @@ define sw_interface_get_speed_capa_reply
+   u32 speeds[count];
  };
  
 +/** \brief Get available, cached and used buffers
@@ -93,12 +90,12 @@ index 470f72cac..e3cae68c3 100644
   * Local Variables:
   * eval: (c-set-style "gnu")
 diff --git a/src/vnet/interface_api.c b/src/vnet/interface_api.c
-index 7648b0410..9df3042f9 100644
+index 6718fb5c2..9667ed14d 100644
 --- a/src/vnet/interface_api.c
 +++ b/src/vnet/interface_api.c
-@@ -74,6 +74,23 @@ vpe_api_main_t vpe_api_main;
-   _ (SW_INTERFACE_ADDRESS_REPLACE_BEGIN, sw_interface_address_replace_begin)                       \
-   _ (SW_INTERFACE_ADDRESS_REPLACE_END, sw_interface_address_replace_end)
+@@ -76,6 +76,23 @@ vpe_api_main_t vpe_api_main;
+   _ (SW_INTERFACE_SET_LINK_SPEED, sw_interface_set_link_speed)                                     \
+   _ (SW_INTERFACE_GET_SPEED_CAPA, sw_interface_get_speed_capa)
  
 +static void
 +vl_api_get_buffers_stats_t_handler (vl_api_get_buffers_stats_t *mp)
@@ -121,7 +118,7 @@ index 7648b0410..9df3042f9 100644
  vl_api_sw_interface_set_flags_t_handler (vl_api_sw_interface_set_flags_t * mp)
  {
 diff --git a/src/vnet/interface_test.c b/src/vnet/interface_test.c
-index d37d4deee..0ada3e137 100644
+index afc508dec..d88265866 100644
 --- a/src/vnet/interface_test.c
 +++ b/src/vnet/interface_test.c
 @@ -33,6 +33,18 @@ typedef struct

--- a/vpplink/generated/vpp_clone_current.sh
+++ b/vpplink/generated/vpp_clone_current.sh
@@ -71,6 +71,8 @@ function copy_private_plugin ()
 	blue "Copying private plugin $name..."
 	rm -rf "src/plugins/$name"
 	cp -r "$SCRIPTDIR/private_plugins/$name" "src/plugins/$name"
+	git add "src/plugins/$name"
+	git commit -m "calicovpp plugin:$name"
 }
 
 
@@ -113,7 +115,7 @@ function git_clone_cd_and_reset ()
 # --------------- Things to cherry pick ---------------
 
 #
-BASE="${BASE:-"e84849bcdb70ce7b77e17e04575059856735da50"}"
+BASE="${BASE:-"2f04d5e7c49bb21d3055f1d798f9137d2a6ddb5d"}"
 if [ "$VPP_DIR" = "" ]; then
        VPP_DIR="$1"
 fi
@@ -128,12 +130,13 @@ git_cherry_pick refs/changes/99/45099/2 # 45099: ip6-nd: add nd-proxy all dst | 
 git_cherry_pick refs/changes/46/45046/4 # 45046: ip6-nd: add punt reason for neigh advs | https://gerrit.fd.io/r/c/vpp/+/45046
 
 # --------------- private patches/plugins ---------------
-# Patch files generated with 'git format-patch --zero-commit -o ./patches/ HEAD^^^'
+# Patch files generated with 'git format-patch --zero-commit -o ./patches/ HEAD^^^^^'
 git_apply_private 0001-cnat-WIP-no-k8s-maglev-from-pods.patch
 git_apply_private 0002-acl-acl-plugin-custom-policies.patch
 git_apply_private 0003-ip-neighbor-preserve-interface-LL-receive-DPO-for-se.patch
 git_apply_private 0004-npol-add-matched-rule-id-to-acl-trace.patch
 git_apply_private 0005-interface-add-buffer-stats-api.patch
+
 # VPP Private plugins:
 copy_private_plugin ip_ttl_fixup
 copy_private_plugin pbl


### PR DESCRIPTION
this patch upgrades vpp to the [0] commit hash.
This addresses a conflict in the private patch adding the buffer stats API [1]

The VPP diff contains 80 new patches
```
$ git lg e84849bc..2f04d5e7c4 | wc -l
80
```

[0] 2f04d5e7c49bb21d3055f1d798f9137d2a6ddb5d
[1] 0005-interface-add-buffer-stats-api.patch