### PR TITLE
[v3.30] refactor: switch kube-test backport to kustomize sources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,29 +30,46 @@ image-kind: image
 vpp:
 	$(MAKE) -C vpp-manager $@ VPP_DIR=$(VPP_DIR) BASE=$(BASE)
 
-# kube-test-template: emit a KinD manifest template for kube-test.
-# Bakes in repo layout-specific values (CALICOVPP_AGENT_IMAGE, VPP_BUILD_REL_PATH)
-# so that VPP kube-test does not need to know the repo layout.
-# Old layout: separate images, VPP build at vpp-manager/vpp_build/.
+# kube-test-template: emit a self-contained kube-test manifest for the
+# the requested cluster flavor. All CalicoVPP-internal layout details
+# (image names, in-repo paths to the VPP build output, etc.) are
+# resolved here from the kustomize sources under
+# yaml/overlays/kube-test-* and baked into the emitted manifest.
+#
+# Only consumer-owned runtime placeholders survive in the output:
+#   ${CALICOVPP_VERSION}, ${HOME}, ${ADDITIONAL_VPP_CONFIG},
+#   ${CALICOVPP_ENABLE_MEMIF}, ${CALICO_NETWORK_CONFIG} and
+#   ${CALICOVPP_INTERFACE} (baremetal only)
+#
+# The consumer (e.g. VPP `extras/kube-test`) does NOT need to know
+# which image to use or where the VPP build lives in this repo.
+#
+# Usage:
+#   make kube-test-template FLAVOR=kind        # default
+#   make kube-test-template FLAVOR=baremetal
+FLAVOR ?= kind
 .PHONY: kube-test-template
 kube-test-template:
-	@CALICOVPP_AGENT_IMAGE=calicovpp/agent VPP_BUILD_REL_PATH=vpp-manager/vpp_build \
-	  envsubst '$$CALICOVPP_AGENT_IMAGE $$VPP_BUILD_REL_PATH' \
-	  < yaml/generated/calico-vpp-kubetest.yaml
+	@if [ "$(FLAVOR)" != "kind" ] && [ "$(FLAVOR)" != "baremetal" ]; then \
+	  echo "kube-test-template: unsupported FLAVOR=$(FLAVOR) (expected kind or baremetal)" >&2; \
+	  exit 2; \
+	fi
+	@kubectl kustomize yaml/overlays/kube-test-$(FLAVOR) 2>/dev/null
+	@echo "---"
+	@cat yaml/components/kube-test/tigera-installation.snippet.yaml
 
-# kube-test-push-images: pull this release's CalicoVPP images from docker.io and push
-# to localhost:5000 for kube-test consumption. Called by kube-test release-cluster flow.
+# kube-test-push-images: pull this release's CalicoVPP images from docker.io
+# and push to localhost:5000 for kube-test consumption. Called by the
+# VPP kube-test `release-cluster` flow. On this split-image release,
+# we ship three images; master / >= v3.33 ships only `calicovpp/vpp`.
+KUBE_TEST_IMAGES ?= calicovpp/vpp calicovpp/agent calicovpp/multinet-monitor
 .PHONY: kube-test-push-images
 kube-test-push-images:
