### PR TITLE
agent: SpreadTxQueuesOnWorkers only if flag is on for tuntap

### DIFF
--- a/calico-vpp-agent/cni/podinterface/tuntap.go
+++ b/calico-vpp-agent/cni/podinterface/tuntap.go
@@ -169,11 +169,12 @@ func (i *TunTapPodInterfaceDriver) CreateInterface(podSpec *model.LocalPodSpec, 
 	} else {
 		stack.Push(i.vpp.DelTap, swIfIndex)
 	}
-	err = i.SpreadTxQueuesOnWorkers(swIfIndex, tun.NumTxQueues)
-	if err != nil {
-		return err
+	if *(*config.CalicoVppDebug).SpreadTxQueuesOnWorkers {
+		err = i.SpreadTxQueuesOnWorkers(swIfIndex, tun.NumTxQueues)
+		if err != nil {
+			return err
+		}
 	}
-
 	podSpec.TunTapSwIfIndex = swIfIndex
 	i.log.Infof("pod(add) tun swIfIndex=%d", swIfIndex)
 


### PR DESCRIPTION
**Problem:** 
Drops seen on tun interfaces:
```
00:03:26:172606: drop
  tun6-output: no tx queue available
```
since last vpp rebase, because of this vpp patch: https://gerrit.fd.io/r/c/vpp/+/45878
