### PR TITLE
feat(srv6): SRv6-native (DSR) ClusterIP Services

### DIFF
--- a/calico-vpp-agent/cmd/calico_vpp_dataplane.go
+++ b/calico-vpp-agent/cmd/calico_vpp_dataplane.go
@@ -150,7 +150,6 @@ func main() {
 	bgpFilterWatcher := watchers.NewBGPFilterWatcher(clientv3, k8sclient, log.WithFields(logrus.Fields{"subcomponent": "BGPFilter-watcher"}))
 	netWatcher := watchers.NewNetWatcher(vpp, log.WithFields(logrus.Fields{"component": "net-watcher"}))
 	routingServer := routing.NewRoutingServer(vpp, bgpServer, log.WithFields(logrus.Fields{"component": "routing"}))
-	serviceServer := services.NewServiceServer(vpp, k8sclient, log.WithFields(logrus.Fields{"component": "services"}))
 	localSIDWatcher := watchers.NewLocalSIDWatcher(vpp, clientv3, log.WithFields(logrus.Fields{"subcomponent": "localsid-watcher"}))
 	felixServer, err := felix.NewFelixServer(vpp, log.WithFields(logrus.Fields{"component": "felix"}))
 	if err != nil {
@@ -160,6 +159,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("could not install felix plugin: %s", err)
 	}
+	serviceServer := services.NewServiceServer(vpp, k8sclient, felixServer, log.WithFields(logrus.Fields{"component": "services"}))
 	connectivityServer := connectivity.NewConnectivityServer(vpp, felixServer, clientv3, log.WithFields(logrus.Fields{"subcomponent": "connectivity"}))
 	cniServer := cni.NewCNIServer(vpp, felixServer, log.WithFields(logrus.Fields{"component": "cni"}))
 

--- a/calico-vpp-agent/cni/cni_dsr.go
+++ b/calico-vpp-agent/cni/cni_dsr.go
@@ -1,0 +1,287 @@
+package cni
+
+import (
+	"net"
+
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/vishvananda/netlink"
+
+	"github.com/projectcalico/vpp-dataplane/v3/calico-vpp-agent/cni/model"
+	"github.com/projectcalico/vpp-dataplane/v3/calico-vpp-agent/common"
+	"github.com/projectcalico/vpp-dataplane/v3/vpplink"
+	"github.com/projectcalico/vpp-dataplane/v3/vpplink/types"
+)
+
+// dsrVIPState tracks a DSR ClusterIP's shared PodVRFIndex delivery route and the
+// local pods that currently have the VIP programmed (lo bind + uRPF allow).
+// boundPods drives cleanup: a pod stays until its binding is removed or it's gone.
+type dsrVIPState struct {
+	vip       net.IP
+	delivery  *types.Route
+	boundPods map[string]bool
+}
+
+func (s *Server) handleDSRServiceAdded(svc *common.DSRService) {
+	if svc == nil || svc.VIP == nil {
+		return
+	}
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.dsrDesired[svc.VIP.String()] = svc
+	s.reconcileDSRVIPs()
+}
+
+func (s *Server) handleDSRServiceDeleted(svc *common.DSRService) {
+	if svc == nil || svc.VIP == nil {
+		return
+	}
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	delete(s.dsrDesired, svc.VIP.String())
+	s.reconcileDSRVIPs()
+}
+
+// reconcileDSRVIPs drives installed DSR VIP state toward the desired set,
+// retrying failed installs/removals. Invoked on DSR events, resync, pod add/del.
+// Caller holds s.lock.
+func (s *Server) reconcileDSRVIPs() {
+	for _, svc := range s.dsrDesired {
+		s.programDSRVIP(svc)
+	}
+	for key := range s.dsrVIPs {
+		if _, ok := s.dsrDesired[key]; !ok {
+			s.teardownDSRVIP(key)
+		}
+	}
+}
+
+// programDSRVIP binds the VIP on local backend pods (lo + uRPF), unbinds
+// departed ones, and reconciles the PodVRFIndex ECMP delivery route. Holds s.lock.
+func (s *Server) programDSRVIP(svc *common.DSRService) {
+	vipKey := svc.VIP.String()
+	prev := s.dsrVIPs[vipKey]
+	boundPods := map[string]bool{}
+	if prev != nil {
+		for ip := range prev.boundPods {
+			boundPods[ip] = true
+		}
+	}
+
+	desiredLocal := map[string]bool{}
+	var deliveryPaths []types.RoutePath
+	for _, beIP := range svc.Backends {
+		podSpec := s.findLocalPodByIP(beIP)
+		if podSpec == nil || podSpec.TunTapSwIfIndex == vpplink.InvalidSwIfIndex {
+			continue // not a local tun-backed pod
+		}
+		desiredLocal[beIP.String()] = true
+		if err := s.bindVIPInPod(podSpec, svc.VIP, true /* add */); err != nil {
+			s.log.Errorf("cni(dsr) bind vip=%s pod=%s: %v", svc.VIP, beIP, err)
+		}
+		if err := s.dsrRPFRoute(podSpec, svc.VIP, true /* add */); err != nil {
+			s.log.Errorf("cni(dsr) rpf add vip=%s pod=%s: %v", svc.VIP, beIP, err)
+		}
+		boundPods[beIP.String()] = true
+		deliveryPaths = append(deliveryPaths, types.RoutePath{
+			SwIfIndex: podSpec.TunTapSwIfIndex,
+			Gw:        beIP,
+		})
+	}
+
+	// Unbind pods no longer backing the service; keep ones whose cleanup fails so
+	// a departed-but-running pod can't keep answering as / uRPF-spoofing the VIP.
+	for ipStr := range boundPods {
+		if desiredLocal[ipStr] {
+			continue
+		}
+		if s.cleanupDSRPod(ipStr, svc.VIP) {
+			delete(boundPods, ipStr)
+		}
+	}
+
+	st := &dsrVIPState{vip: svc.VIP, boundPods: boundPods}
+	st.delivery = s.updateDeliveryRoute(svc.VIP, prev, deliveryPaths)
+	// Drop the entry only once the route is gone AND no pod cleanup is pending.
+	if st.delivery == nil && len(boundPods) == 0 {
+		delete(s.dsrVIPs, vipKey)
+		return
+	}
+	s.dsrVIPs[vipKey] = st
+	s.log.Debugf("cni(dsr) vip=%s local backends=%d bound=%d", svc.VIP, len(desiredLocal), len(boundPods))
+}
+
+// teardownDSRVIP removes all DSR state for an undesired VIP, retaining anything
+// whose removal fails for the next reconcile. Caller holds s.lock.
+func (s *Server) teardownDSRVIP(key string) {
+	st := s.dsrVIPs[key]
+	if st == nil {
+		return
+	}
+	st.delivery = s.updateDeliveryRoute(st.vip, st, nil /* no paths */)
+	for ipStr := range st.boundPods {
+		if s.cleanupDSRPod(ipStr, st.vip) {
+			delete(st.boundPods, ipStr)
+		}
+	}
+	if st.delivery == nil && len(st.boundPods) == 0 {
+		delete(s.dsrVIPs, key)
+	}
+}
+
+// cleanupDSRPod removes a pod's VIP binding (lo) + uRPF allow. Returns true when
+// done (pod gone, or both removals succeeded), false to retry.
+func (s *Server) cleanupDSRPod(ipStr string, vip net.IP) bool {
+	ip := net.ParseIP(ipStr)
+	if ip == nil {
+		return true
+	}
+	podSpec := s.findLocalPodByIP(ip)
+	if podSpec == nil {
+		return true // pod gone; netns + per-pod RPF VRF auto-cleaned
+	}
+	ok := true
+	if err := s.bindVIPInPod(podSpec, vip, false /* del */); err != nil {
+		s.log.Errorf("cni(dsr) unbind vip=%s pod=%s: %v", vip, ip, err)
+		ok = false
+	}
+	if err := s.dsrRPFRoute(podSpec, vip, false /* del */); err != nil {
+		s.log.Errorf("cni(dsr) rpf del vip=%s pod=%s: %v", vip, ip, err)
+		ok = false
+	}
+	return ok
+}
+
+// updateDeliveryRoute reconciles the PodVRFIndex delivery route for a VIP to the
+// given paths (unchanged = keep; changed = del+add; none = del), retaining the
+// installed route on VPP failure so the next reconcile retries.
+func (s *Server) updateDeliveryRoute(vip net.IP, prev *dsrVIPState, paths []types.RoutePath) *types.Route {
+	if prev != nil && prev.delivery != nil {
+		if len(paths) > 0 && samePaths(prev.delivery.Paths, paths) {
+			return prev.delivery
+		}
+		if err := s.vpp.RouteDel(prev.delivery); err != nil {
+			s.log.Errorf("cni(dsr) del delivery route vip=%s: %v", vip, err)
+			return prev.delivery // keep old; retry replacement next reconcile
+		}
+	}
+	if len(paths) == 0 {
+		return nil
+	}
+	route := &types.Route{
+		Dst:   common.ToMaxLenCIDR(vip),
+		Paths: paths,
+		Table: common.PodVRFIndex,
+	}
+	if err := s.vpp.RouteAdd(route); err != nil {
+		s.log.Errorf("cni(dsr) add delivery route vip=%s: %v", vip, err)
+		return nil // retry add next reconcile
+	}
+	return route
+}
+
+// samePaths reports whether two route path sets are equal (order-independent).
+func samePaths(a, b []types.RoutePath) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	type key struct {
+		idx uint32
+		gw  string
+	}
+	m := make(map[key]int)
+	for _, p := range a {
+		m[key{p.SwIfIndex, p.Gw.String()}]++
+	}
+	for _, p := range b {
+		m[key{p.SwIfIndex, p.Gw.String()}]--
+	}
+	for _, v := range m {
+		if v != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// findLocalPodByIP returns the local pod spec whose container IP equals ip.
+func (s *Server) findLocalPodByIP(ip net.IP) *model.LocalPodSpec {
+	for key := range s.podInterfaceMap {
+		spec := s.podInterfaceMap[key]
+		for _, cip := range spec.GetContainerIPs() {
+			if cip.IP.Equal(ip) {
+				return &spec
+			}
+		}
+	}
+	return nil
+}
+
+// bindVIPInPod adds/removes the VIP on the pod's lo inside its netns, checking
+// presence first so add/del are no-ops (not spurious errors) when already done.
+func (s *Server) bindVIPInPod(podSpec *model.LocalPodSpec, vip net.IP, add bool) error {
+	if podSpec.NetnsName == "" {
+		return nil
+	}
+	return ns.WithNetNSPath(podSpec.NetnsName, func(ns.NetNS) error {
+		lo, err := netlink.LinkByName("lo")
+		if err != nil {
+			return err
+		}
+		addrs, err := netlink.AddrList(lo, netlink.FAMILY_V6)
+		if err != nil {
+			return err
+		}
+		present := false
+		for _, a := range addrs {
+			if a.IP.Equal(vip) {
+				present = true
+				break
+			}
+		}
+		addr := &netlink.Addr{IPNet: common.ToMaxLenCIDR(vip)}
+		if add {
+			if present {
+				return nil
+			}
+			return netlink.AddrAdd(lo, addr)
+		}
+		if present {
+			return netlink.AddrDel(lo, addr)
+		}
+		return nil
+	})
+}
+
+// dsrRPFRoute adds/removes a VIP route in the pod's RPF VRF so loose uRPF accepts
+// (add) / rejects (del) a reply sourced from the VIP. RouteDel is idempotent.
+func (s *Server) dsrRPFRoute(podSpec *model.LocalPodSpec, vip net.IP, add bool) error {
+	vipNet := common.ToMaxLenCIDR(vip)
+	rpfVrfID := podSpec.GetRPFVrfID(vpplink.IPFamilyFromIPNet(vipNet))
+	if rpfVrfID == vpplink.InvalidID {
+		return nil
+	}
+	gw := podContainerIPForVIP(podSpec, vip)
+	if gw == nil {
+		return nil
+	}
+	paths := []types.RoutePath{{SwIfIndex: podSpec.TunTapSwIfIndex, Gw: gw}}
+	if podSpec.MemifSwIfIndex != vpplink.InvalidSwIfIndex {
+		paths = append(paths, types.RoutePath{SwIfIndex: podSpec.MemifSwIfIndex, Gw: gw})
+	}
+	route := &types.Route{Dst: vipNet, Paths: paths, Table: rpfVrfID}
+	if add {
+		return s.vpp.RouteAdd(route)
+	}
+	return s.vpp.RouteDel(route)
+}
+
+// podContainerIPForVIP returns the pod's container IP of the same family as vip.
+func podContainerIPForVIP(podSpec *model.LocalPodSpec, vip net.IP) net.IP {
+	wantV6 := vip.To4() == nil
+	for _, cip := range podSpec.GetContainerIPs() {
+		if (cip.IP.To4() == nil) == wantV6 {
+			return cip.IP
+		}
+	}
+	return nil
+}

--- a/calico-vpp-agent/cni/cni_server.go
+++ b/calico-vpp-agent/cni/cni_server.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/pkg/errors"
 	calicov3 "github.com/projectcalico/api/pkg/apis/projectcalico/v3"
@@ -54,6 +55,12 @@ type Server struct {
 	podInterfaceMap map[string]model.LocalPodSpec
 	lock            sync.Mutex /* protects Add/DelVppInterace/RescanState */
 	cniEventChan    chan common.CalicoVppEvent
+	// dsrVIPs tracks the shared PodVRFIndex delivery route per SRv6-native (DSR)
+	// ClusterIP VIP for which this node hosts backend pods.
+	dsrVIPs map[string]*dsrVIPState
+	// dsrDesired is the desired DSR service set (by VIP), reconciled against
+	// dsrVIPs so failed installs AND removals are retried, not lost.
+	dsrDesired map[string]*common.DSRService
 
 	memifDriver    *podinterface.MemifPodInterfaceDriver
 	tuntapDriver   *podinterface.TunTapPodInterfaceDriver
@@ -147,6 +154,9 @@ func (s *Server) Add(ctx context.Context, request *cniproto.AddRequest) (*cnipro
 	if err != nil {
 		s.log.Errorf("CNI state persist errored %v", err)
 	}
+	// A newly-added pod may be a backend of a desired DSR service; reconcile so
+	// its VIP binding + delivery route (and any pending DSR retries) are applied.
+	s.reconcileDSRVIPs()
 	s.log.Infof("pod(add) Done spec=%s", podSpec.String())
 	// XXX: container MAC doesn't make sense with tun, we just pass back a constant one.
 	// How does calico / k8s use it?
@@ -280,6 +290,10 @@ func (s *Server) Del(ctx context.Context, request *cniproto.DelRequest) (*cnipro
 		s.log.Errorf("CNI state persist errored %v", err)
 	}
 
+	// A removed pod may have been a DSR backend; reconcile so the delivery route
+	// drops its path and any pending DSR delete/install retries are driven.
+	s.reconcileDSRVIPs()
+
 	return &cniproto.DelReply{
 		Successful: true,
 	}, nil
@@ -296,6 +310,8 @@ func NewCNIServer(vpp *vpplink.VppLink, felixServerIpam common.FelixServerIpam, 
 
 		grpcServer:      grpc.NewServer(),
 		podInterfaceMap: make(map[string]model.LocalPodSpec),
+		dsrVIPs:         make(map[string]*dsrVIPState),
+		dsrDesired:      make(map[string]*common.DSRService),
 		tuntapDriver:    podinterface.NewTunTapPodInterfaceDriver(vpp, log, felixServerIpam),
 		memifDriver:     podinterface.NewMemifPodInterfaceDriver(vpp, log, felixServerIpam),
 		vclDriver:       podinterface.NewVclPodInterfaceDriver(vpp, log, felixServerIpam),
@@ -307,6 +323,8 @@ func NewCNIServer(vpp *vpplink.VppLink, felixServerIpam common.FelixServerIpam, 
 	reg.ExpectEvents(
 		common.FelixConfChanged,
 		common.IpamConfChanged,
+		common.ServiceDSRClusterIPAdded,
+		common.ServiceDSRClusterIPDeleted,
 	)
 	regM := common.RegisterHandler(server.cniMultinetEventChan, "CNI server Multinet events")
 	regM.ExpectEvents(
@@ -317,11 +335,19 @@ func NewCNIServer(vpp *vpplink.VppLink, felixServerIpam common.FelixServerIpam, 
 	return server
 }
 func (s *Server) cniServerEventLoop(t *tomb.Tomb) error {
+	// Periodically reconcile SRv6-native (DSR) VIP state so a withdrawn-service
+	// cleanup (or install) that failed is retried even without further events.
+	dsrTicker := time.NewTicker(30 * time.Second)
+	defer dsrTicker.Stop()
 forloop:
 	for {
 		select {
 		case <-t.Dying():
 			break forloop
+		case <-dsrTicker.C:
+			s.lock.Lock()
+			s.reconcileDSRVIPs()
+			s.lock.Unlock()
 		case evt := <-s.cniEventChan:
 			switch evt.Type {
 			case common.FelixConfChanged:
@@ -364,6 +390,18 @@ forloop:
 				s.lock.Lock()
 				s.tuntapDriver.FelixConfigChanged(nil /* felixConfig */, ipipEncapRefCountDelta, vxlanEncapRefCountDelta, s.podInterfaceMap)
 				s.lock.Unlock()
+			case common.ServiceDSRClusterIPAdded:
+				if svc, ok := evt.New.(*common.DSRService); ok {
+					s.handleDSRServiceAdded(svc)
+				} else {
+					s.log.Errorf("evt.New is not a *common.DSRService %v", evt.New)
+				}
+			case common.ServiceDSRClusterIPDeleted:
+				if svc, ok := evt.Old.(*common.DSRService); ok {
+					s.handleDSRServiceDeleted(svc)
+				} else {
+					s.log.Errorf("evt.Old is not a *common.DSRService %v", evt.Old)
+				}
 			}
 		}
 	}

--- a/calico-vpp-agent/common/dsr.go
+++ b/calico-vpp-agent/common/dsr.go
@@ -1,0 +1,19 @@
+package common
+
+import "net"
+
+// DSRService describes an SRv6-native / NAT-less (DSR) ClusterIP service,
+// published by the services server and consumed by the SRv6 and CNI servers.
+type DSRService struct {
+	VIP       net.IP   // service ClusterIP
+	Backends  []net.IP // all pod-backed endpoint IPs (local + remote)
+	ServiceID string   // namespace/name, for logging
+}
+
+// Key identifies a DSR service by its VIP.
+func (d *DSRService) Key() string {
+	if d == nil || d.VIP == nil {
+		return ""
+	}
+	return d.VIP.String()
+}

--- a/calico-vpp-agent/common/pubsub.go
+++ b/calico-vpp-agent/common/pubsub.go
@@ -37,6 +37,11 @@ const (
 	SRv6PolicyAdded   CalicoVppEventType = "SRv6PolicyAdded"
 	SRv6PolicyDeleted CalicoVppEventType = "SRv6PolicyDeleted"
 
+	// ServiceDSRClusterIP{Added,Deleted} carry a *DSRService, consumed by the
+	// SRv6 provider (policy+steering) and CNI server (pod VIP bind + delivery).
+	ServiceDSRClusterIPAdded   CalicoVppEventType = "ServiceDSRClusterIPAdded"
+	ServiceDSRClusterIPDeleted CalicoVppEventType = "ServiceDSRClusterIPDeleted"
+
 	PodAdded   CalicoVppEventType = "PodAdded"
 	PodDeleted CalicoVppEventType = "PodDeleted"
 

--- a/calico-vpp-agent/connectivity/connectivity_server.go
+++ b/calico-vpp-agent/connectivity/connectivity_server.go
@@ -18,6 +18,7 @@ package connectivity
 import (
 	"fmt"
 	"net"
+	"time"
 
 	"github.com/pkg/errors"
 	felixConfig "github.com/projectcalico/calico/felix/config"
@@ -89,6 +90,8 @@ func NewConnectivityServer(vpp *vpplink.VppLink, felixServerIpam common.FelixSer
 		common.IpamConfChanged,
 		common.SRv6PolicyAdded,
 		common.SRv6PolicyDeleted,
+		common.ServiceDSRClusterIPAdded,
+		common.ServiceDSRClusterIPDeleted,
 		common.WireguardPublicKeyChanged,
 	)
 
@@ -162,11 +165,20 @@ func (s *ConnectivityServer) ServeConnectivity(t *tomb.Tomb) error {
 	for _, provider := range s.providers {
 		provider.RescanState()
 	}
+	// Periodically reconcile SRv6-native (DSR) services so a withdrawn-service
+	// cleanup (or install) that failed is retried even when no further events
+	// arrive (e.g. the last DSR service was deleted in a quiet cluster).
+	dsrTicker := time.NewTicker(30 * time.Second)
+	defer dsrTicker.Stop()
 	for {
 		select {
 		case <-t.Dying():
 			s.log.Warn("Connectivity Server asked to stop")
 			return nil
+		case <-dsrTicker.C:
+			if p, ok := s.providers[SRv6].(*SRv6Provider); ok {
+				p.reconcileDSRServices()
+			}
 		case evt := <-s.connectivityEventChan:
 			/* Note: we will only receive events we ask for when registering the chan */
 			switch evt.Type {
@@ -287,6 +299,22 @@ func (s *ConnectivityServer) ServeConnectivity(t *tomb.Tomb) error {
 				err := s.UpdateSRv6Policy(old, true /* isWithdraw */)
 				if err != nil {
 					s.log.Errorf("Error while deleting SRv6 Policy %s", err)
+				}
+			case common.ServiceDSRClusterIPAdded:
+				if svc, ok := evt.New.(*common.DSRService); !ok {
+					s.log.Errorf("evt.New is not a *common.DSRService %v", evt.New)
+				} else if p, ok := s.providers[SRv6].(*SRv6Provider); ok {
+					if err := p.UpdateDSRService(svc, false /* isWithdraw */); err != nil {
+						s.log.Errorf("Error while adding DSR service: %s", err)
+					}
+				}
+			case common.ServiceDSRClusterIPDeleted:
+				if svc, ok := evt.Old.(*common.DSRService); !ok {
+					s.log.Errorf("evt.Old is not a *common.DSRService %v", evt.Old)
+				} else if p, ok := s.providers[SRv6].(*SRv6Provider); ok {
+					if err := p.UpdateDSRService(svc, true /* isWithdraw */); err != nil {
+						s.log.Errorf("Error while deleting DSR service: %s", err)
+					}
 				}
 			}
 		}

--- a/calico-vpp-agent/connectivity/srv6.go
+++ b/calico-vpp-agent/connectivity/srv6.go
@@ -13,6 +13,7 @@ import (
 	"github.com/projectcalico/vpp-dataplane/v3/calico-vpp-agent/common"
 	"github.com/projectcalico/vpp-dataplane/v3/config"
 	"github.com/projectcalico/vpp-dataplane/v3/vpplink"
+	"github.com/projectcalico/vpp-dataplane/v3/vpplink/generated/bindings/interface_types"
 	"github.com/projectcalico/vpp-dataplane/v3/vpplink/generated/bindings/ip_types"
 	"github.com/projectcalico/vpp-dataplane/v3/vpplink/types"
 )
@@ -44,10 +45,16 @@ type SRv6Provider struct {
 	policyIPPool net.IPNet
 	// localSidIPPool is IP pool for LocalSID's SIDs (SID = IPv6 address in SRv6)
 	localSidIPPool net.IPNet
+	// dsrServices tracks the SR policy + steering installed for SRv6-native /
+	// NAT-less (DSR) ClusterIP services, keyed by VIP string.
+	dsrServices map[string]*dsrServiceState
+	// dsrDesired is the desired DSR service set (by VIP) — the source of truth
+	// reconciled against dsrServices, so failed installs AND removals retry.
+	dsrDesired map[string]*common.DSRService
 }
 
 func NewSRv6Provider(d *ConnectivityProviderData) *SRv6Provider {
-	p := &SRv6Provider{d, make(map[string]*NodeToPrefixes), make(map[string]*NodeToPolicies), net.IPNet{}, net.IPNet{}}
+	p := &SRv6Provider{d, make(map[string]*NodeToPrefixes), make(map[string]*NodeToPolicies), net.IPNet{}, net.IPNet{}, make(map[string]*dsrServiceState), make(map[string]*common.DSRService)}
 	if *config.GetCalicoVppFeatureGates().SRv6Enabled {
 		p.localSidIPPool = cnet.MustParseNetwork(config.GetCalicoVppSrv6().LocalsidPool).IPNet
 		p.policyIPPool = cnet.MustParseNetwork(config.GetCalicoVppSrv6().PolicyPool).IPNet
@@ -259,6 +266,10 @@ func (p *SRv6Provider) AddConnectivity(cn *common.NodeConnectivity) (err error) 
 		p.steerNodeIPViaSID(nodeip)
 	}
 
+	// A backend node's End.DT6 SID may have just become available (or a pending
+	// DSR removal may need retrying); reconcile the DSR services.
+	p.reconcileDSRServices()
+
 	return err
 }
 
@@ -318,16 +329,45 @@ func (p *SRv6Provider) createLocalSidTunnels(currentLocalSids []*types.SrLocalsi
 	p.log.Infof("SRv6Provider createLocalSidTunnels")
 	endDt4Exist := false
 	endDt6Exist := false
+	// End.DT must decap into PodVRFIndex (where pod + DSR delivery routes live).
+	// VPP takes the decap VRF from sw_if_index, so a correct End.DT has
+	// SwIfIndex == PodVRFIndex.
+	podVRF := interface_types.InterfaceIndex(common.PodVRFIndex)
 	for _, localSid := range currentLocalSids {
 		p.log.Debugf("Found existing SRv6Localsid: %s", localSid.String())
 
-		if localSid.Behavior == types.SrBehaviorDT6 && localSid.FibTable == 0 {
-			endDt6Exist = true
+		isDT6 := localSid.Behavior == types.SrBehaviorDT6
+		isDT4 := localSid.Behavior == types.SrBehaviorDT4
+		if !isDT6 && !isDT4 {
+			continue
 		}
 
-		if localSid.Behavior == types.SrBehaviorDT4 && localSid.FibTable == 0 {
-			endDt4Exist = true
+		if localSid.SwIfIndex == podVRF {
+			endDt6Exist = endDt6Exist || isDT6
+			endDt4Exist = endDt4Exist || isDT4
+			continue
 		}
+
+		// Migrate a stale localsid created by an older agent to decap into the
+		// main table: delete it and re-add it at the same SID address decapping
+		// into PodVRFIndex, so remote nodes keep encapsulating to the same SID.
+		p.log.Infof("SRv6Provider migrating End.DT localsid %s into PodVRFIndex", localSid.Localsid.String())
+		if err := p.vpp.DelSRv6Localsid(localSid); err != nil {
+			p.log.Errorf("SRv6Provider migrate: delete stale localsid %s: %v", localSid.Localsid.String(), err)
+			continue
+		}
+		migrated := &types.SrLocalsid{
+			Localsid:  localSid.Localsid,
+			EndPsp:    false,
+			SwIfIndex: podVRF,
+			Behavior:  localSid.Behavior,
+		}
+		if err := p.vpp.AddSRv6Localsid(migrated); err != nil {
+			p.log.Errorf("SRv6Provider migrate: re-add localsid %s in PodVRFIndex: %v", localSid.Localsid.String(), err)
+			continue
+		}
+		endDt6Exist = endDt6Exist || isDT6
+		endDt4Exist = endDt4Exist || isDT4
 	}
 	if !endDt4Exist {
 		if localSidDT4, err := p.setEndDT(4); err != nil {
@@ -370,8 +410,10 @@ func (p *SRv6Provider) setEndDT(typeDT int) (newLocalSid *types.SrLocalsid, err 
 	newLocalSid = &types.SrLocalsid{
 		Localsid: newLocalSidAddr,
 		EndPsp:   false,
-		FibTable: 0,
-		Behavior: behavior,
+		// End.DT reads the decap VRF from sw_if_index (not fib_table); point it
+		// at PodVRFIndex so the inner packet resolves in the pod VRF.
+		SwIfIndex: interface_types.InterfaceIndex(common.PodVRFIndex),
+		Behavior:  behavior,
 	}
 	if err = p.vpp.AddSRv6Localsid(newLocalSid); err != nil {
 		p.log.Infof("SRv6Provider Error adding LocalSid")

--- a/calico-vpp-agent/connectivity/srv6_dsr.go
+++ b/calico-vpp-agent/connectivity/srv6_dsr.go
@@ -1,0 +1,255 @@
+package connectivity
+
+import (
+	"net"
+
+	"github.com/pkg/errors"
+
+	"github.com/projectcalico/vpp-dataplane/v3/calico-vpp-agent/common"
+	"github.com/projectcalico/vpp-dataplane/v3/config"
+	"github.com/projectcalico/vpp-dataplane/v3/vpplink/generated/bindings/ip_types"
+	"github.com/projectcalico/vpp-dataplane/v3/vpplink/types"
+)
+
+// dsrServiceState tracks the SR policy + steering installed for a DSR ClusterIP.
+type dsrServiceState struct {
+	vip    net.IP
+	bsid   ip_types.IP6Address
+	policy *types.SrPolicy
+	steer  *types.SrSteer
+}
+
+// UpdateDSRService records/withdraws a DSR ClusterIP in the desired set and
+// reconciles. The client-side steers VIP traffic over a per-service ECMP SR
+// policy (one weighted SID list per backend node's End.DT6 SID); local backends
+// are delivered by the CNI server in PodVRFIndex and excluded here.
+func (p *SRv6Provider) UpdateDSRService(svc *common.DSRService, isWithdraw bool) error {
+	if !*config.GetCalicoVppFeatureGates().SRv6Enabled || svc == nil || svc.VIP == nil {
+		return nil
+	}
+	key := svc.VIP.String()
+	if isWithdraw {
+		delete(p.dsrDesired, key)
+	} else {
+		p.dsrDesired[key] = svc
+	}
+	p.reconcileDSRServices()
+	return nil
+}
+
+// reconcileDSRServices drives installed DSR state toward the desired set,
+// retrying failed installs and removals (called on DSR + connectivity events).
+func (p *SRv6Provider) reconcileDSRServices() {
+	for _, svc := range p.dsrDesired {
+		if err := p.programDSRService(svc); err != nil {
+			p.log.Errorf("SRv6Provider DSR program vip %s: %v", svc.VIP, err)
+		}
+	}
+	for key := range p.dsrServices {
+		if _, ok := p.dsrDesired[key]; !ok {
+			p.removeDSRService(key)
+		}
+	}
+}
+
+// programDSRService installs (idempotently) the per-service SR policy + steering.
+func (p *SRv6Provider) programDSRService(svc *common.DSRService) error {
+	key := svc.VIP.String()
+	// Group remote backends by node (exclude this node).
+	_, myIP6 := p.GetNodeIPs()
+	weights := make(map[string]uint32)
+	for _, beIP := range svc.Backends {
+		nodeIP := p.findNodeForPrefix(beIP)
+		if nodeIP == nil {
+			p.log.Infof("SRv6Provider DSR: no node for backend %s (vip %s), skipping", beIP, key)
+			continue
+		}
+		if myIP6 != nil && nodeIP.Equal(*myIP6) {
+			continue // local backend, delivered by CNI in PodVRFIndex
+		}
+		weights[nodeIP.String()]++
+	}
+
+	if len(weights) == 0 {
+		// No remote backends: local delivery suffices; drop any stale steer.
+		p.removeDSRService(key)
+		return nil
+	}
+
+	// One weighted SID list per backend node, ending at its End.DT6 SID.
+	var sidLists []types.Srv6SidList
+	for nodeIPStr, w := range weights {
+		policy, err := p.getPolicyNode(nodeIPStr, types.SrBehaviorDT6)
+		if err != nil || policy == nil || len(policy.SidLists) == 0 || policy.SidLists[0].NumSids == 0 {
+			p.log.Infof("SRv6Provider DSR: no DT6 SID for node %s yet (vip %s), skipping", nodeIPStr, key)
+			continue
+		}
+		sl := types.Srv6SidList{NumSids: 1, Weight: w}
+		sl.Sids[0] = policy.SidLists[0].Sids[0]
+		sidLists = append(sidLists, sl)
+	}
+	if len(sidLists) == 0 {
+		p.log.Infof("SRv6Provider DSR: no usable backend node SIDs yet for vip %s; will retry on next reconcile", key)
+		return nil
+	}
+
+	// Skip if already installed identically (guard st.policy: a partial remove
+	// may have nil'd it). Lets re-publish retry without churning steady state.
+	if st, ok := p.dsrServices[key]; ok && st.steer != nil && st.policy != nil && sameSidLists(st.policy.SidLists, sidLists) {
+		return nil
+	}
+
+	// Reuse the chosen BSID for stability; derive (collision-avoiding) on first install.
+	var bsid ip_types.IP6Address
+	if st, ok := p.dsrServices[key]; ok {
+		bsid = st.bsid
+	} else {
+		bsid = p.dsrBsidForVIP(svc.VIP)
+	}
+	policy := &types.SrPolicy{
+		Bsid:     bsid,
+		IsEncap:  true,
+		FibTable: 0,
+		SidLists: sidLists,
+	}
+	if err := p.vpp.AddModSRv6Policy(policy); err != nil {
+		return errors.Wrapf(err, "SRv6Provider DSR AddModSRv6Policy vip %s", key)
+	}
+
+	prefix, err := ip_types.ParsePrefix(svc.VIP.String() + "/128")
+	if err != nil {
+		return errors.Wrapf(err, "SRv6Provider DSR parse vip prefix %s", key)
+	}
+	steer := &types.SrSteer{
+		TrafficType: types.SrSteerIPv6,
+		FibTable:    0,
+		Prefix:      prefix,
+		Bsid:        bsid,
+	}
+	if st, ok := p.dsrServices[key]; ok && st.steer != nil {
+		_ = p.vpp.DelSRv6Steering(st.steer)
+	}
+	if err := p.vpp.AddSRv6Steering(steer); err != nil {
+		return errors.Wrapf(err, "SRv6Provider DSR AddSRv6Steering vip %s", key)
+	}
+	p.dsrServices[key] = &dsrServiceState{vip: svc.VIP, bsid: bsid, policy: policy, steer: steer}
+	p.log.Infof("SRv6Provider DSR: vip %s steered over %d backend node(s)", key, len(sidLists))
+	return nil
+}
+
+// removeDSRService withdraws the SR policy + steering for a VIP, nil'ing the
+// parts that succeeded so the next reconcile retries only what failed.
+func (p *SRv6Provider) removeDSRService(key string) {
+	st, ok := p.dsrServices[key]
+	if !ok {
+		return
+	}
+	failed := false
+	if st.steer != nil {
+		if err := p.vpp.DelSRv6Steering(st.steer); err != nil {
+			p.log.Errorf("SRv6Provider DSR DelSRv6Steering vip %s: %v", key, err)
+			failed = true
+		} else {
+			st.steer = nil
+		}
+	}
+	if st.policy != nil {
+		if err := p.vpp.DelSRv6Policy(st.policy); err != nil {
+			p.log.Errorf("SRv6Provider DSR DelSRv6Policy vip %s: %v", key, err)
+			failed = true
+		} else {
+			st.policy = nil
+		}
+	}
+	if failed {
+		return // keep state; retried on next reconcile
+	}
+	delete(p.dsrServices, key)
+}
+
+// sameSidLists reports whether two sets of single-SID weighted lists are equal
+// (order-independent). ip_types.IP6Address is an array, hence comparable.
+func sameSidLists(a, b []types.Srv6SidList) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	type key struct {
+		sid    ip_types.IP6Address
+		weight uint32
+	}
+	m := make(map[key]int)
+	for _, sl := range a {
+		m[key{sl.Sids[0], sl.Weight}]++
+	}
+	for _, sl := range b {
+		m[key{sl.Sids[0], sl.Weight}]--
+	}
+	for _, v := range m {
+		if v != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// findNodeForPrefix returns the node IP whose advertised pod prefix contains ip.
+func (p *SRv6Provider) findNodeForPrefix(ip net.IP) net.IP {
+	for _, np := range p.nodePrefixes {
+		for _, prefix := range np.Prefixes {
+			ipnet := prefix.ToIPNet()
+			if ipnet != nil && ipnet.Contains(ip) {
+				return np.Node
+			}
+		}
+	}
+	return nil
+}
+
+// dsrBsidForVIP derives a service BSID from the policy pool (prefix + VIP host
+// bytes), perturbed to avoid colliding with an in-use per-node BSID (which are
+// IPAM-allocated from the same pool — a collision would clobber pod connectivity).
+func (p *SRv6Provider) dsrBsidForVIP(vip net.IP) ip_types.IP6Address {
+	bsid := make(net.IP, net.IPv6len)
+	copy(bsid, p.policyIPPool.IP.To16())
+	v := vip.To16()
+	ones, _ := p.policyIPPool.Mask.Size()
+	for i := ones / 8; i < net.IPv6len && i < len(v); i++ {
+		bsid[i] = v[i]
+	}
+	taken := p.takenBsids()
+	for tries := 0; tries < 1024 && taken[bsid.String()]; tries++ {
+		bsid[net.IPv6len-1]++ // perturb low byte until free
+	}
+	return types.ToVppIP6Address(bsid)
+}
+
+// takenBsids returns BSIDs in use by non-DSR (per-node) SR policies, so DSR
+// derivation avoids clobbering them. Own DSR policies are excluded.
+func (p *SRv6Provider) takenBsids() map[string]bool {
+	m := make(map[string]bool)
+	for _, np := range p.nodePolices {
+		for _, t := range np.SRv6Tunnel {
+			if t.Bsid != nil {
+				m[t.Bsid.String()] = true
+			}
+		}
+	}
+	if pols, err := p.vpp.ListSRv6Policies(); err == nil {
+		for _, pol := range pols {
+			if p.isOwnDSRBsid(pol.Bsid) {
+				continue
+			}
+			m[pol.Bsid.ToIP().String()] = true
+		}
+	}
+	return m
+}
+
+func (p *SRv6Provider) isOwnDSRBsid(b ip_types.IP6Address) bool {
+	for _, st := range p.dsrServices {
+		if st.bsid == b {
+			return true
+		}
+	}
+	return false
+}

--- a/calico-vpp-agent/services/service.go
+++ b/calico-vpp-agent/services/service.go
@@ -29,4 +29,7 @@ type serviceInfo struct {
 	keepOriginalPacket bool
 	lbType             lbType
 	hashConfig         types.IPFlowHash
+	// srv6Native opts this service into the SRv6-native / NAT-less (DSR) path
+	// (cni.projectcalico.org/vppSRv6Native: "true").
+	srv6Native bool
 }

--- a/calico-vpp-agent/services/service_dsr.go
+++ b/calico-vpp-agent/services/service_dsr.go
@@ -1,0 +1,159 @@
+package services
+
+import (
+	"net"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	discoveryv1 "k8s.io/api/discovery/v1"
+
+	"github.com/projectcalico/vpp-dataplane/v3/calico-vpp-agent/common"
+	"github.com/projectcalico/vpp-dataplane/v3/config"
+)
+
+// dsrEligible reports whether a service should use the SRv6-native (DSR) path
+// instead of cnat: requires the feature gate + opt-in annotation, ClusterIP
+// type, port==targetPort on every port, and pod-backed endpoints.
+func (s *Server) dsrEligible(service *v1.Service, epSlices []*discoveryv1.EndpointSlice, svcInfo *serviceInfo) bool {
+	gates := config.GetCalicoVppFeatureGates()
+	if gates.SRv6NativeServicesEnabled == nil || !*gates.SRv6NativeServicesEnabled {
+		return false
+	}
+	if gates.SRv6Enabled == nil || !*gates.SRv6Enabled {
+		return false
+	}
+	if !svcInfo.srv6Native {
+		return false
+	}
+	if service.Spec.Type != v1.ServiceTypeClusterIP {
+		return false
+	}
+	// External/LB IPs stay on cnat; keep the whole service on cnat for consistency.
+	if len(service.Spec.ExternalIPs) > 0 || len(service.Status.LoadBalancer.Ingress) > 0 {
+		return false
+	}
+	for _, port := range service.Spec.Ports {
+		tp := port.TargetPort
+		if tp.Type == intstr.String { // named targetPort: can't verify port==targetPort
+			s.log.Warnf("svc(dsr) %s/%s: named targetPort not supported, falling back to cnat", service.Namespace, service.Name)
+			return false
+		}
+		if tp.IntVal != 0 && tp.IntVal != port.Port {
+			s.log.Warnf("svc(dsr) %s/%s: port remap %d->%d not supported, falling back to cnat", service.Namespace, service.Name, port.Port, tp.IntVal)
+			return false
+		}
+	}
+	// Backends must be pod-backed (IP in a Calico IPAM pool); host-network
+	// services (endpoint == node IP) can't be DSR-delivered, so keep them on cnat.
+	if s.felixServerIpam != nil {
+		for _, epslice := range epSlices {
+			for _, ep := range epslice.Endpoints {
+				if ep.Conditions.Ready != nil && !*ep.Conditions.Ready {
+					continue
+				}
+				for _, addr := range ep.Addresses {
+					ip := net.ParseIP(addr)
+					if ip == nil || ip.To4() != nil {
+						continue
+					}
+					if s.felixServerIpam.GetPrefixIPPool(common.ToMaxLenCIDR(ip)) == nil {
+						s.log.Warnf("svc(dsr) %s/%s: backend %s is not pod-backed (not in an IPAM pool); falling back to cnat", service.Namespace, service.Name, addr)
+						return false
+					}
+				}
+			}
+		}
+	}
+	return true
+}
+
+// buildDSRServices returns one common.DSRService per (IPv6) ClusterIP of a
+// DSR-eligible service, carrying all of its ready pod-backed backend IPs.
+func (s *Server) buildDSRServices(service *v1.Service, epSlices []*discoveryv1.EndpointSlice, svcInfo *serviceInfo) []common.DSRService {
+	if !s.dsrEligible(service, epSlices, svcInfo) {
+		return nil
+	}
+	backendSet := make(map[string]net.IP)
+	for _, epslice := range epSlices {
+		for _, ep := range epslice.Endpoints {
+			if ep.Conditions.Ready != nil && !*ep.Conditions.Ready {
+				continue
+			}
+			for _, addr := range ep.Addresses {
+				ip := net.ParseIP(addr)
+				if ip == nil || ip.To4() != nil {
+					continue // IPv6 backends only for now
+				}
+				backendSet[ip.String()] = ip
+			}
+		}
+	}
+	backends := make([]net.IP, 0, len(backendSet))
+	for _, ip := range backendSet {
+		backends = append(backends, ip)
+	}
+
+	var out []common.DSRService
+	for _, cip := range service.Spec.ClusterIPs {
+		vip := net.ParseIP(cip)
+		if vip == nil || vip.To4() != nil || vip.IsUnspecified() {
+			continue // IPv6 ClusterIP only for now
+		}
+		out = append(out, common.DSRService{
+			VIP:       vip,
+			Backends:  backends,
+			ServiceID: objectID(&service.ObjectMeta),
+		})
+	}
+	return out
+}
+
+// handleDSREntries publishes add/delete events for a service's DSR entries,
+// diffing against tracked state (robust to caller arg order). Deletion is
+// handled in deleteServiceByName.
+func (s *Server) handleDSREntries(service *LocalService, _ *LocalService) {
+	if service == nil {
+		return
+	}
+	serviceID := service.ServiceID
+	desired := make(map[string]common.DSRService)
+	for _, d := range service.DSREntries {
+		desired[d.Key()] = d
+	}
+	s.reconcileDSR(serviceID, desired)
+}
+
+// reconcileDSR diffs the desired DSR entries for a service against the tracked
+// set and publishes the resulting add/delete events.
+func (s *Server) reconcileDSR(serviceID string, desired map[string]common.DSRService) {
+	prev := s.dsrByServiceID[serviceID]
+
+	// VIPs present before but gone now.
+	for key, d := range prev {
+		if _, ok := desired[key]; !ok {
+			entry := d
+			s.log.Infof("svc(dsr-del) %s vip=%s", entry.ServiceID, key)
+			common.SendEvent(common.CalicoVppEvent{
+				Type: common.ServiceDSRClusterIPDeleted,
+				Old:  &entry,
+			})
+		}
+	}
+	// Always re-publish desired VIPs (consumers are idempotent); the periodic
+	// informer resync thus retries any programming that previously failed.
+	for _, d := range desired {
+		entry := d
+		s.log.Debugf("svc(dsr-add) %s vip=%s backends=%d", entry.ServiceID, entry.Key(), len(entry.Backends))
+		common.SendEvent(common.CalicoVppEvent{
+			Type: common.ServiceDSRClusterIPAdded,
+			New:  &entry,
+		})
+	}
+
+	if len(desired) == 0 {
+		delete(s.dsrByServiceID, serviceID)
+	} else {
+		s.dsrByServiceID[serviceID] = desired
+	}
+}

--- a/calico-vpp-agent/services/service_handler.go
+++ b/calico-vpp-agent/services/service_handler.go
@@ -158,6 +158,10 @@ func (s *Server) GetLocalService(service *v1.Service, epSlicesMap map[string]*di
 	}
 
 	serviceSpec := s.ParseServiceAnnotations(service.Annotations, service.Name)
+	// DSR-eligible ClusterIPs are steered/delivered over SRv6 (NAT-less) instead
+	// of being programmed as cnat translations.
+	dsr := s.dsrEligible(service, epSlices, serviceSpec)
+	localService.DSREntries = s.buildDSRServices(service, epSlices, serviceSpec)
 	var clusterIPs []net.IP
 	var nodeIPs []net.IP
 	for _, cip := range service.Spec.ClusterIPs {
@@ -166,7 +170,8 @@ func (s *Server) GetLocalService(service *v1.Service, epSlicesMap map[string]*di
 	}
 	for _, servicePort := range service.Spec.Ports {
 		for _, cip := range clusterIPs {
-			if !cip.IsUnspecified() && len(cip) > 0 {
+			// Skip cnat for ClusterIPs handled by the SRv6-native (DSR) path.
+			if !dsr && !cip.IsUnspecified() && len(cip) > 0 {
 				entry := s.buildCnatEntryForServicePort(&servicePort, epSlices, cip, false /* isNodePort */, *serviceSpec, InternalIsLocalOnly(service))
 				localService.Entries = append(localService.Entries, *entry)
 			}
@@ -301,6 +306,8 @@ func (s *Server) deleteServiceEntries(entries []types.CnatTranslateEntry, oldSer
 func (s *Server) deleteServiceByName(serviceID string) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
+	// Withdraw any SRv6-native (DSR) entries published for this service.
+	s.reconcileDSR(serviceID, nil)
 	for key := range s.cnatEntryBySidAndKey[serviceID] {
 		s.deleteServiceEntry(key, serviceID)
 	}

--- a/calico-vpp-agent/services/service_server.go
+++ b/calico-vpp-agent/services/service_server.go
@@ -50,6 +50,9 @@ type LocalService struct {
 	Entries        []types.CnatTranslateEntry
 	SpecificRoutes []net.IP
 	ServiceID      string
+	// DSREntries holds DSR ClusterIP entries; those ClusterIPs use SRv6 DSR
+	// instead of cnat.
+	DSREntries []common.DSRService
 }
 
 /**
@@ -63,6 +66,7 @@ type cnatEntry struct {
 type Server struct {
 	log                    *logrus.Entry
 	vpp                    *vpplink.VppLink
+	felixServerIpam        common.FelixServerIpam
 	endpointslicesStore    cache.Store
 	serviceStore           cache.Store
 	serviceInformer        cache.Controller
@@ -83,6 +87,10 @@ type Server struct {
 	// cache of all endpoint slices, by service name
 	endpointSlicesByService map[string]map[string]*discoveryv1.EndpointSlice
 	endpointSlices          map[string]*discoveryv1.EndpointSlice
+
+	// dsrByServiceID tracks the DSR entries we've published, keyed by service id
+	// then VIP, so we can diff/withdraw them (including on service deletion).
+	dsrByServiceID map[string]map[string]common.DSRService
 
 	t tomb.Tomb
 }
@@ -140,6 +148,12 @@ func (s *Server) ParseServiceAnnotations(annotations map[string]string, name str
 			if err1 != nil {
 				err = append(err, errors.Wrapf(err1, "Unknown value %s for key %s", value, key))
 			}
+		case config.SRv6NativeAnnotation:
+			var err1 error
+			svc.srv6Native, err1 = strconv.ParseBool(value)
+			if err1 != nil {
+				err = append(err, errors.Wrapf(err1, "Unknown value %s for key %s", value, key))
+			}
 		default:
 			continue
 		}
@@ -157,15 +171,17 @@ func (s *Server) resolveLocalServiceFromService(service *v1.Service) *LocalServi
 	return s.GetLocalService(service, s.endpointSlicesByService[objectID(&service.ObjectMeta)])
 }
 
-func NewServiceServer(vpp *vpplink.VppLink, k8sclient *kubernetes.Clientset, log *logrus.Entry) *Server {
+func NewServiceServer(vpp *vpplink.VppLink, k8sclient *kubernetes.Clientset, felixServerIpam common.FelixServerIpam, log *logrus.Entry) *Server {
 	server := Server{
 		vpp:                     vpp,
+		felixServerIpam:         felixServerIpam,
 		log:                     log,
 		cnatEntryByKeyAndSid:    make(map[string]map[string]*cnatEntry),
 		cnatEntryBySidAndKey:    make(map[string]map[string]*cnatEntry),
 		serviceIDByKey:          make(map[string]string),
 		endpointSlicesByService: make(map[string]map[string]*discoveryv1.EndpointSlice),
 		endpointSlices:          make(map[string]*discoveryv1.EndpointSlice),
+		dsrByServiceID:          make(map[string]map[string]common.DSRService),
 	}
 	serviceStore, serviceInformer := cache.NewInformerWithOptions(
 		cache.InformerOptions{
@@ -489,6 +505,7 @@ func (s *Server) handleServiceEndpointEvent(service *LocalService, oldService *L
 	if added, deleted, changed := compareSpecificRoutes(service, oldService); changed {
 		s.advertiseSpecificRoute(added, deleted)
 	}
+	s.handleDSREntries(service, oldService)
 }
 
 func (s *Server) getServiceIPs() ([]*net.IPNet, []*net.IPNet, []*net.IPNet) {

--- a/calico-vpp-agent/services/services_test.go
+++ b/calico-vpp-agent/services/services_test.go
@@ -96,7 +96,7 @@ var _ = Describe("Service creation functionality", func() {
 		}
 		_, serviceip, err := net.ParseCIDR("10.96.0.1/24")
 		config.ServiceCIDRs = &[]*net.IPNet{serviceip}
-		serviceServer = NewServiceServer(vpp, k8sclient, log.WithFields(logrus.Fields{"component": "services"}))
+		serviceServer = NewServiceServer(vpp, k8sclient, nil /* felixServerIpam */, log.WithFields(logrus.Fields{"component": "services"}))
 		_, ipv4net, err := net.ParseCIDR("1.1.1.1/32")
 		_, ipv6net, err := net.ParseCIDR("f::f/128")
 		serviceServer.SetOurBGPSpec(&common.LocalNodeSpec{

--- a/config/config.go
+++ b/config/config.go
@@ -80,6 +80,9 @@ const (
 	KeepOriginalPacketAnnotation string = "cni.projectcalico.org/vppKeepOriginalPacket"
 	HashConfigAnnotation         string = "cni.projectcalico.org/vppHashConfig"
 	LBTypeAnnotation             string = "cni.projectcalico.org/vppLBType"
+	// SRv6NativeAnnotation ("true") opts a ClusterIP service into the DSR path
+	// (requires the SRv6NativeServicesEnabled gate).
+	SRv6NativeAnnotation string = "cni.projectcalico.org/vppSRv6Native"
 )
 
 type BGPServerModeType string
@@ -400,6 +403,9 @@ type CalicoVppFeatureGatesConfigType struct {
 	SRv6Enabled       *bool `json:"srv6Enabled,omitempty"`
 	IPSecEnabled      *bool `json:"ipsecEnabled,omitempty"`
 	PrometheusEnabled *bool `json:"prometheusEnabled,omitempty"`
+	// SRv6NativeServicesEnabled serves eligible pod-backed ClusterIP services via
+	// SRv6 DSR instead of cnat. Experimental; requires SRv6Enabled.
+	SRv6NativeServicesEnabled *bool `json:"srv6NativeServicesEnabled,omitempty"`
 }
 
 func (cfg *CalicoVppFeatureGatesConfigType) Validate() (err error) {
@@ -409,6 +415,7 @@ func (cfg *CalicoVppFeatureGatesConfigType) Validate() (err error) {
 	cfg.SRv6Enabled = DefaultToPtr(cfg.SRv6Enabled, false)
 	cfg.IPSecEnabled = DefaultToPtr(cfg.IPSecEnabled, false)
 	cfg.PrometheusEnabled = DefaultToPtr(cfg.PrometheusEnabled, false)
+	cfg.SRv6NativeServicesEnabled = DefaultToPtr(cfg.SRv6NativeServicesEnabled, false)
 	return nil
 }
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -88,6 +88,7 @@ data:
     "vclEnabled": false,
     "multinetEnabled": true,
     "srv6Enabled": false,
+    "srv6NativeServicesEnabled": false,
     "ipsecEnabled": false
   }
 ````

--- a/docs/services/README.md
+++ b/docs/services/README.md
@@ -22,4 +22,32 @@ metadata:
 `srcport, dstport, srcaddr, dstaddr, iproto, reverse, symmetric`, that the
 forwarding of packets is based on.
 
+## SRv6-native (NAT-less) ClusterIP services
+
+When SRv6 is enabled, a ClusterIP service can be served over SRv6 steering with
+Direct Server Return instead of the cnat DNAT/un-DNAT path. The VIP is not
+translated: the client packet is steered to a backend node over an SRv6 policy,
+the backend pod binds the VIP and replies with it as source, so no reverse
+translation is needed and the client source address is preserved across nodes.
+
+This is opt-in and coexists with cnat. It requires:
+
+* the `srv6NativeServicesEnabled` feature gate
+  (see [config](../config/README.md)), and
+* the annotation below on the service.
+
+````yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service
+  annotations:
+    "cni.projectcalico.org/vppSRv6Native": "true"
+````
+
+Eligibility (first cut): pod-backed ClusterIP with `port == targetPort`. Services
+that are not eligible (host-backed, port remap, ExternalIP/LoadBalancer) keep the
+cnat path. This is distinct from the `maglevdsr` `vppLBType` above, which is a
+cnat load-balancing mode rather than SRv6-native steering.
+
 For troubleshooting, please consult [troubleshooting.md]


### PR DESCRIPTION
## Summary

Adds an opt-in SRv6-native data path for **pod-backed** ClusterIP Services that
uses Direct Server Return (DSR) instead of cnat.

In an IPv6 single-stack + SRv6 setup, cross-node pod-backed ClusterIP Services
break: cnat's reverse session lives in the main FIB and the `cnat-lookup` input
arc never runs on the SRv6-decapped inner packet, so the reply is never
un-DNAT'd (the SYN-ACK keeps the backend Pod IP → client RST). This is the
pod-backed counterpart of the host-network case fixed in #1028.

## Approach

Rather than make cnat compose with SRv6, steer the VIP over SRv6 and let the
backend accept it directly (DSR): the inner packet keeps `dst=VIP` end to end
and the backend replies with `src=VIP`, so no reverse translation is needed.
Source IP is preserved.

- **Opt-in**: feature gate `srv6NativeServicesEnabled` + Service annotation
  `cni.projectcalico.org/vppSRv6Native: "true"`. Eligible = ClusterIP, all ports
  `port==targetPort`, pod-backed. host-network / port-remapped / External-LB
  Services keep the cnat path.
- Per-service ECMP SR policy over the backend nodes' `End.DT6` SIDs + steering;
  backends bind the VIP and are allowed through uRPF; PodVRF delivery route.
  Reconcile-based, no NAT on the path.

Verified end to end on an IPv6 single-stack cluster: cross-node client reaches
the VIP with no cnat, no RST, and the client source IP preserved.