-	docker pull docker.io/calicovpp/agent:$(CALICOVPP_VERSION)
-	docker image tag docker.io/calicovpp/agent:$(CALICOVPP_VERSION) localhost:5000/calicovpp/agent:$(CALICOVPP_VERSION)
-	docker push localhost:5000/calicovpp/agent:$(CALICOVPP_VERSION)
-	docker pull docker.io/calicovpp/vpp:$(CALICOVPP_VERSION)
-	docker image tag docker.io/calicovpp/vpp:$(CALICOVPP_VERSION) localhost:5000/calicovpp/vpp:$(CALICOVPP_VERSION)
-	docker push localhost:5000/calicovpp/vpp:$(CALICOVPP_VERSION)
-	docker pull docker.io/calicovpp/multinet-monitor:$(CALICOVPP_VERSION)
-	docker image tag docker.io/calicovpp/multinet-monitor:$(CALICOVPP_VERSION) localhost:5000/calicovpp/multinet-monitor:$(CALICOVPP_VERSION)
-	docker push localhost:5000/calicovpp/multinet-monitor:$(CALICOVPP_VERSION)
+	@for img in $(KUBE_TEST_IMAGES); do \
+	  docker pull docker.io/$$img:$(CALICOVPP_VERSION); \
+	  docker image tag docker.io/$$img:$(CALICOVPP_VERSION) localhost:5000/$$img:$(CALICOVPP_VERSION); \
+	  docker push localhost:5000/$$img:$(CALICOVPP_VERSION); \
+	done
 
 .PHONY: kind-new-cluster
 kind-new-cluster:

