### PR TITLE
prometheus: export CNAT flow gauges and error counters

### DIFF
--- a/calico-vpp-agent/prometheus/prometheus.go
+++ b/calico-vpp-agent/prometheus/prometheus.go
@@ -94,6 +94,14 @@ func cleanVppSessionStatName(vppStatName string) string {
 	return config.GetCalicoVppInitialConfig().PrometheusStatsPrefix + vppStatName
 }
 
+func cleanVppCNATStatName(vppStatName string, prefix string) string {
+	vppStatName = strings.TrimPrefix(vppStatName, prefix)
+	vppStatName = strings.ReplaceAll(vppStatName, "-", "_")
+	vppStatName = strings.ReplaceAll(vppStatName, "/", "_")
+	vppStatName = strings.ReplaceAll(vppStatName, " ", "_")
+	return config.GetCalicoVppInitialConfig().PrometheusStatsPrefix + vppStatName
+}
+
 const (
 	UnitPackets = "packets"
 	UnitBytes   = "bytes"
@@ -179,6 +187,33 @@ func (p *PrometheusServer) exportMetrics() error {
 		case adapter.ScalarStat:
 			// ScalarStat is a single value, not per-worker
 			p.exportSessionScalarStat(string(vppStat.Name), int64(values))
+		}
+	}
+
+	// Export CNAT flow gauges and error counters.
+	cnatStats, err := p.statsclient.DumpStats(
+		"^/cnat/flows/",
+		"^/err/[^/]*cnat[^/]*/",
+	)
+	if err != nil {
+		p.log.Errorf("Error running statsclient.DumpStats for CNAT stats %v", err)
+		return nil
+	}
+	for _, vppStat := range cnatStats {
+		name := string(vppStat.Name)
+		switch values := vppStat.Data.(type) {
+		case adapter.GaugeStat:
+			if strings.HasPrefix(name, "/cnat/flows/") {
+				p.exportCNATFlowGauge(name, int64(values))
+			}
+		case adapter.ScalarStat:
+			if strings.HasPrefix(name, "/cnat/flows/") {
+				p.exportCNATFlowGauge(name, int64(values))
+			}
+		case adapter.SimpleCounterStat:
+			if strings.HasPrefix(name, "/err/") {
+				p.exportCNATErrorCounter(name, values)
+			}
 		}
 	}
 
@@ -396,6 +431,64 @@ func (p *PrometheusServer) exportSessionScalarStat(name string, value int64) {
 	)
 	if err != nil {
 		p.log.Errorf("Error prometheus exporter.ExportMetric for Session %v", err)
+	}
+}
+
+func (p *PrometheusServer) exportCNATFlowGauge(name string, value int64) {
+	err := p.exporter.ExportMetric(
+		context.Background(),
+		nil, /* node */
+		nil, /* resource */
+		&metricspb.Metric{
+			MetricDescriptor: &metricspb.MetricDescriptor{
+				Name:        cleanVppCNATStatName(name, "/"),
+				Description: getVppCNATStatDescription(name),
+				Type:        metricspb.MetricDescriptor_GAUGE_INT64,
+			},
+			Timeseries: []*metricspb.TimeSeries{{
+				Points: []*metricspb.Point{{
+					Value: &metricspb.Point_Int64Value{Int64Value: value},
+				}},
+			}},
+		},
+	)
+	if err != nil {
+		p.log.Errorf("Error prometheus exporter.ExportMetric for CNAT flow gauge %v", err)
+	}
+}
+
+func (p *PrometheusServer) exportCNATErrorCounter(name string, values adapter.SimpleCounterStat) {
+	metric := &metricspb.Metric{
+		MetricDescriptor: &metricspb.MetricDescriptor{
+			Name:        cleanVppCNATStatName(name, "/err/"),
+			Description: getVppCNATStatDescription(name),
+			Type:        metricspb.MetricDescriptor_CUMULATIVE_INT64,
+			LabelKeys: []*metricspb.LabelKey{
+				{Key: "worker", Description: "VPP worker index"},
+			},
+		},
+	}
+	for worker, perWorkerValues := range values {
+		for _, counter := range perWorkerValues {
+			metric.Timeseries = append(metric.Timeseries, &metricspb.TimeSeries{
+				LabelValues: []*metricspb.LabelValue{
+					{Value: strconv.Itoa(worker)},
+				},
+				Points: []*metricspb.Point{{
+					Value: &metricspb.Point_Int64Value{Int64Value: int64(counter)},
+				}},
+			})
+		}
+	}
+
+	err := p.exporter.ExportMetric(
+		context.Background(),
+		nil, /* node */
+		nil, /* resource */
+		metric,
+	)
+	if err != nil {
+		p.log.Errorf("Error prometheus exporter.ExportMetric for CNAT error counter %v", err)
 	}
 }
 

