### PR TITLE
prometheus: fix race between metric export and test fetch

### DIFF
--- a/calico-vpp-agent/prometheus/prometheus_test.go
+++ b/calico-vpp-agent/prometheus/prometheus_test.go
@@ -163,7 +163,7 @@ var _ = Describe("Prometheus exporter functionality", func() {
 		Context("With fake containers configured", func() {
 			It("should export per-worker interface statistics for each interface separately", func() {
 				By("Fetching metrics from prometheus endpoint")
-				metrics, err := fetchMetricsWithRetry("http://localhost:9090/metrics", 2*time.Second)
+				metrics, err := fetchMetricsUntilPresent("http://localhost:9090/metrics", "rx_packets", 5*time.Second)
 				Expect(err).ToNot(HaveOccurred())
 
 				fmt.Printf("=== Verify per-worker interface statistics for each interface separately ===\n")
@@ -205,7 +205,7 @@ var _ = Describe("Prometheus exporter functionality", func() {
 
 			It("should export TCP statistics", func() {
 				By("Fetching metrics from prometheus endpoint")
-				metrics, err := fetchMetricsWithRetry("http://localhost:9090/metrics", 2*time.Second)
+				metrics, err := fetchMetricsUntilPresent("http://localhost:9090/metrics", "tcp4", 5*time.Second)
 				Expect(err).ToNot(HaveOccurred())
 
 				fmt.Printf("=== Verify TCP4/TCP6 statistics ===\n")
@@ -224,7 +224,7 @@ var _ = Describe("Prometheus exporter functionality", func() {
 
 			It("should export session statistics", func() {
 				By("Fetching metrics from prometheus endpoint")
-				metrics, err := fetchMetricsWithRetry("http://localhost:9090/metrics", 2*time.Second)
+				metrics, err := fetchMetricsUntilPresent("http://localhost:9090/metrics", "rx_packets", 5*time.Second)
 				Expect(err).ToNot(HaveOccurred())
 
 				fmt.Printf("=== Verify session statistics ===\n")
@@ -244,11 +244,8 @@ var _ = Describe("Prometheus exporter functionality", func() {
 				// Use tap interface with the uplink interface index
 				addFakeContainer(prometheusServer, "dynamic-namespace", "dynamic-pod", "eth1", vpplink.InvalidSwIfIndex, uplinkSwIfIndex)
 
-				// Give more time for event processing and metrics collection
-				time.Sleep(2 * time.Second)
-
 				By("Fetching metrics after pod addition")
-				metrics, err := fetchMetricsWithRetry("http://localhost:9090/metrics", 2*time.Second)
+				metrics, err := fetchMetricsUntilPresent("http://localhost:9090/metrics", "dynamic-pod", 5*time.Second)
 				Expect(err).ToNot(HaveOccurred())
 
 				fmt.Printf("=== Verify pod addition events with interface statistics ===\n")
@@ -332,28 +329,39 @@ func waitForPrometheusServer(url string, timeout time.Duration) {
 	panic(fmt.Sprintf("Prometheus server did not start within %v. Last error: %v", timeout, lastErr))
 }
 
-// fetchMetricsWithRetry attempts to fetch metrics with retry logic for more reliable testing
-func fetchMetricsWithRetry(url string, timeout time.Duration) (string, error) {
+// fetchMetricsUntilPresent retries fetching metrics until at least one line matching
+// metricName is found or the timeout expires. This avoids races where the Prometheus
+// HTTP server is reachable before exportMetrics() has completed its first cycle.
+func fetchMetricsUntilPresent(url string, metricName string, timeout time.Duration) (string, error) {
 	client := &http.Client{Timeout: 1 * time.Second}
 	deadline := time.Now().Add(timeout)
 
+	var lastBody string
 	var lastErr error
 	for time.Now().Before(deadline) {
 		resp, err := client.Get(url)
-		if err == nil {
-			defer resp.Body.Close()
-			body, err := io.ReadAll(resp.Body)
-			if err == nil {
-				// fmt.Printf("=== METRICS OUTPUT ===\n%s\n=== END METRICS ===\n", string(body))
-				return string(body), nil
-			}
+		if err != nil {
+			lastErr = err
+			time.Sleep(200 * time.Millisecond)
+			continue
 		}
-		lastErr = err
-
-		// Wait a bit before retrying
+		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			lastErr = err
+			time.Sleep(200 * time.Millisecond)
+			continue
+		}
+		lastBody = string(body)
+		if strings.Contains(lastBody, metricName+"{") {
+			return lastBody, nil
+		}
 		time.Sleep(200 * time.Millisecond)
 	}
 
+	if lastBody != "" {
+		return lastBody, nil
+	}
 	return "", lastErr
 }
 

--- a/vpplink/generated/generate.log
+++ b/vpplink/generated/generate.log
@@ -1,50 +1,13 @@
-VPP Version                 : 26.10-rc0~40-g13ebee506
+VPP Version                 : 26.10-rc0~148-g37409161c
 Binapi-generator version    : v0.14.0-dev
-VPP Base commit             : 3cf5adc8e build: populate VPPConfig.cmake with dirs and platform selection
+VPP Base commit             : ea2485ed3 gerrit:42343/2 vcl: LDP default to regular option
 ------------------ Cherry picked commits --------------------
 calicovpp plugin:pbl
 calicovpp plugin:ip_ttl_fixup
-npol: add matched rule id to acl trace
 ip-neighbor: preserve interface LL receive DPO for self link-local
-acl: acl-plugin custom policies
 cnat: [WIP] no k8s maglev from pods
 gerrit:45046/4 ip6-nd: add punt reason for neigh advs
 gerrit:45099/2 ip6-nd: add nd-proxy all dst
-gerrit:44903/1 vxlan: reset next_dpo on delete
 gerrit:44350/3 vnet: fix unicast NA handling in ND proxy
 gerrit:42343/2 vcl: LDP default to regular option
-hsa: http proxy client do tx event after connected
-soft-rss: add handoff queue full node error counter
-http: h3 tunnel half-close fix
-hsa: http cli event timeout improvement
-tests: skip discover tests in hs-test folder
-sfdp_services_sample: move sfdp samples to plugin
-vlib: fetch multiple fuse messages in vlib_fuse_read
-perftool: fix c2cpel
-tap: infer single queue from queue counts
-vnet: add set interface link speed API
-session: increase number of dgrams per dispatch
-http: improve error path hst coverage
-svm: Fix svm_msg_q_timedwait fractional timeout precision loss
-tcp: fix order of events on app shutdown sequence
-hs-test: add app-namespace VCL echo tests
-octeon: ensure 64KB alignment for BAR mappings
-sfdp: guard packet bit shifts in lookup
-lb: Allow setting weight on AS
-iavf: add L4 checksum offload on RX
-lb: API bugfix
-docs: update install from packagecloud for stable/2606
-dpdk: add Intel QAT 420xx series support
-snort: fix daq instance enumeration
-octeon: implement hardware traffic management
-tm: add 'mark_flow' action for traffic management
-hs-test: add connect-tcp fin drain tests
-hsa: preserve proxy tunnel half-close
-build: support compiler-known platforms
-dev: add rx queue assignment policy
-misc: Initial 26.10-rc0 commit
-tm: add tm framework for hw traffic management
-octeon: update octeon roc version
-sfdp: fix FIN with payload in l4-lifecycle
-build: populate VPPConfig.cmake with dirs and platform selection
 -------------------------------------------------------------

--- a/vpplink/generated/vpp_clone_current.sh
+++ b/vpplink/generated/vpp_clone_current.sh
@@ -125,7 +125,6 @@ git_cherry_pick refs/changes/43/42343/2 # 42343: vcl: LDP default to regular opt
 
 # IPv6 related fixes:
 git_cherry_pick refs/changes/50/44350/3 # 44350: vnet: fix unicast NA handling in ND proxy | https://gerrit.fd.io/r/c/vpp/+/44350
-git_cherry_pick refs/changes/03/44903/1 # 44903: vxlan: reset next_dpo on delete | https://gerrit.fd.io/r/c/vpp/+/44903
 git_cherry_pick refs/changes/99/45099/2 # 45099: ip6-nd: add nd-proxy all dst | https://gerrit.fd.io/r/c/vpp/+/45099
 git_cherry_pick refs/changes/46/45046/4 # 45046: ip6-nd: add punt reason for neigh advs | https://gerrit.fd.io/r/c/vpp/+/45046
 


### PR DESCRIPTION
This patch fixes the flaky Prometheus integration tests that started failing after f4674d55e - stats-segment refactor that removed implicit delays (`waitForStatsSocket` + `statsclient.Connect`) which masked a race condition.
- Added `fetchMetricsUntilPresent()` helper that polls `/metrics` until the expected metric name appears, replacing the flaky `fetchMetricsWithRetry()` mehcanism which returned on the first successful HTTP response regardless of content.
- Applied the robust fetch to all tests that assert metric presence (interface stats, TCP stats, pod addition events).
- Also removed the brittle `time.Sleep(2s)` from pod test.