### PR TITLE
Revert "cni: switch buffer checks to stats segment"

### DIFF
--- a/calico-vpp-agent/cmd/calico_vpp_dataplane.go
+++ b/calico-vpp-agent/cmd/calico_vpp_dataplane.go
@@ -29,7 +29,6 @@ import (
 	felixconfig "github.com/projectcalico/calico/felix/config"
 	calicov3cli "github.com/projectcalico/calico/libcalico-go/lib/clientv3"
 	"github.com/sirupsen/logrus"
-	"go.fd.io/govpp/adapter/statsclient"
 	"google.golang.org/grpc"
 	"gopkg.in/tomb.v2"
 	"k8s.io/client-go/kubernetes"
@@ -108,17 +107,6 @@ func main() {
 	}
 	healthServer.SetComponentStatus(health.ComponentVPPManager, true, "VPP Manager ready")
 
-	statsClient := statsclient.NewStatsClient(*config.VppStatsSocket)
-	err = statsClient.Connect()
-	if err != nil {
-		log.Fatalf("Cannot create VPP stats client: %v", err)
-	}
-	defer func() {
-		if err := statsClient.Disconnect(); err != nil {
-			log.Warnf("Failed to disconnect VPP stats client: %v", err)
-		}
-	}()
-
 	common.ThePubSub = common.NewPubSub(log.WithFields(logrus.Fields{"component": "pubsub"}))
 
 	/**
@@ -164,7 +152,7 @@ func main() {
 	routingServer := routing.NewRoutingServer(vpp, bgpServer, log.WithFields(logrus.Fields{"component": "routing"}))
 	serviceServer := services.NewServiceServer(vpp, k8sclient, log.WithFields(logrus.Fields{"component": "services"}))
 	localSIDWatcher := watchers.NewLocalSIDWatcher(vpp, clientv3, log.WithFields(logrus.Fields{"subcomponent": "localsid-watcher"}))
-	felixServer, err := felix.NewFelixServer(vpp, statsClient, log.WithFields(logrus.Fields{"component": "felix"}))
+	felixServer, err := felix.NewFelixServer(vpp, log.WithFields(logrus.Fields{"component": "felix"}))
 	if err != nil {
 		log.Fatalf("Failed to create felix server %s", err)
 	}
@@ -173,7 +161,7 @@ func main() {
 		log.Fatalf("could not install felix plugin: %s", err)
 	}
 	connectivityServer := connectivity.NewConnectivityServer(vpp, felixServer, clientv3, log.WithFields(logrus.Fields{"subcomponent": "connectivity"}))
-	cniServer := cni.NewCNIServer(vpp, felixServer, statsClient, log.WithFields(logrus.Fields{"component": "cni"}))
+	cniServer := cni.NewCNIServer(vpp, felixServer, log.WithFields(logrus.Fields{"component": "cni"}))
 
 	/* Pubsub should now be registered */
 

--- a/calico-vpp-agent/cni/cni_pod_test.go
+++ b/calico-vpp-agent/cni/cni_pod_test.go
@@ -40,7 +40,6 @@ import (
 	"github.com/projectcalico/vpp-dataplane/v3/vpplink"
 	"github.com/projectcalico/vpp-dataplane/v3/vpplink/types"
 
-	"go.fd.io/govpp/adapter"
 	gomemif "go.fd.io/govpp/extras/gomemif/memif"
 )
 
@@ -73,7 +72,7 @@ var _ = Describe("Pod-related functionality of CNI", func() {
 		}
 		// setup CNI server (functionality target of tests)
 		common.ThePubSub = common.NewPubSub(log.WithFields(logrus.Fields{"component": "pubsub"}))
-		cniServer = cni.NewCNIServer(vpp, ipamStub, &testStatsClient{}, log.WithFields(logrus.Fields{"component": "cni"}))
+		cniServer = cni.NewCNIServer(vpp, ipamStub, log.WithFields(logrus.Fields{"component": "cni"}))
 		cniServer.SetFelixConfig(&felixconfig.Config{})
 		cniServer.FetchBufferConfig()
 		vpp.CnatSetSnatAddresses(nodeIP4String, nodeIP6String)
@@ -780,37 +779,3 @@ var _ = Describe("Pod-related functionality of CNI", func() {
 		testutils.TeardownVPP()
 	})
 })
