### PR TITLE
multinet: stop NAD watcher during net watcher cleanup

### DIFF
--- a/calico-vpp-agent/watchers/net_watcher.go
+++ b/calico-vpp-agent/watchers/net_watcher.go
@@ -90,7 +90,7 @@ func (w *NetWatcher) SetOurBGPSpec(nodeBGPSpec *common.LocalNodeSpec) {
 }
 
 func (w *NetWatcher) cleanExistingWatchers() {
-	for _, wat := range []watch.Interface{w.NetWatcher, w.NetWatcher} {
+	for _, wat := range []watch.Interface{w.NetWatcher, w.NadWatcher} {
 		if wat != nil {
 			wat.Stop()
 			w.log.Debug("Stopped watcher")


### PR DESCRIPTION
cleanExistingWatchers stopped the Network watcher twice and never stopped the NetworkAttachmentDefinition watcher. Stop both watchers so restarts and resyncs do not leave the old NAD watch running.