--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,6 @@ require (
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
-	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/jinzhu/copier v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,6 @@ github.com/google/pprof v0.0.0-20241210010833-40e02aabc2ad/go.mod h1:vavhavw2zAx
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKeRZfjY=
-github.com/hashicorp/go-version v1.7.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=

--- a/yaml/Makefile
+++ b/yaml/Makefile
@@ -22,6 +22,16 @@ build: clean
 	kubectl kustomize overlays/eks-dpdk-multinet               > generated/calico-vpp-eks-dpdk-multinet.yaml
 	kubectl kustomize overlays/kind                            > generated/calico-vpp-kind.yaml
 	kubectl kustomize overlays/kind-multinet                   > generated/calico-vpp-kind-multinet.yaml
+	# Kube-test manifest (consumed by `make -C .. kube-test-template`).
+	# The kind flavor is checked-in as the canonical generated file; the
+	# baremetal flavor is generated on demand via `make kube-test-template
+	# FLAVOR=baremetal` from the repo root.
+	{ kubectl kustomize overlays/kube-test-kind ; \
+	  echo "---" ; \
+	  cat components/kube-test/tigera-installation.snippet.yaml ; \
+	} > generated/calico-vpp-kubetest.yaml
+	# Sanity-check the baremetal flavor compiles (not exported)
+	kubectl kustomize overlays/kube-test-baremetal              > /dev/null
 	# Do not export the test-* overlays, but still check they compile
 	kubectl kustomize overlays/test-vagrant                    > /dev/null
 	kubectl kustomize overlays/test-vagrant-mounts             > /dev/null

--- a/yaml/components/kube-test/README.md
+++ b/yaml/components/kube-test/README.md
@@ -1,0 +1,42 @@
+# Kube-test kustomize component
+
+This component transforms the standard CalicoVPP daemonset for use
+by the VPP `extras/kube-test` test harness (and other consumers that
+share its constraints).
+
+This file documents the **split-image** variant of the component used
+on release branches `<= v3.32`. `master`/`>= v3.33` ships a unified-image
+variant where the agent container reuses `calicovpp/vpp` with an explicit
+`command: ["/bin/calico-vpp-agent"]` override. Either way, the consumer
+just sees a working manifest.
+
+## What this component owns (consumer-agnostic, layout-aware)
+
+* Image references (registry `localhost:5000`, `imagePullPolicy: Always`).
+* The split-image layout: the `vpp` container uses `calicovpp/vpp` and the
+  `agent` container uses `calicovpp/agent` with no command override.
+* The path to the in-tree VPP build output that is bind-mounted into the
+  containers as `/repo/vpp-manager/vpp_build/...`.
+* The tigera-operator `Installation` and `APIServer` CRs that kube-test
+  needs to bootstrap Calico.
+
+When the layout changes, **only this component** (and its base manifest)
+needs to change. Consumers stay untouched.
+
+## What the consumer (e.g. VPP kube-test) owns
+
+Only the following placeholders survive in the emitted manifest and must
+be substituted by the consumer at apply-time (e.g. via `envsubst`):
+
+| Placeholder                   | Owner / typical source               |
+| ----------------------------- | ------------------------------------ |
+| `${CALICOVPP_VERSION}`        | image tag (`kt-master`, `v3.30.0`)   |
+| `${HOME}`                     | host path for calicovpp checkout     |
+| `${ADDITIONAL_VPP_CONFIG}`    | per-test extra VPP startup CLI       |
+| `${CALICOVPP_ENABLE_MEMIF}`   | per-test memif feature toggle        |
+| `${CALICO_NETWORK_CONFIG}`    | per-test calico-network override     |
+| `${CALICOVPP_INTERFACE}`      | baremetal-only: uplink NIC name      |
+
+The consumer MUST NOT need to know which image name to use, what the
+in-repo path of the VPP build directory is or any other CalicoVPP
+internal detail.

--- a/yaml/components/kube-test/baremetal/configmap-baremetal.yaml
+++ b/yaml/components/kube-test/baremetal/configmap-baremetal.yaml
@@ -1,0 +1,58 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: calico-vpp-config
+  namespace: calico-vpp-dataplane
+data:
+  CALICOVPP_CONFIG_TEMPLATE: |-
+    unix {
+      nodaemon
+      full-coredump
+      cli-listen /var/run/vpp/cli.sock
+      pidfile /run/vpp/vpp.pid
+      exec /etc/vpp/startup.exec
+    }
+    api-trace { on }
+    socksvr {
+        socket-name /var/run/vpp/vpp-api.sock
+    }
+    plugins {
+        plugin default { enable }
+        plugin dpdk_plugin.so { enable }
+        plugin calico_plugin.so { enable }
+        plugin ping_plugin.so { enable }
+        plugin dispatch_trace_plugin.so { enable }
+    }
+    buffers {
+      buffers-per-numa 131072
+    }
+    ${ADDITIONAL_VPP_CONFIG}
+  CALICOVPP_INITIAL_CONFIG: |-
+    {
+      "vppStartupSleepSeconds": 1,
+      "corePattern": "/var/lib/vpp/vppcore.%e.%p"
+    }
+  CALICOVPP_FEATURE_GATES: |-
+    {
+      "memifEnabled": true,
+      "vclEnabled": true
+    }
+  CALICOVPP_INTERFACES: |-
+    {
+      "maxPodIfSpec": {
+        "rx": 10, "tx": 10, "rxqsz": 1024, "txqsz": 1024
+      },
+      "defaultPodIfSpec": {
+        "rx": 1, "tx":1, "isl3": true
+      },
+      "vppHostTapSpec": {
+        "rx": 1, "tx":1, "rxqsz": 1024, "txqsz": 1024, "isl3": false
+      },
+      "uplinkInterfaces": [
+        {
+          "interfaceName": "${CALICOVPP_INTERFACE}",
+          "vppDriver": "dpdk"
+        }
+      ]
+    }
+  SERVICE_PREFIX: 10.96.0.0/12

--- a/yaml/components/kube-test/baremetal/daemonset-baremetal.yaml
+++ b/yaml/components/kube-test/baremetal/daemonset-baremetal.yaml
@@ -1,0 +1,29 @@
+# Baremetal kube-test overrides: DPDK driver requires hugepages and a
+# larger CPU allocation than the KinD flavor.
+#
+# Also, baremetal uses docker.io as the image registry (no kind-registry),
+# so we override the registry prefix back to docker.io and switch to
+# `imagePullPolicy: IfNotPresent` since images come from a public registry.
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: calico-vpp-node
+  namespace: calico-vpp-dataplane
+spec:
+  template:
+    spec:
+      containers:
+        - name: vpp
+          image: docker.io/calicovpp/vpp:${CALICOVPP_VERSION}
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              cpu: "10"
+              hugepages-2Mi: 4Gi
+              memory: 4Gi
+            requests:
+              cpu: "10"
+              memory: 4Gi
+        - name: agent
+          image: docker.io/calicovpp/agent:${CALICOVPP_VERSION}
+          imagePullPolicy: IfNotPresent

--- a/yaml/components/kube-test/baremetal/kustomization.yaml
+++ b/yaml/components/kube-test/baremetal/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+# Baremetal-flavor adjustments on top of components/kube-test:
+# - uplink interface name is provided by the consumer at apply-time
+# - DPDK driver
+# - hugepages and a larger buffer pool
+patchesStrategicMerge:
+- daemonset-baremetal.yaml
+- configmap-baremetal.yaml

--- a/yaml/components/kube-test/configmap-kube-test.yaml
+++ b/yaml/components/kube-test/configmap-kube-test.yaml
@@ -1,0 +1,70 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: calico-vpp-config
+  namespace: calico-vpp-dataplane
+data:
+  CALICOVPP_BGP_LOG_LEVEL: ""
+  CALICOVPP_CONFIG_EXEC_TEMPLATE: ""
+  CALICOVPP_CONFIG_TEMPLATE: |-
+    unix {
+      nodaemon
+      full-coredump
+      log /var/run/vpp/vpp.log
+      cli-listen /var/run/vpp/cli.sock
+      pidfile /run/vpp/vpp.pid
+    }
+    cpu {
+      workers 0
+    }
+    socksvr {
+      socket-name /var/run/vpp/vpp-api.sock
+    }
+    buffers {
+      buffers-per-numa 16384
+      page-size 4K
+    }
+    plugins {
+        plugin default { enable }
+        plugin calico_plugin.so { enable }
+        plugin dpdk_plugin.so { disable }
+    }
+    ${ADDITIONAL_VPP_CONFIG}
+  CALICOVPP_DEBUG: |-
+    {
+          "servicesEnabled": true,
+          "gsoEnabled": true
+        }
+  CALICOVPP_FEATURE_GATES: |-
+    {
+          "memifEnabled": true,
+          "vclEnabled": true,
+          "multinetEnabled": false,
+          "ipsecEnabled": false,
+          "prometheusEnabled": true
+        }
+  CALICOVPP_INIT_SCRIPT_TEMPLATE: ""
+  CALICOVPP_INITIAL_CONFIG: |-
+    {
+          "vppStartupSleepSeconds": 0,
+          "corePattern": "/var/lib/vpp/vppcore.%e.%p",
+          "defaultGWs": "",
+          "redirectToHostRules": [
+          {
+            "proto": "udp",
+            "port": 53,
+            "ip": "172.18.0.1"
+          }
+        ]
+        }
+  CALICOVPP_IPSEC: |-
+    {}
+  CALICOVPP_IPSEC_IKEV2_PSK: "keykeykey"
+  CALICOVPP_LOG_FORMAT: pretty
+  CALICOVPP_LOG_LEVEL: "debug"
+  CALICOVPP_SRV6: |-
+    {}
+  CALICOVPP_SWAP_DRIVER: ""
+  DEBUG: "false"
+  GOCOVERDIR: /repo/.coverage/kind
+  SERVICE_PREFIX: 11.96.0.0/12,fd10::0/120

--- a/yaml/components/kube-test/daemonset-kube-test.yaml
+++ b/yaml/components/kube-test/daemonset-kube-test.yaml
@@ -1,0 +1,59 @@
+# Strategic-merge patch on top of yaml/base/calico-vpp-daemonset.yaml
+# that adapts the daemonset for kube-test consumption.
+#
+# Layout-specific knowledge baked in here (split-image layout for <= v3.32):
+#   - vpp container image:         calicovpp/vpp
+#   - agent container image:       calicovpp/agent (no command override)
+#   - VPP build path inside repo:  vpp-manager/vpp_build
+#
+# From v3.33 onwards, we have an unified image (calicovpp/vpp with an explicit
+# command override) and a flatter repo layout (vpp_build/). When backporting
+# the kube-test integration to a different layout, update only this file and
+# baremetal/daemonset-baremetal.yaml; consumers stay untouched.
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: calico-vpp-node
+  namespace: calico-vpp-dataplane
+spec:
+  template:
+    spec:
+      containers:
+        - name: vpp
+          image: localhost:5000/calicovpp/vpp:${CALICOVPP_VERSION}
+          imagePullPolicy: Always
+          env:
+            - name: LD_LIBRARY_PATH
+              value: /repo/vpp-manager/vpp_build/build-root/install-vpp-native/vpp/
+          resources:
+            limits:
+              memory: 80Gi
+            requests:
+              cpu: 1
+              memory: 4Gi
+          volumeMounts:
+            - mountPath: /repo
+              name: repo-directory
+            - mountPath: /etc/ssl/certs/
+              name: ssl-certs
+            - mountPath: /usr/share/ca-certificates
+              name: share-certs
+        - name: agent
+          image: localhost:5000/calicovpp/agent:${CALICOVPP_VERSION}
+          imagePullPolicy: Always
+          env:
+            - name: CALICOVPP_ENABLE_MEMIF
+              value: ${CALICOVPP_ENABLE_MEMIF}
+          volumeMounts:
+            - mountPath: /repo
+              name: repo-directory
+      volumes:
+        - name: repo-directory
+          hostPath:
+            path: ${HOME}/vpp-dataplane
+        - name: ssl-certs
+          hostPath:
+            path: /etc/ssl/certs/
+        - name: share-certs
+          hostPath:
+            path: /usr/share/ca-certificates

--- a/yaml/components/kube-test/kind/configmap-kind.yaml
+++ b/yaml/components/kube-test/kind/configmap-kind.yaml
@@ -1,0 +1,32 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: calico-vpp-config
+  namespace: calico-vpp-dataplane
+data:
+  CALICOVPP_INTERFACES: |-
+    {
+        "defaultPodIfSpec": {
+          "rx": 1,
+          "tx": 1,
+          "rxqsz": 128,
+          "txqsz": 128,
+          "isl3": true,
+          "rxMode": "interrupt"
+        },
+        "vppHostTapSpec": {
+          "rx": 1,
+          "tx": 1,
+          "rxqsz": 512,
+          "txqsz": 512,
+          "isl3": false,
+          "rxMode": "interrupt"
+        },
+      "uplinkInterfaces": [
+        {
+          "interfaceName": "eth0",
+          "vppDriver": "af_packet",
+          "rxMode": "interrupt"
+        }
+      ]
+    }

--- a/yaml/components/kube-test/kind/kustomization.yaml
+++ b/yaml/components/kube-test/kind/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+# KinD-flavor adjustments on top of components/kube-test:
+# - uplink interface is the KinD bridge (eth0, af_packet)
+# - no hugepages
+patchesStrategicMerge:
+- configmap-kind.yaml

--- a/yaml/components/kube-test/kustomization.yaml
+++ b/yaml/components/kube-test/kustomization.yaml
@@ -1,0 +1,22 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+# Kube-test specific transformations applied on top of the standard
+# CalicoVPP daemonset. This component is intentionally consumer-agnostic:
+# it produces a manifest that VPP kube-test (or any other consumer) can
+# apply after substituting only its own runtime variables.
+#
+# Layout-specific values (image names, in-repo paths to VPP build, etc.)
+# are owned by THIS file and the base daemonset - they MUST NOT leak into
+# the consumer (VPP kube-test). Runtime placeholders that remain in the
+# emitted manifest are documented in yaml/components/kube-test/README.md.
+
+patchesStrategicMerge:
+- daemonset-kube-test.yaml
+- configmap-kube-test.yaml
+
+# Note: the tigera-operator `Installation`/`APIServer` resources are not part
+# of this component because they need to embed the `${CALICO_NETWORK_CONFIG}`
+# runtime placeholder, which is not a valid YAML scalar at kustomize parse
+# time. They are appended by `make kube-test-template` from
+# `components/kube-test/tigera-installation.snippet.yaml`.

--- a/yaml/components/kube-test/tigera-installation.snippet.yaml
+++ b/yaml/components/kube-test/tigera-installation.snippet.yaml
@@ -1,0 +1,29 @@
+# NOT a kustomize resource - this file embeds the `${CALICO_NETWORK_CONFIG}`
+# runtime placeholder which makes it invalid YAML until `envsubst` has run.
+# Appended verbatim by `make kube-test-template` after the kustomize build.
+apiVersion: operator.tigera.io/v1
+kind: APIServer
+metadata:
+  name: default
+spec: {}
+---
+apiVersion: operator.tigera.io/v1
+kind: Installation
+metadata:
+  name: default
+spec:
+  registry: localhost:5000
+  calicoNetwork:
+    ipPools:
+    - cidr: 11.0.0.0/24
+      encapsulation: IPIP
+      natOutgoing: Enabled
+    - cidr: fd20::/64
+      encapsulation: VXLAN
+      natOutgoing: Enabled
+    linuxDataplane: VPP
+    nodeAddressAutodetectionV4:
+      interface: eth0
+    nodeAddressAutodetectionV6:
+      interface: eth0
+    ${CALICO_NETWORK_CONFIG}

--- a/yaml/generated/calico-vpp-kubetest.yaml
+++ b/yaml/generated/calico-vpp-kubetest.yaml
@@ -223,13 +223,11 @@ data:
         }
       ]
     }