-
-type testStatsClient struct{}
-
-func (s *testStatsClient) Connect() error {
-	return nil
-}
-
-func (s *testStatsClient) Disconnect() error {
-	return nil
-}
-
-func (s *testStatsClient) DumpStats(patterns ...string) ([]adapter.StatEntry, error) {
-	return []adapter.StatEntry{{
-		StatIdentifier: adapter.StatIdentifier{Name: []byte("/buffer-pools/default-numa-0/available")},
-		Type:           adapter.ScalarIndex,
-		Data:           adapter.ScalarStat(1 << 20),
-	}}, nil
-}
-
-func (s *testStatsClient) ListStats(patterns ...string) ([]adapter.StatIdentifier, error) {
-	return nil, nil
-}
-
-func (s *testStatsClient) PrepareDir(patterns ...string) (*adapter.StatDir, error) {
-	return nil, nil
-}
-
-func (s *testStatsClient) PrepareDirOnIndex(indexes ...uint32) (*adapter.StatDir, error) {
-	return nil, nil
-}
-
-func (s *testStatsClient) UpdateDir(dir *adapter.StatDir) error {
-	return nil
-}

--- a/calico-vpp-agent/cni/cni_server.go
+++ b/calico-vpp-agent/cni/cni_server.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"strings"
 	"sync"
 	"syscall"
 