--- a/calico-vpp-agent/prometheus/prometheus_test.go
+++ b/calico-vpp-agent/prometheus/prometheus_test.go
@@ -235,6 +235,34 @@ var _ = Describe("Prometheus exporter functionality", func() {
 				Expect(len(sessionMetrics)).To(Equal(0), "Should not contain session statistics")
 				fmt.Printf("=== Success! session statistics not found as expected ===\n")
 			})
+
+			It("should export CNAT flow and error statistics", func() {
+				By("Verifying CNAT active-flow gauges")
+				for _, metricName := range []string{
+					"cnat_flows_total",
+					"cnat_flows_nat",
+					"cnat_flows_no_nat",
+					"cnat_flows_pass_through",
+				} {
+					metrics, err := fetchMetricsUntilPresent(
+						"http://localhost:9090/metrics", metricName, 5*time.Second,
+					)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(metrics).To(ContainSubstring(metricName + " "))
+				}
+
+				By("Verifying CNAT error counters")
+				for _, metricName := range []string{
+					"cnat_input_ip4_no_active_backend",
+					"cnat_output_ip4_snat_address_unavailable",
+				} {
+					metrics, err := fetchMetricsUntilPresent(
+						"http://localhost:9090/metrics", metricName, 5*time.Second,
+					)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(metrics).To(ContainSubstring(metricName + "{"))
+				}
+			})
 		})
 
 		Context("When pod events occur", func() {
@@ -353,7 +381,8 @@ func fetchMetricsUntilPresent(url string, metricName string, timeout time.Durati
 			continue
 		}
 		lastBody = string(body)
-		if strings.Contains(lastBody, metricName+"{") {
+		if strings.Contains(lastBody, metricName+"{") ||
+			strings.Contains(lastBody, metricName+" ") {
 			return lastBody, nil
 		}
 		time.Sleep(200 * time.Millisecond)

--- a/calico-vpp-agent/prometheus/stats_description.go
+++ b/calico-vpp-agent/prometheus/stats_description.go
@@ -1492,3 +1492,18 @@ func getVppSessionStatDescription(vppStatName string) string {
 		return vppStatName
 	}
 }
+
+func getVppCNATStatDescription(vppStatName string) string {
+	switch vppStatName {
+	case "/cnat/flows/total":
+		return "total number of active CNAT flows"
+	case "/cnat/flows/nat":
+		return "number of active CNAT flows with an address or port rewrite"
+	case "/cnat/flows/no-nat":
+		return "number of active CNAT Maglev/DSR flows forwarded without a rewrite"
+	case "/cnat/flows/pass-through":
+		return "number of active CNAT flows forwarded without a NAT or NO_NAT decision"
+	default:
+		return vppStatName
+	}
+}

--- a/docs/metrics/metrics.md
+++ b/docs/metrics/metrics.md
@@ -76,6 +76,23 @@ RX is what comes in VPP, TX is what goes out of VPP
 - `cni_projectcalico_vpp_rx_no_buf`
 - `cni_projectcalico_vpp_drops`
 
+## CNAT metrics
+
+The CNAT active-flow metrics are gauges without labels:
+
+- `cni_projectcalico_vpp_cnat_flows_total`
+- `cni_projectcalico_vpp_cnat_flows_nat`
+- `cni_projectcalico_vpp_cnat_flows_no_nat`
+- `cni_projectcalico_vpp_cnat_flows_pass_through`
+
+CNAT error counters are cumulative and tagged with the `worker` label. The
+metric name combines the VPP node and error names. For example:
+
+- `cni_projectcalico_vpp_cnat_input_ip4_no_active_backend`
+- `cni_projectcalico_vpp_cnat_output_ip4_snat_address_unavailable`
+
+All VPP error counters whose node name contains `cnat` are exported.
+
 ## Hoststack counters
 
 Every host stack counter is tagged with


### PR DESCRIPTION
Scrape CNAT active-flow gauges and error counters from VPP stats and export them through Prometheus. The flow gauges are global and unlabeled, while error counters are cumulative and labeled by VPP worker.

The exported flow metrics are:

  cni_projectcalico_vpp_cnat_flows_total
  cni_projectcalico_vpp_cnat_flows_nat
  cni_projectcalico_vpp_cnat_flows_no_nat
  cni_projectcalico_vpp_cnat_flows_pass_through

CNAT error metric names combine the VPP node and error names. For example:

  cni_projectcalico_vpp_cnat_input_ip4_no_active_backend{
    worker="0"
  } 1

All VPP error counters whose node name contains "cnat" are exported.

Also, document the new metrics and add Prometheus integration coverage that verifies the flow gauges and error counters are exposed.