-  CALICOVPP_IPSEC: |-
-    {}
-  CALICOVPP_IPSEC_IKEV2_PSK: "keykeykey"
+  CALICOVPP_IPSEC: '{}'
+  CALICOVPP_IPSEC_IKEV2_PSK: keykeykey
   CALICOVPP_LOG_FORMAT: pretty
-  CALICOVPP_LOG_LEVEL: "debug"
-  CALICOVPP_SRV6: |-
-    {}
+  CALICOVPP_LOG_LEVEL: debug
+  CALICOVPP_SRV6: '{}'
   CALICOVPP_SWAP_DRIVER: ""
   DEBUG: "false"
   GOCOVERDIR: /repo/.coverage/kind
@@ -257,6 +255,8 @@ spec:
     spec:
       containers:
       - env:
+        - name: LD_LIBRARY_PATH
+          value: /repo/vpp-manager/vpp_build/build-root/install-vpp-native/vpp/
         - name: DATASTORE_TYPE
           value: kubernetes
         - name: WAIT_FOR_DATASTORE
@@ -265,8 +265,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        - name: LD_LIBRARY_PATH
-          value: /repo/${VPP_BUILD_REL_PATH}/build-root/install-vpp-native/vpp/
         envFrom:
         - configMapRef:
             name: calico-vpp-config