@@ -31,7 +30,6 @@ import (
 	felixConfig "github.com/projectcalico/calico/felix/config"
 	"github.com/projectcalico/calico/felix/proto"
 	"github.com/sirupsen/logrus"
-	"go.fd.io/govpp/adapter"
 	"google.golang.org/grpc"
 	"gopkg.in/tomb.v2"
 
@@ -46,9 +44,8 @@ import (
 
 type Server struct {
 	cniproto.UnimplementedCniDataplaneServer
-	log         *logrus.Entry
-	vpp         *vpplink.VppLink
-	statsclient adapter.StatsAPI
+	log *logrus.Entry
+	vpp *vpplink.VppLink
 
 	felixServerIpam common.FelixServerIpam
 
@@ -71,8 +68,6 @@ type Server struct {
 	cniMultinetEventChan chan common.CalicoVppEvent
 	nodeBGPSpec          *common.LocalNodeSpec
 }
-
-const bufferPoolAvailableStatPattern = "^/buffer-pools/.*/available$"
 
 func swIfIdxToIfName(idx uint32) string {
 	return fmt.Sprintf("vpp-tun-%d", idx)
@@ -170,50 +165,11 @@ func (s *Server) fetchNDataThreads() {
 }
 
 func (s *Server) FetchBufferConfig() {
-	availableBuffers, err := s.fetchAvailableBuffers()
+	availableBuffers, _, _, err := s.vpp.GetBufferStats()
 	if err != nil {
 		s.log.WithError(err).Errorf("could not get available buffers")
-		return
 	}
-	s.availableBuffers = availableBuffers
-}
-
-func (s *Server) fetchAvailableBuffers() (uint64, error) {
-	if s.statsclient == nil {
-		return 0, errors.New("stats client is nil")
-	}
-
-	stats, err := s.statsclient.DumpStats(bufferPoolAvailableStatPattern)
-	if err != nil {
-		return 0, errors.Wrap(err, "failed to dump VPP buffer pool stats")
-	}
-	var totalAvailableBuffers uint64
-	found := false
-	for _, stat := range stats {
-		statName := string(stat.Name)
-		if !strings.HasPrefix(statName, "/buffer-pools/") || !strings.HasSuffix(statName, "/available") {
-			continue
-		}
-		switch value := stat.Data.(type) {
-		case adapter.ScalarStat:
-			if value < 0 {
-				return 0, errors.Errorf("unexpected negative available buffer stat %s=%f", statName, value)
-			}
-			totalAvailableBuffers += uint64(value)
-			found = true
-		default:
-			s.log.Debugf("skipping non-scalar available buffer stat %s type=%T", statName, stat.Data)
-		}
-	}
-	if found {
-		return totalAvailableBuffers, nil
-	}
-
-	statNames := make([]string, 0, len(stats))
-	for _, stat := range stats {
-		statNames = append(statNames, string(stat.Name))
-	}
-	return 0, errors.Errorf("no scalar available buffer stats matched %s, got [%s]", bufferPoolAvailableStatPattern, strings.Join(statNames, ", "))
+	s.availableBuffers = uint64(availableBuffers)
 }
 
 func (s *Server) rescanState() {
@@ -330,11 +286,10 @@ func (s *Server) Del(ctx context.Context, request *cniproto.DelRequest) (*cnipro
 }
 
 // Serve runs the grpc server for the Calico CNI backend API
-func NewCNIServer(vpp *vpplink.VppLink, felixServerIpam common.FelixServerIpam, statsclient adapter.StatsAPI, log *logrus.Entry) *Server {
+func NewCNIServer(vpp *vpplink.VppLink, felixServerIpam common.FelixServerIpam, log *logrus.Entry) *Server {
 	server := &Server{
-		vpp:         vpp,
-		statsclient: statsclient,
-		log:         log,
+		vpp: vpp,
+		log: log,
 
 		felixServerIpam: felixServerIpam,
 		cniEventChan:    make(chan common.CalicoVppEvent, common.ChanSize),

--- a/calico-vpp-agent/felix/felix_server.go
+++ b/calico-vpp-agent/felix/felix_server.go
@@ -29,7 +29,6 @@ import (
 	"github.com/pkg/errors"
 	felixConfig "github.com/projectcalico/calico/felix/config"
 	"github.com/sirupsen/logrus"
-	"go.fd.io/govpp/adapter"
 	"gopkg.in/tomb.v2"
 
 	nettypes "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
@@ -127,7 +126,7 @@ type Server struct {
 }
 
 // NewFelixServer creates a felix server
-func NewFelixServer(vpp *vpplink.VppLink, statsclient adapter.StatsAPI, log *logrus.Entry) (*Server, error) {
+func NewFelixServer(vpp *vpplink.VppLink, log *logrus.Entry) (*Server, error) {
 	var err error
 
 	server := &Server{
@@ -156,7 +155,7 @@ func NewFelixServer(vpp *vpplink.VppLink, statsclient adapter.StatsAPI, log *log
 		nodeStatesByName:  make(map[string]*common.LocalNodeSpec),
 		GotOurNodeBGPchan: make(chan interface{}),
 
-		prometheusServer: prometheus.NewPrometheusServer(vpp, statsclient, log.WithFields(logrus.Fields{"component": "prometheus"})),
+		prometheusServer: prometheus.NewPrometheusServer(vpp, log.WithFields(logrus.Fields{"component": "prometheus"})),
 	}
 
 	reg := common.RegisterHandler(server.felixServerEventChan, "felix server events")

--- a/calico-vpp-agent/felix/felix_server_test.go
+++ b/calico-vpp-agent/felix/felix_server_test.go
@@ -79,7 +79,7 @@ var _ = Describe("Felix functionality", func() {
 		CreateLoopbackAndTaggingItAsMain(vpp, log)
 		common.ThePubSub = common.NewPubSub(log.WithFields(logrus.Fields{"component": "pubsub"}))
 		var err error
-		felixServer, err = NewFelixServer(vpp, nil, log.WithFields(logrus.Fields{"component": "policy"}))
+		felixServer, err = NewFelixServer(vpp, log.WithFields(logrus.Fields{"component": "policy"}))
 		if err != nil {
 			log.Fatalf("Failed to create felix server %s", err)
 		}
@@ -90,6 +90,10 @@ var _ = Describe("Felix functionality", func() {
 	})
 
 	AfterEach(func() {
+
+		// Clean up the symlink we created
+		os.Remove("/run/vpp/stats.sock")
+
 		// Clean up the VPP container
 		testutils.TeardownVPP()
 	})

--- a/calico-vpp-agent/prometheus/prometheus.go
+++ b/calico-vpp-agent/prometheus/prometheus.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"go.fd.io/govpp/adapter"
+	"go.fd.io/govpp/adapter/statsclient"
 	"gopkg.in/tomb.v2"
 
 	"github.com/projectcalico/vpp-dataplane/v3/calico-vpp-agent/cni/model"
@@ -46,13 +47,13 @@ type PrometheusServer struct {
 	vpp                             *vpplink.VppLink
 	podInterfacesDetailsBySwifIndex map[uint32]podInterfaceDetails
 	podInterfacesByKey              map[string]model.LocalPodSpec
-	statsclient                     adapter.StatsAPI
+	statsclient                     *statsclient.StatsClient
 	lock                            sync.Mutex
 	httpServer                      *http.Server
 	exporter                        *prometheusExporter.Exporter
 }
 
-func NewPrometheusServer(vpp *vpplink.VppLink, statsclient adapter.StatsAPI, log *logrus.Entry) *PrometheusServer {
+func NewPrometheusServer(vpp *vpplink.VppLink, log *logrus.Entry) *PrometheusServer {
 	exporter, err := prometheusExporter.New(prometheusExporter.Options{})
 	if err != nil {
 		log.Fatalf("Failed to create new exporter: %v", err)
@@ -64,7 +65,7 @@ func NewPrometheusServer(vpp *vpplink.VppLink, statsclient adapter.StatsAPI, log
 		vpp:                             vpp,
 		podInterfacesByKey:              make(map[string]model.LocalPodSpec),
 		podInterfacesDetailsBySwifIndex: make(map[uint32]podInterfaceDetails),
-		statsclient:                     statsclient,
+		statsclient:                     statsclient.NewStatsClient("" /* default socket name */),
 		httpServer: &http.Server{
 			Addr:    config.GetCalicoVppInitialConfig().PrometheusListenEndpoint,
 			Handler: mux,
@@ -458,8 +459,10 @@ func (p *PrometheusServer) ServePrometheus(t *tomb.Tomb) error {
 		return nil
 	}
 	p.log.Infof("Serve() Prometheus exporter")
-	if p.statsclient == nil {
-		return errors.New("stats client is nil")
+
+	err := p.statsclient.Connect()
+	if err != nil {
+		return errors.Wrap(err, "could not connect statsclient")
 	}
 
 	go func() {
@@ -477,7 +480,7 @@ func (p *PrometheusServer) ServePrometheus(t *tomb.Tomb) error {
 	}
 	ticker.Stop()
 	p.log.Warn("Prometheus Server returned")
-	err := p.httpServer.Shutdown(context.Background())
+	err = p.httpServer.Shutdown(context.Background())
 	if err != nil {
 		return errors.Wrap(err, "Could not shutdown http server")
 	}

--- a/calico-vpp-agent/prometheus/prometheus_test.go
+++ b/calico-vpp-agent/prometheus/prometheus_test.go
@@ -28,7 +28,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
-	"go.fd.io/govpp/adapter/statsclient"
 	"gopkg.in/tomb.v2"
 
 	"github.com/projectcalico/vpp-dataplane/v3/calico-vpp-agent/cni/model"
@@ -88,7 +87,6 @@ var _ = Describe("Prometheus exporter functionality", func() {
 	var (
 		log              *logrus.Logger
 		vpp              *vpplink.VppLink
-		stats            *statsclient.StatsClient
 		prometheusServer *prometheus.PrometheusServer
 		testTomb         *tomb.Tomb
 		uplinkSwIfIndex  uint32
@@ -112,10 +110,28 @@ var _ = Describe("Prometheus exporter functionality", func() {
 		testutils.StartVPP()
 		vpp, uplinkSwIfIndex = testutils.ConfigureVPP(log)
 
-		stats = testutils.NewStatsClient()
+		// Wait for VPP stats socket to become available
+		pidSubdir := "/tmp/prometheus-tests-vpp/" + strconv.Itoa(os.Getpid())
+		waitForStatsSocket(pidSubdir+"/stats.sock", 2*time.Second)
+
+		// Create a symlink from the expected location to the actual stats socket location
+		// This is a workaround for the issue where the statsclient expects /run/vpp/stats.sock
+		// but our test VPP container has this at /tmp/prometheus-tests-vpp/<PID>/stats.sock
+		actualSocketPath := pidSubdir + "/stats.sock"
+		expectedSocketPath := "/run/vpp/stats.sock"
+
+		// Create the directory if it doesn't exist
+		os.MkdirAll("/run/vpp", 0755)
+
+		// Remove any existing file/symlink and create a new symlink
+		os.Remove(expectedSocketPath)
+		err := os.Symlink(actualSocketPath, expectedSocketPath)
+		if err != nil {
+			fmt.Printf("Warning: Could not create symlink for stats socket: %v\n", err)
+		}
 
 		// Create prometheus server
-		prometheusServer = prometheus.NewPrometheusServer(vpp, stats, log.WithFields(logrus.Fields{"subcomponent": "prometheus"}))
+		prometheusServer = prometheus.NewPrometheusServer(vpp, log.WithFields(logrus.Fields{"subcomponent": "prometheus"}))
 
 		// Add some fake containers to test interface stats using actual VPP interface indices
 		// Use the uplink interface (tap0) and local0 interface for testing
@@ -151,9 +167,8 @@ var _ = Describe("Prometheus exporter functionality", func() {
 			testTomb.Wait()
 		}
 
-		if stats != nil {
-			stats.Disconnect()
-		}
+		// Clean up the symlink we created
+		os.Remove("/run/vpp/stats.sock")
 
 		// Clean up the VPP container
 		testutils.TeardownVPP()

--- a/calico-vpp-agent/testutils/testutils.go
+++ b/calico-vpp-agent/testutils/testutils.go
@@ -34,7 +34,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"go.fd.io/govpp/adapter/statsclient"
 
 	"github.com/containernetworking/plugins/pkg/ns"
 	apiv3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
@@ -308,7 +307,7 @@ func IPFamilyIndex(ipFamily vpplink.IPFamily) int {
 func StartVPP() {
 	// Create PID-based subdirectory within the /tmp/prometheus-tests-vpp/
 	// mounted volume to ensure uniqueness across parallel test runs
-	pidSubdir := VPPStatsSocketDir()
+	pidSubdir := "/tmp/prometheus-tests-vpp/" + strconv.Itoa(os.Getpid())
 	err := os.MkdirAll(pidSubdir, 0755)
 	Expect(err).Should(BeNil(), "Failed to create PID subdirectory")
 
@@ -360,25 +359,10 @@ func StartVPP() {
 	Expect(err).Should(BeNil(), "Failed to start VPP inside docker container")
 }
 
-func VPPStatsSocketDir() string {
-	return "/tmp/prometheus-tests-vpp/" + strconv.Itoa(os.Getpid())
-}
-
-func VPPStatsSocketPath() string {
-	return filepath.Join(VPPStatsSocketDir(), "stats.sock")
-}
-
-func NewStatsClient() *statsclient.StatsClient {
-	statsClient := statsclient.NewStatsClient(VPPStatsSocketPath())
-	err := statsClient.Connect()
-	Expect(err).ToNot(HaveOccurred(), "Cannot create VPP stats client")
-	return statsClient
-}
-
 // ConfigureVPP connects to VPP and configures it with common configuration needed for tests
 func ConfigureVPP(log *logrus.Logger) (vpp *vpplink.VppLink, uplinkSwIfIndex uint32) {
 	// connect to VPP using PID-based subdirectory path
-	pidSubdir := VPPStatsSocketDir()
+	pidSubdir := "/tmp/prometheus-tests-vpp/" + strconv.Itoa(os.Getpid())
 	vpp, err := common.CreateVppLinkInRetryLoop(pidSubdir+"/vpp-api-test.sock",
 		log.WithFields(logrus.Fields{"component": "vpp-api"}), 20*time.Second, 100*time.Millisecond)
 	Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Cannot create VPP client: %v", err))

--- a/config/config.go
+++ b/config/config.go
@@ -143,7 +143,6 @@ var (
 	CalicoVppInitialConfig           = JSONEnvVar("CALICOVPP_INITIAL_CONFIG", &CalicoVppInitialConfigConfigType{})
 	CalicoVppGracefulShutdownTimeout = EnvVar("CALICOVPP_GRACEFUL_SHUTDOWN_TIMEOUT", 10*time.Second, time.ParseDuration)
 	LogFormat                        = StringEnvVar("CALICOVPP_LOG_FORMAT", "")
-	VppStatsSocket                   = StringEnvVar("CALICOVPP_STATS_SOCKET", "")
 
 	/* Deprecated vars */
 	/* linux name of the uplink interface to be used by VPP */

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -64,9 +64,6 @@ data:
       "defaultGWs": "192.168.0.1",
     }
 
-  # Optional VPP stats segment socket path. Empty uses govpp's default.
-  CALICOVPP_STATS_SOCKET: ""
-
   CALICOVPP_DEBUG: |-
   {
     "servicesEnabled": true,

--- a/vpplink/generated/bindings/interface/interface.ba.go
+++ b/vpplink/generated/bindings/interface/interface.ba.go
@@ -3,7 +3,7 @@
 // Package interfaces contains generated bindings for API file interface.api.
 //
 // Contents:
-// - 80 messages
+// - 82 messages
 package interfaces
 
 import (
@@ -23,7 +23,7 @@ const _ = api.GoVppAPIPackageIsVersion2
 const (
 	APIFile    = "interface"
 	APIVersion = "3.2.5"
-	VersionCrc = 0x98d849f6
+	VersionCrc = 0x89001687
 )
 
 // Enable or disable detailed interface stats
@@ -572,6 +572,87 @@ func (m *DeleteSubifReply) Marshal(b []byte) ([]byte, error) {
 func (m *DeleteSubifReply) Unmarshal(b []byte) error {
 	buf := codec.NewBuffer(b)
 	m.Retval = buf.DecodeInt32()
+	return nil
+}
+
+// Get available, cached and used buffers
+//   - buffer_index - buffer stat index
+//
+// GetBuffersStats defines message 'get_buffers_stats'.
+type GetBuffersStats struct {
+	BufferIndex uint32 `binapi:"u32,name=buffer_index" json:"buffer_index,omitempty"`
+}
+
+func (m *GetBuffersStats) Reset()               { *m = GetBuffersStats{} }
+func (*GetBuffersStats) GetMessageName() string { return "get_buffers_stats" }
+func (*GetBuffersStats) GetCrcString() string   { return "d698f87e" }
+func (*GetBuffersStats) GetMessageType() api.MessageType {
+	return api.RequestMessage
+}
+
+func (m *GetBuffersStats) Size() (size int) {
+	if m == nil {
+		return 0
+	}
+	size += 4 // m.BufferIndex
+	return size
+}
+func (m *GetBuffersStats) Marshal(b []byte) ([]byte, error) {
+	if b == nil {
+		b = make([]byte, m.Size())
+	}
+	buf := codec.NewBuffer(b)
+	buf.EncodeUint32(m.BufferIndex)
+	return buf.Bytes(), nil
+}
+func (m *GetBuffersStats) Unmarshal(b []byte) error {
+	buf := codec.NewBuffer(b)
+	m.BufferIndex = buf.DecodeUint32()
+	return nil
+}
+
+// GetBuffersStatsReply defines message 'get_buffers_stats_reply'.
+type GetBuffersStatsReply struct {
+	Retval           int32  `binapi:"i32,name=retval" json:"retval,omitempty"`
+	AvailableBuffers uint32 `binapi:"u32,name=available_buffers" json:"available_buffers,omitempty"`
+	CachedBuffers    uint32 `binapi:"u32,name=cached_buffers" json:"cached_buffers,omitempty"`
+	UsedBuffers      uint32 `binapi:"u32,name=used_buffers" json:"used_buffers,omitempty"`
+}
+
+func (m *GetBuffersStatsReply) Reset()               { *m = GetBuffersStatsReply{} }
+func (*GetBuffersStatsReply) GetMessageName() string { return "get_buffers_stats_reply" }
+func (*GetBuffersStatsReply) GetCrcString() string   { return "22c0649d" }
+func (*GetBuffersStatsReply) GetMessageType() api.MessageType {
+	return api.ReplyMessage
+}
+
+func (m *GetBuffersStatsReply) Size() (size int) {
+	if m == nil {
+		return 0
+	}
+	size += 4 // m.Retval
+	size += 4 // m.AvailableBuffers
+	size += 4 // m.CachedBuffers
+	size += 4 // m.UsedBuffers
+	return size
+}
+func (m *GetBuffersStatsReply) Marshal(b []byte) ([]byte, error) {
+	if b == nil {
+		b = make([]byte, m.Size())
+	}
+	buf := codec.NewBuffer(b)
+	buf.EncodeInt32(m.Retval)
+	buf.EncodeUint32(m.AvailableBuffers)
+	buf.EncodeUint32(m.CachedBuffers)
+	buf.EncodeUint32(m.UsedBuffers)
+	return buf.Bytes(), nil
+}
+func (m *GetBuffersStatsReply) Unmarshal(b []byte) error {
+	buf := codec.NewBuffer(b)
+	m.Retval = buf.DecodeInt32()
+	m.AvailableBuffers = buf.DecodeUint32()
+	m.CachedBuffers = buf.DecodeUint32()
+	m.UsedBuffers = buf.DecodeUint32()
 	return nil
 }
 
@@ -3432,6 +3513,8 @@ func file_interfaces_binapi_init() {
 	api.RegisterMessage((*DeleteLoopbackReply)(nil), "delete_loopback_reply_e8d4e804")
 	api.RegisterMessage((*DeleteSubif)(nil), "delete_subif_f9e6675e")
 	api.RegisterMessage((*DeleteSubifReply)(nil), "delete_subif_reply_e8d4e804")
+	api.RegisterMessage((*GetBuffersStats)(nil), "get_buffers_stats_d698f87e")
+	api.RegisterMessage((*GetBuffersStatsReply)(nil), "get_buffers_stats_reply_22c0649d")
 	api.RegisterMessage((*HwInterfaceSetMtu)(nil), "hw_interface_set_mtu_e6746899")
 	api.RegisterMessage((*HwInterfaceSetMtuReply)(nil), "hw_interface_set_mtu_reply_e8d4e804")
 	api.RegisterMessage((*InterfaceNameRenumber)(nil), "interface_name_renumber_2b8858b8")
@@ -3517,6 +3600,8 @@ func AllMessages() []api.Message {
 		(*DeleteLoopbackReply)(nil),
 		(*DeleteSubif)(nil),
 		(*DeleteSubifReply)(nil),
+		(*GetBuffersStats)(nil),
+		(*GetBuffersStatsReply)(nil),
 		(*HwInterfaceSetMtu)(nil),
 		(*HwInterfaceSetMtuReply)(nil),
 		(*InterfaceNameRenumber)(nil),

--- a/vpplink/generated/bindings/interface/interface_rpc.ba.go
+++ b/vpplink/generated/bindings/interface/interface_rpc.ba.go
@@ -20,6 +20,7 @@ type RPCService interface {
 	CreateVlanSubif(ctx context.Context, in *CreateVlanSubif) (*CreateVlanSubifReply, error)
 	DeleteLoopback(ctx context.Context, in *DeleteLoopback) (*DeleteLoopbackReply, error)
 	DeleteSubif(ctx context.Context, in *DeleteSubif) (*DeleteSubifReply, error)
+	GetBuffersStats(ctx context.Context, in *GetBuffersStats) (*GetBuffersStatsReply, error)
 	HwInterfaceSetMtu(ctx context.Context, in *HwInterfaceSetMtu) (*HwInterfaceSetMtuReply, error)
 	InterfaceNameRenumber(ctx context.Context, in *InterfaceNameRenumber) (*InterfaceNameRenumberReply, error)
 	PcapSetFilterFunction(ctx context.Context, in *PcapSetFilterFunction) (*PcapSetFilterFunctionReply, error)
@@ -118,6 +119,15 @@ func (c *serviceClient) DeleteLoopback(ctx context.Context, in *DeleteLoopback) 
 
 func (c *serviceClient) DeleteSubif(ctx context.Context, in *DeleteSubif) (*DeleteSubifReply, error) {
 	out := new(DeleteSubifReply)
+	err := c.conn.Invoke(ctx, in, out)
+	if err != nil {
+		return nil, err
+	}
+	return out, api.RetvalToVPPApiError(out.Retval)
+}
+
+func (c *serviceClient) GetBuffersStats(ctx context.Context, in *GetBuffersStats) (*GetBuffersStatsReply, error) {
+	out := new(GetBuffersStatsReply)
 	err := c.conn.Invoke(ctx, in, out)
 	if err != nil {
 		return nil, err

--- a/vpplink/generated/generate.log
+++ b/vpplink/generated/generate.log
@@ -1,9 +1,10 @@
-VPP Version                 : 26.10-rc0~40-g45ee0eff6
-Binapi-generator version    : v0.11.0
+VPP Version                 : 26.10-rc0~41-g3f188bc18
+Binapi-generator version    : v0.13.0
 VPP Base commit             : 3cf5adc8e build: populate VPPConfig.cmake with dirs and platform selection
 ------------------ Cherry picked commits --------------------
 calicovpp plugin:pbl
 calicovpp plugin:ip_ttl_fixup
+interface: add buffer stats api
 npol: add matched rule id to acl trace
 ip-neighbor: preserve interface LL receive DPO for self link-local
 acl: acl-plugin custom policies

--- a/vpplink/generated/vpp_clone_current.sh
+++ b/vpplink/generated/vpp_clone_current.sh
@@ -130,11 +130,13 @@ git_cherry_pick refs/changes/99/45099/2 # 45099: ip6-nd: add nd-proxy all dst | 
 git_cherry_pick refs/changes/46/45046/4 # 45046: ip6-nd: add punt reason for neigh advs | https://gerrit.fd.io/r/c/vpp/+/45046
 
 # --------------- private patches/plugins ---------------
-# Patch files generated with 'git format-patch --zero-commit -o ./patches/ HEAD^^^^'
+# Patch files generated with 'git format-patch --zero-commit -o ./patches/ HEAD^^^^^'
 git_apply_private 0001-cnat-WIP-no-k8s-maglev-from-pods.patch
 git_apply_private 0002-acl-acl-plugin-custom-policies.patch
 git_apply_private 0003-ip-neighbor-preserve-interface-LL-receive-DPO-for-se.patch
 git_apply_private 0004-npol-add-matched-rule-id-to-acl-trace.patch
+git_apply_private 0005-interface-add-buffer-stats-api.patch
+
 # VPP Private plugins:
 copy_private_plugin ip_ttl_fixup
 copy_private_plugin pbl

--- a/vpplink/stats.go
+++ b/vpplink/stats.go
@@ -1,0 +1,32 @@
+// Copyright (C) 2019 Cisco Systems Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vpplink
+
+import (
+	"fmt"
+
+	interfaces "github.com/projectcalico/vpp-dataplane/v3/vpplink/generated/bindings/interface"
+)
+
+func (v *VppLink) GetBufferStats() (available uint32, cached uint32, used uint32, err error) {
+	client := interfaces.NewServiceClient(v.GetConnection())
+
+	response, err := client.GetBuffersStats(v.GetContext(), &interfaces.GetBuffersStats{})
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("failed to get buffer stats: %w", err)
+	}
+	return response.AvailableBuffers, response.CachedBuffers, response.UsedBuffers, nil
+}


### PR DESCRIPTION
This reverts commit 9f2d2ac1a6371474b2883c54d524c90e4511ce89.

Detailed analysis of the issue from @hedibouattour here: https://github.com/projectcalico/vpp-dataplane/pull/1041#issuecomment-4632613957

I think we should probably revert the culprit commit for now to ensure `master` is not broken.