@@ -323,7 +321,7 @@ spec:
         envFrom:
         - configMapRef:
             name: calico-vpp-config
-        image: localhost:5000/${CALICOVPP_AGENT_IMAGE}:${CALICOVPP_VERSION}
+        image: localhost:5000/calicovpp/agent:${CALICOVPP_VERSION}
         imagePullPolicy: Always
         name: agent
         resources:
@@ -377,7 +375,7 @@ spec:
         name: vpp-rundir
       - hostPath:
           path: /var/lib/vpp
-        type: DirectoryOrCreate
+          type: DirectoryOrCreate
         name: vpp-data
       - hostPath:
           path: /etc/vpp
@@ -405,6 +403,9 @@ spec:
       maxUnavailable: 1
     type: RollingUpdate
 ---
+# NOT a kustomize resource - this file embeds the `${CALICO_NETWORK_CONFIG}`
+# runtime placeholder which makes it invalid YAML until `envsubst` has run.
+# Appended verbatim by `make kube-test-template` after the kustomize build.
 apiVersion: operator.tigera.io/v1
 kind: APIServer
 metadata:

--- a/yaml/overlays/kube-test-baremetal/kustomization.yaml
+++ b/yaml/overlays/kube-test-baremetal/kustomization.yaml
@@ -1,0 +1,11 @@
+# Kube-test overlay for baremetal clusters (DPDK uplink).
+#
+# Consumed by `make kube-test-template FLAVOR=baremetal` and shipped
+# to the VPP kube-test harness as a single fully-resolved manifest.
+
+resources:
+- ../../base
+
+components:
+- ../../components/kube-test
+- ../../components/kube-test/baremetal

--- a/yaml/overlays/kube-test-kind/kustomization.yaml
+++ b/yaml/overlays/kube-test-kind/kustomization.yaml
@@ -1,0 +1,11 @@
+# Kube-test overlay for KinD clusters.
+#
+# Consumed by `make kube-test-template FLAVOR=kind` and shipped to
+# the VPP kube-test harness as a single fully-resolved manifest.
+
+resources:
+- ../../base
+
+components:
+- ../../components/kube-test
+- ../../components/kube-test/kind


### PR DESCRIPTION
### Summary:

Backport the `kustomize`-based VPP `kube-test` integration from `master` (unify-images / flatten-repo-layout refactor #994) to `release/v3.30.0`. This is a follow-up to the previous repo-layout-aware `kube-test` backport (436db1f84f0285202f2ef7c63d0b2c1d8095eded). It replaces the hand-maintained `yaml/generated/calico-vpp-kubetest.yaml` + `envsubst`-based `Makefile` target with the same `kustomize`-driven design that `master` uses, so the `kube-test` integration on every release shares one source of truth (`kustomize` patches under `yaml/components/kube-test/`).

The previous backport's `CALICOVPP_AGENT_IMAGE` / `VPP_BUILD_REL_PATH` `envsubst` placeholders are removed from the manifest. Only consumer-owned runtime placeholders survive in the emitted manifest: `${CALICOVPP_VERSION}`, `${ADDITIONAL_VPP_CONFIG}`, `${HOME}`, `${CALICOVPP_ENABLE_MEMIF}`, `${CALICO_NETWORK_CONFIG}` and `${CALICOVPP_INTERFACE}` (baremetal only) .

### Changes:

- `yaml/components/kube-test/` - `kustomize` component shared by the `kind` and `baremetal` flavors. The daemonset patch encodes this release's split-image layout: `calicovpp/vpp` for the `vpp` container, `calicovpp/agent` for the `agent` container (no command override) and the in-repo VPP build at `/repo/vpp-manager/vpp_build/...`.
- `yaml/components/kube-test/kind/` - KinD-flavor adjustments (uplink `eth0` via `af_packet`, no hugepages).
- `yaml/components/kube-test/baremetal/` - baremetal-flavor adjustments (DPDK uplink driven by `${CALICOVPP_INTERFACE}`, hugepages, larger CPU / buffer allocation, `docker.io` registry with `IfNotPresent` pull policy).
- `yaml/overlays/kube-test-{kind,baremetal}/` - overlays wiring the base daemonset and the `kube-test` components.
- `yaml/generated/calico-vpp-kubetest.yaml` - regenerated from the new sources so the checked-in file matches the `kustomize` output for this release's base daemonset.
- `yaml/Makefile` - regenerates the checked-in `kubetest.yaml` for `kind` and sanity-checks the `baremetal` overlay.
- `make kube-test-template FLAVOR={kind,baremetal}` (default `kind`) now runs `kubectl kustomize` against the requested overlay and appends the tigera-operator `Installation`/`APIServer` snippet. The previous `CALICOVPP_AGENT_IMAGE` / `VPP_BUILD_REL_PATH` `envsubst` placeholders have been removed - layout knowledge lives only in the `kustomize` sources.
- `make kube-test-push-images` is now driven by `KUBE_TEST_IMAGES` (default `calicovpp/vpp calicovpp/agent calicovpp/multinet-monitor` on this split-image release).